### PR TITLE
fix: release the IMAPI2FS COM objects after writing the ISO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ between minor versions.
   of scope.
 - `CHANGELOG.md` — this file.
 
+### Fixed
+
+- **Building a disc and then rebuilding it immediately failed**, with "the old disc
+  folder cannot be replaced — something is still using it" and a suggestion to close
+  Explorer or eject a mounted ISO. Neither was the cause: the ISO builder left its
+  COM objects alive, so DiscWright was still holding a handle on every file in its
+  own staging folder. Waiting a minute and trying again worked, which made it look
+  intermittent rather than reproducible.
+
 ## [0.1.0] — 2026-08-16
 
 First public release.

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -711,26 +711,48 @@ public class ISOFile {
                    "Then build again.`r`n`r`nWindows said: $($_.Exception.Message)")
         }
     }
-    $fsi=New-Object -ComObject IMAPI2FS.MsftFileSystemImage
+    # Every one of these COM objects has to be released by hand. AddTree opens a
+    # handle on each staged file and CreateResultImage holds them until the image
+    # is released, so leaving it to the garbage collector means DiscWright is still
+    # locking its own disc folder when the build returns. Rebuilding then failed
+    # with "something is still using it", pointing the blame at Explorer or a
+    # mounted ISO when the process holding the files was DiscWright itself.
+    $fsi=$null; $rootItem=$null; $img=$null; $stream=$null
+    try {
+        $fsi=New-Object -ComObject IMAPI2FS.MsftFileSystemImage
 
-    # Size the virtual medium to the actual payload. The old fixed 12.5M blocks
-    # (~25 GB) silently capped builds well below the BD-R DL / XL sizes the UI
-    # recommends.
-    $payload = (Get-ChildItem -Recurse -File -Force $stageDir | Measure-Object Length -Sum).Sum
-    $blocks  = [long][math]::Ceiling(($payload * 1.05) / 2048) + 65536
-    if ($blocks -lt 12500000) { $blocks = 12500000 }
-    if ($blocks -gt 2147483000) { $blocks = 2147483000 }
-    $fsi.FreeMediaBlocks=[int]$blocks
+        # Size the virtual medium to the actual payload. The old fixed 12.5M blocks
+        # (~25 GB) silently capped builds well below the BD-R DL / XL sizes the UI
+        # recommends.
+        $payload = (Get-ChildItem -Recurse -File -Force $stageDir | Measure-Object Length -Sum).Sum
+        $blocks  = [long][math]::Ceiling(($payload * 1.05) / 2048) + 65536
+        if ($blocks -lt 12500000) { $blocks = 12500000 }
+        if ($blocks -gt 2147483000) { $blocks = 2147483000 }
+        $fsi.FreeMediaBlocks=[int]$blocks
 
-    # UDF only. GOG part filenames run past 64 chars, which Joliet cannot hold,
-    # and the .bin parts sit at the ISO9660 4 GiB ceiling.
-    $fsi.FileSystemsToCreate=4
-    try { $fsi.UDFRevision=0x250 } catch {}
-    $vn = ($volLabel -replace '[^A-Za-z0-9_]','_'); if($vn.Length -gt 16){$vn=$vn.Substring(0,16)}
-    $fsi.VolumeName=$vn
-    $fsi.Root.AddTree($stageDir,$false)
-    $img=$fsi.CreateResultImage()
-    [ISOFile]::Create($isoPath,$img.ImageStream,$img.BlockSize,$img.TotalBlocks)
+        # UDF only. GOG part filenames run past 64 chars, which Joliet cannot hold,
+        # and the .bin parts sit at the ISO9660 4 GiB ceiling.
+        $fsi.FileSystemsToCreate=4
+        try { $fsi.UDFRevision=0x250 } catch {}
+        $vn = ($volLabel -replace '[^A-Za-z0-9_]','_'); if($vn.Length -gt 16){$vn=$vn.Substring(0,16)}
+        $fsi.VolumeName=$vn
+        # Bind Root once. Reading it creates a fresh wrapper every time, and a
+        # wrapper nobody kept a reference to is a wrapper nobody can release.
+        $rootItem=$fsi.Root
+        $rootItem.AddTree($stageDir,$false)
+        $img=$fsi.CreateResultImage()
+        $stream=$img.ImageStream
+        [ISOFile]::Create($isoPath,$stream,$img.BlockSize,$img.TotalBlocks)
+    }
+    finally {
+        foreach ($o in @($stream,$img,$rootItem,$fsi)) {
+            if ($o) { try { [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($o) } catch {} }
+        }
+        # Releasing drops our references; the handles close when the runtime runs
+        # the finalisers. Waiting for that here is what makes an immediate rebuild
+        # work instead of failing on a lock that clears a few seconds later.
+        [GC]::Collect(); [GC]::WaitForPendingFinalizers()
+    }
 }
 
 # =================== PROJECT SAVE / REOPEN ===================


### PR DESCRIPTION
Building a disc and rebuilding it straight away failed with "the old disc
folder cannot be replaced - something is still using it", and pointed the user
at Explorer or a mounted ISO. Neither was holding the files: New-Iso never
released the file system image, so DiscWright still had a handle on every file
it had just staged. It cleared whenever the GC got round to it, which is why it
looked intermittent rather than reproducible.

Bind Root once instead of re-reading the property - each read makes a new
wrapper, and a wrapper nobody holds is a wrapper nobody can release - then
FinalReleaseComObject everything in a finally block and wait for the finalisers,
so the handles are gone before the function returns.

Verified against v0.1.0: the same build-then-rebuild test fails before and
passes after.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
