### PR TITLE
feat: report the app version, and keep it honest

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: [main]
+    tags: ['v*']
 
 # Read-only token: nothing here writes to the repo.
 permissions:
@@ -93,3 +94,33 @@ jobs:
               }
           }
           if ($failed) { exit 1 }
+
+  # A version constant maintained by hand drifts, because bumping it is a step
+  # that gets forgotten. This runs only when a tag is pushed and fails the tag if
+  # the app would report a version it is not.
+  version-matches-tag:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: App version must match the tag
+        shell: powershell
+        run: |
+          # GITHUB_REF_NAME rather than an expression, so the tag arrives as data
+          # instead of being pasted into the script before it runs.
+          $tag      = $env:GITHUB_REF_NAME
+          $expected = $tag -replace '^v',''
+          $m = [regex]::Match((Get-Content DiscWright.ps1 -Raw), '\$APP_VERSION\s*=\s*''([^'']+)''')
+          if (-not $m.Success) {
+              Write-Host "::error::no `$APP_VERSION assignment found in DiscWright.ps1"
+              exit 1
+          }
+          $actual = $m.Groups[1].Value
+          Write-Host "tag: $tag   expects: $expected   DiscWright.ps1 says: $actual"
+          if ($actual -ne $expected) {
+              Write-Host "::error::`$APP_VERSION is '$actual' but the tag is '$tag' - bump the constant before tagging"
+              exit 1
+          }
+          Write-Host "ok"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ between minor versions.
 
 ## [Unreleased]
 
+### Added
+
+- **DiscWright now says which version it is.** The title bar reads `DiscWright 0.2.0`,
+  the log box opens with the version and the PowerShell it is running under, and every
+  `discproject.json` records the version that wrote it — so a project file attached to a
+  bug report says for itself what built the disc.
+
 ## [0.1.1] — 2026-08-18
 
 ### Added

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -54,6 +54,12 @@ Add-Type -AssemblyName System.Drawing
 
 $PROJECT_FILE = 'discproject.json'
 
+# Kept in step with the git tag by a CI check that runs when a tag is pushed, so
+# this cannot quietly drift a release behind. Shown in the title bar and the log,
+# and written into every project file - a bug report that comes with a project
+# file then says for itself which version built the disc.
+$APP_VERSION  = '0.2.0'
+
 # =================== SMALL HELPERS ===================
 
 function Test-SamePath([string]$a,[string]$b) {
@@ -759,7 +765,11 @@ public class ISOFile {
 
 function Save-Project([hashtable]$s,[string]$outDir) {
     $o = [ordered]@{
+        # Version is the schema of this file. AppVersion is the DiscWright that
+        # wrote it - two different things, deliberately two different keys, so a
+        # project file attached to a bug report says which build produced it.
         Version      = 1
+        AppVersion   = $APP_VERSION
         SavedUtc     = (Get-Date).ToUniversalTime().ToString('s')
         SourceFolder = $s.Game.Folder
         GameName     = $s.Game.GameName
@@ -1032,7 +1042,9 @@ function Invoke-Build([hashtable]$s, [scriptblock]$log) {
 $state = @{ Game=$null; IconPath=$null; IconIsIco=$false; BgPath=$null; MusicFile=$null; ManualPath=$null; ExtrasPath=$null; ExtraItems=@() }
 
 $form=New-Object System.Windows.Forms.Form
-$form.Text='DiscWright'
+# The version belongs where it can be read off a screenshot without being asked
+# for, since that is how it arrives in a bug report.
+$form.Text="DiscWright $APP_VERSION"
 $form.Size=New-Object System.Drawing.Size(700,996)
 $form.StartPosition='CenterScreen'
 $form.Font=New-Object System.Drawing.Font('Segoe UI',9)
@@ -1600,6 +1612,10 @@ Add-Type -Namespace GDA -Name Win -MemberDefinition @'
 [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr hWnd);
 '@
 Update-ActionButtons   # start greyed out - nothing to open yet
+
+# First line in the log box, so it is already in the screenshot when someone
+# posts one, and already in the copied text when someone pastes the log.
+& $log "DiscWright $APP_VERSION  -  Windows PowerShell $($PSVersionTable.PSVersion)"
 
 $form.Add_Shown({
     [void][GDA.Win]::ShowWindow($form.Handle,5)      # SW_SHOW

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,11 +4,26 @@ What is planned for DiscWright, what is being considered, and what is deliberate
 of scope. Ordered by intent rather than by date — this is a hobby project and nothing
 here carries a delivery promise.
 
-Most of what follows came from people replying to the
+Most of the **Later** list came from people replying to the
 [r/gog launch thread](https://www.reddit.com/r/gog/comments/1vrmyt0/made_a_free_tool_that_turns_gog_offline/).
 If what you want is missing, [open an issue](../../issues).
 
-## Planned — v0.2.0
+Version numbers are deliberately not attached to anything below. Releases get numbered
+for what they turn out to contain, not the other way around — pinning a number to a
+feature only creates pressure to cram things in to justify it.
+
+## Next
+
+**Say what is happening during a build.** Writing the ISO gives no feedback at all, and
+because the whole build runs on the interface thread the window goes grey and Windows
+paints it "Not Responding". On a full-size game that is minutes of looking like a crash.
+Wanted: a progress bar fed by the ISO writer itself, elapsed time, per-file progress
+during the copy, and a window that keeps repainting throughout.
+
+**Show which version is running.** In the title bar, in the log, and recorded into every
+project file, so a bug report says for itself what produced the disc.
+
+## Later
 
 **Several games on one disc.** A 25 GB BD-R holds a lot of older games. Put more than
 one installer on a disc and let the menu ask which to install. Needs a per-game section
@@ -18,8 +33,6 @@ already installed when there is more than one candidate.
 **"Install DLC" as its own menu button.** DLC that ships as a separate installer
 currently has to go in Extras, where it is just a file in a folder. It deserves a button
 next to Install.
-
-## Planned — later
 
 **Multi-disc splitting.** Listed today as a known limitation: anything larger than a
 single disc is out of scope. It was requested twice, independently, within hours of the


### PR DESCRIPTION
There was no way to answer "which version are you running?" - not in the title
bar, not in the log, not in the project file. For the rebuild bug fixed in
0.1.1 that is exactly the question that decides whether a report is worth
chasing.

One $APP_VERSION constant, surfaced in three places:

  - the title bar, so it is in the screenshot without anyone being asked
  - the first line of the log, so it is in the pasted text
  - discproject.json, so a project file says what built the disc

AppVersion is a separate key from the existing Version, which is the schema of
the file rather than the app that wrote it. Conflating them would make the
schema unreadable the first time the two need to diverge.

A constant maintained by hand drifts, because bumping it is a step that gets
forgotten, so checks.yml gains a job that runs on tag pushes and fails the tag
when the constant disagrees with it. Verified both ways locally: passes against
v0.2.0, fails against v0.2.1 and v1.0.0.

ROADMAP.md drops the version numbers pinned to features. Releases should be
numbered for what they contain rather than features being crammed in to justify
a number that was promised early.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
