### PR TITLE
docs: add roadmap and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+Notable changes to DiscWright, newest first.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the
+versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). While the
+version stays below 1.0.0, the project file format and the on-disc layout may change
+between minor versions.
+
+## [Unreleased]
+
+### Added
+
+- `ROADMAP.md` — planned work, what is under consideration, and what is deliberately out
+  of scope.
+- `CHANGELOG.md` — this file.
+
+## [0.1.0] — 2026-08-16
+
+First public release.
+
+### Added
+
+- Builds a burnable ISO from a GOG offline installer folder, reading the game's name out
+  of the installer and reporting which disc size the payload needs.
+- Custom drive icon in This PC — takes a `.ico`, or builds a multi-size icon from any
+  PNG or JPG. The icon is named after the disc rather than a fixed `disc.ico`, because
+  Explorer caches drive icons by file path and would otherwise redraw the previous game's
+  icon after a disc swap.
+- Custom drive label, checked in advance against what the system ANSI codepage can
+  actually encode, since AutoRun reads `autorun.inf` with no Unicode mode at all.
+- Autorun menu as an HTA — Play, Install, Game Manual, Extras and Exit, with configurable
+  background artwork, button side, optional title overlay and optional background music.
+- Play locates an installed copy through the registry and stays greyed out until the game
+  is actually installed; Install runs the GOG installer directly from the disc.
+- Extra content: a manual, an Extras folder, and any loose files or folders to place at
+  the disc root.
+- **Preview menu** renders the current settings to a temporary folder so layout changes
+  can be checked without rebuilding the ISO.
+- Every build writes a `discproject.json` beside the ISO, which **Open existing disc...**
+  loads back so a disc can be rebuilt later with one setting changed.
+- Media size guidance from CD-R through BD-R XL.
+- Startup check for Windows PowerShell 5.1, with an explanation rather than a stack trace
+  when launched under PowerShell 7.
+- `extras/DiscLabel.ps1`, a parked printable disc-face generator, kept out of the app to
+  keep the tool to one job.
+
+[Unreleased]: https://github.com/lazardjokovic/discwright/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/lazardjokovic/discwright/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Stated up front rather than discovered later.
 - **No multi-disc splitting.** Anything larger than a 100 GB BD-R XL is out of scope.
 - **Disc labels are limited to what Windows can encode.** AutoRun reads `autorun.inf` in the system ANSI codepage and has no Unicode mode at all, so accented Latin characters are fine but Cyrillic, Greek and CJK are not. DiscWright shows you exactly what This PC will display and asks before building one it cannot represent.
 
+Not all of these are permanent — multi-disc splitting in particular is on the [roadmap](ROADMAP.md). [Issues](../../issues) is the place to ask for something, and [CHANGELOG.md](CHANGELOG.md) records what has changed between releases.
+
 ## Media sizes
 
 | Payload | Disc |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,62 @@
+# Roadmap
+
+What is planned for DiscWright, what is being considered, and what is deliberately out
+of scope. Ordered by intent rather than by date — this is a hobby project and nothing
+here carries a delivery promise.
+
+Most of what follows came from people replying to the
+[r/gog launch thread](https://www.reddit.com/r/gog/comments/1vrmyt0/made_a_free_tool_that_turns_gog_offline/).
+If what you want is missing, [open an issue](../../issues).
+
+## Planned — v0.2.0
+
+**Several games on one disc.** A 25 GB BD-R holds a lot of older games. Put more than
+one installer on a disc and let the menu ask which to install. Needs a per-game section
+in the project file, a chooser in the menu, and a rethink of how Play decides a game is
+already installed when there is more than one candidate.
+
+**"Install DLC" as its own menu button.** DLC that ships as a separate installer
+currently has to go in Extras, where it is just a file in a folder. It deserves a button
+next to Install.
+
+## Planned — later
+
+**Multi-disc splitting.** Listed today as a known limitation: anything larger than a
+single disc is out of scope. It was requested twice, independently, within hours of the
+first release, so it moves onto the list. Needs a splitting strategy, a volume label
+convention, and a menu that can ask for disc 2 — which is, admittedly, most of what made
+the original experience feel like the original experience.
+
+**Case and disc-face artwork.** `extras/DiscLabel.ps1` already renders a printable
+120 mm disc face at 300 dpi and sits parked in the repo. The request is to go further:
+build front and back case inserts from store artwork — cover on the front, screenshots
+on the back — so the printed result matches the disc without a detour through an image
+editor.
+
+## Considering
+
+- **More than one music track.** One per disc is currently deliberate. A short playlist
+  might justify the complexity. A music player will not.
+- **Menu themes.** The menu is one layout with configurable artwork. Named presets would
+  let a disc look like its own era instead of looking like DiscWright.
+- **A presentation site.** Mainly to give people something plainer than a README to read
+  before deciding to run an unsigned script.
+
+## Not planned
+
+Stated plainly because these come up.
+
+- **Burning.** DiscWright writes an ISO and stops. ImgBurn, Nero and the burner built
+  into Windows all do the rest well, and there is no reason to write a worse one.
+- **Anything that removes DRM.** GOG installers are DRM-free by design — that is the only
+  reason a tool like this can exist. DiscWright circumvents nothing and never will.
+- **Non-Windows support.** The interface is WinForms and the ISO builder is IMAPI2FS.
+  Both are Windows-only and neither has a portable replacement worth the rewrite.
+- **PowerShell 7.** The ISO builder needs `Add-Type -CompilerParameters` with `/unsafe`,
+  which PowerShell 6 removed. Windows PowerShell 5.1 ships with Windows, so requiring it
+  costs nobody an installation.
+
+## How this list changes
+
+[Issues](../../issues) is where requests live. Forum threads scroll away; issues do not.
+A request that other people turn up and agree with moves up.


### PR DESCRIPTION
Captures the feature requests from the r/gog launch thread so they outlive the thread: several games per disc, an Install DLC button, multi-disc splitting and generated case artwork. States what is deliberately out of scope - burning, DRM, non-Windows, PowerShell 7 - so it stops being answered one comment at a time.

Changelog backfills 0.1.0 and follows Keep a Changelog.