### PR TITLE
chore(release): 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ between minor versions.
 
 ## [Unreleased]
 
+## [0.1.1] — 2026-08-18
+
 ### Added
 
 - `ROADMAP.md` — planned work, what is under consideration, and what is deliberately out
@@ -54,5 +56,6 @@ First public release.
 - `extras/DiscLabel.ps1`, a parked printable disc-face generator, kept out of the app to
   keep the tool to one job.
 
-[Unreleased]: https://github.com/lazardjokovic/discwright/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/lazardjokovic/discwright/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/lazardjokovic/discwright/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/lazardjokovic/discwright/releases/tag/v0.1.0


### PR DESCRIPTION
Closes the Unreleased section and dates it, so the tag points at a commit
whose changelog already describes the release it names.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
