### PR TITLE
feat: show progress and elapsed time while a build runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,31 @@ between minor versions.
 
 ### Added
 
+- **The build says what it is doing.** A progress bar and a running clock while the ISO
+  is written, the total time in the log and in the "build complete" dialog. The window
+  keeps repainting throughout — previously the whole build ran on the interface thread
+  with nothing pumping the message queue during the ISO write, so Windows greyed the
+  window out and labelled it "Not Responding" for minutes at a time on a full-size game.
+  It looked exactly like a crash.
 - **DiscWright now says which version it is.** The title bar reads `DiscWright 0.2.0`,
   the log box opens with the version and the PowerShell it is running under, and every
   `discproject.json` records the version that wrote it — so a project file attached to a
   bug report says for itself what built the disc.
+
+### Changed
+
+- **The ISO builder no longer compiles with `/unsafe`.** It used an unsafe pointer to
+  hand `IStream.Read` somewhere to put its byte count; four bytes of unmanaged memory do
+  the same job. This was not tidying: Smart App Control, which is enforced by default on
+  a clean Windows 11, refuses an assembly that combines unsafe pointers with a delegate
+  called inside the copy loop — that being the shape of a shellcode loader. Measured on a
+  machine with it enforced, the pointer build was blocked every time and this one is
+  accepted every time, so without the change the progress bar above would have stopped
+  DiscWright writing ISOs at all on those machines.
+
+  A side effect: `/unsafe` required `Add-Type -CompilerParameters`, which PowerShell 6
+  removed, and that was the one known reason DiscWright could not run on PowerShell 7.
+  It is still untested there and the startup check still refuses it.
 
 ## [0.1.1] — 2026-08-18
 

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -15,9 +15,12 @@
 # Runs before Add-Type on purpose: the things it checks are what make Add-Type and
 # the window itself fail, and both failures look like "the app is just broken".
 #
-#   PS 5.1  New-Iso compiles the ISOFile helper with "Add-Type -CompilerParameters"
-#           and /unsafe. PowerShell 6 dropped -CompilerParameters entirely, so on 7
-#           the app runs fine right up until BUILD ISO and dies at the last step.
+#   PS 5.1  Historically because New-Iso compiled its helper with /unsafe, which
+#           needed "Add-Type -CompilerParameters" - dropped in PowerShell 6, so the
+#           app ran fine until BUILD ISO and died at the last step. That is no
+#           longer true: the helper compiles with a plain Add-Type now. The check
+#           stays because nothing has been tested on 7, not because it is known to
+#           fail. Somebody should try it and either lift this or write down why not.
 #   STA     WinForms needs a single-threaded apartment. powershell.exe -File is STA
 #           by default, but -MTA and several hosting paths are not, and there the
 #           dialogs and file pickers misbehave rather than fail outright.
@@ -102,6 +105,16 @@ function Save-PngAtomic($bmp,[string]$outPng) {
 # Sub-gigabyte payloads read badly in GB - a CD-sized game becomes "0.39 GB", and a
 # few megabytes of extras rounds to "0.00 GB", which looks like nothing at all.
 # Switch units instead of printing a meaningless zero.
+# Minutes and seconds until it runs past an hour, which a 100 GB BD-R XL can.
+#
+# Floor, not [int]: casting a double to [int] in PowerShell ROUNDS rather than
+# truncating, so [int]1.58 is 2 and 95 seconds displayed as "02:35" - a clock that
+# reads a minute ahead of itself. A stopwatch counts up, it does not round.
+function Format-Elapsed([TimeSpan]$t) {
+    if ($t.TotalHours -ge 1) { return '{0:00}:{1:00}:{2:00}' -f [int][math]::Floor($t.TotalHours), $t.Minutes, $t.Seconds }
+    return '{0:00}:{1:00}' -f [int][math]::Floor($t.TotalMinutes), $t.Seconds
+}
+
 function Format-Size([double]$bytes) {
     if ($bytes -ge 1GB) { return ('{0:N2} GB' -f ($bytes/1GB)) }
     if ($bytes -ge 1MB) { return ('{0:N0} MB' -f ($bytes/1MB)) }
@@ -691,20 +704,57 @@ function New-MenuHta([hashtable]$cfg,[string]$out) {
     Clear-ReadOnly $out; Set-Content -LiteralPath $out -Value $html -Encoding ASCII
 }
 
-function New-Iso([string]$stageDir,[string]$isoPath,[string]$volLabel) {
+function New-Iso([string]$stageDir,[string]$isoPath,[string]$volLabel,[scriptblock]$progress=$null) {
     if (-not ([System.Management.Automation.PSTypeName]'ISOFile').Type) {
         $code=@'
 public class ISOFile {
-  public unsafe static void Create(string Path, object Stream, int BlockSize, int TotalBlocks) {
-    int bytes=0; byte[] buf=new byte[BlockSize]; var ptr=(System.IntPtr)(&bytes);
+  // Progress is called every ReportEvery blocks with (blocksWritten, totalBlocks).
+  //
+  // It is not only there to draw a bar. The whole build runs on the interface
+  // thread, and this loop is the longest thing on it by far - without something
+  // pumping the message queue from inside it, Windows greys the window out and
+  // labels it "Not Responding" for the length of the write. On a full-size game
+  // that is minutes of looking exactly like a crash.
+  //
+  // IStream.Read wants somewhere to put the byte count. This used to take the
+  // address of a local with an unsafe pointer, which meant compiling with
+  // /unsafe. Four unmanaged bytes do the same job, and that matters twice over:
+  //
+  //   Smart App Control - enforced by default on a clean Windows 11 - blocks an
+  //   assembly that combines unsafe pointers with a delegate invoked inside the
+  //   copy loop. That is the shape of a shellcode loader, so the heuristic is
+  //   fair; measured here, the pointer-plus-callback build was refused every
+  //   time and this one is accepted every time. Without the change, adding
+  //   progress reporting would have stopped DiscWright writing ISOs at all on
+  //   any machine with SAC on.
+  //
+  //   And /unsafe needed Add-Type -CompilerParameters, which PowerShell 6
+  //   removed. Dropping it removes the one known reason this cannot run on
+  //   PowerShell 7 - untested there, but no longer ruled out by this.
+  public static void Create(string Path, object Stream, int BlockSize, int TotalBlocks,
+                            System.Action<int,int> Progress, int ReportEvery) {
+    byte[] buf=new byte[BlockSize];
+    System.IntPtr ptr=System.Runtime.InteropServices.Marshal.AllocHGlobal(4);
     System.IO.FileStream o=System.IO.File.OpenWrite(Path);
     System.Runtime.InteropServices.ComTypes.IStream i=Stream as System.Runtime.InteropServices.ComTypes.IStream;
-    if(o!=null){ while(TotalBlocks-->0){ i.Read(buf,BlockSize,ptr); o.Write(buf,0,bytes);} o.Flush(); o.Close(); }
+    try {
+      int total=TotalBlocks, done=0;
+      if(o!=null && i!=null){
+        while(TotalBlocks-->0){
+          i.Read(buf,BlockSize,ptr);
+          int bytes=System.Runtime.InteropServices.Marshal.ReadInt32(ptr);
+          o.Write(buf,0,bytes);
+          done++;
+          if(Progress!=null && ReportEvery>0 && done%ReportEvery==0) Progress(done,total);
+        }
+        o.Flush(); o.Close();
+        if(Progress!=null) Progress(total,total);
+      }
+    } finally { System.Runtime.InteropServices.Marshal.FreeHGlobal(ptr); }
   }
 }
 '@
-        $cp=New-Object System.CodeDom.Compiler.CompilerParameters; $cp.CompilerOptions='/unsafe'
-        Add-Type -CompilerParameters $cp -TypeDefinition $code
+        Add-Type -TypeDefinition $code
     }
     # A mounted ISO cannot be overwritten, and "used by another process" on its own
     # does not tell the user that the drive they opened in This PC is the cause.
@@ -748,7 +798,15 @@ public class ISOFile {
         $rootItem.AddTree($stageDir,$false)
         $img=$fsi.CreateResultImage()
         $stream=$img.ImageStream
-        [ISOFile]::Create($isoPath,$stream,$img.BlockSize,$img.TotalBlocks)
+
+        # Report about 200 times over the whole write, whatever its size. A fixed
+        # block interval would fire a handful of times on a CD and tens of
+        # thousands on a BD-R XL, and every call crosses back into PowerShell and
+        # pumps the message queue, which is not free.
+        $every = [int][math]::Max(256, [math]::Floor($img.TotalBlocks / 200))
+        $cb = $null
+        if ($progress) { $cb = [Action[int,int]]$progress }
+        [ISOFile]::Create($isoPath,$stream,$img.BlockSize,$img.TotalBlocks,$cb,$every)
     }
     finally {
         foreach ($o in @($stream,$img,$rootItem,$fsi)) {
@@ -865,7 +923,7 @@ function Import-DiscFolder([string]$discDir) {
 }
 
 # =================== BUILD ORCHESTRATION ===================
-function Invoke-Build([hashtable]$s, [scriptblock]$log) {
+function Invoke-Build([hashtable]$s, [scriptblock]$log, [scriptblock]$progress=$null) {
     $stage = Join-Path $s.OutDir 'disc'
     $tmpKeep = $null
 
@@ -1029,7 +1087,7 @@ function Invoke-Build([hashtable]$s, [scriptblock]$log) {
 
     & $log "Building ISO (UDF, this can take ~30-60s for a full game)..."
     $iso = Join-Path $s.OutDir (($s.Label -replace '[^A-Za-z0-9_\- ]','_').Trim()+'.iso')
-    New-Iso $stage $iso $s.Label
+    New-Iso $stage $iso $s.Label $progress
     & $log ("DONE.  ISO: {0}  ({1:N2} GB)" -f $iso, ((Get-Item $iso).Length/1GB))
 
     Save-Project $s $s.OutDir
@@ -1125,7 +1183,33 @@ $btnOut=AddBtn 'Browse...' 545 808 110
 
 $btnBuild=New-Object System.Windows.Forms.Button; $btnBuild.Text='BUILD ISO'; $btnBuild.Location=New-Object System.Drawing.Point(15,842); $btnBuild.Size=New-Object System.Drawing.Size(150,30); $btnBuild.BackColor=[System.Drawing.Color]::FromArgb(0,150,160); $btnBuild.ForeColor=[System.Drawing.Color]::White; $form.Controls.Add($btnBuild)
 $txtLog=New-Object System.Windows.Forms.TextBox; $txtLog.Multiline=$true; $txtLog.ScrollBars='Vertical'; $txtLog.ReadOnly=$true; $txtLog.Location=New-Object System.Drawing.Point(180,842); $txtLog.Size=New-Object System.Drawing.Size(480,90); $form.Controls.Add($txtLog)
-$log = { param($m) $txtLog.AppendText($m + "`r`n"); [System.Windows.Forms.Application]::DoEvents() }
+
+# Both sit in space the layout already had, under the BUILD button and beside the
+# log, so nothing else has to move. Hidden until a build starts - an idle window
+# looks exactly as it did before.
+$pbBuild=New-Object System.Windows.Forms.ProgressBar; $pbBuild.Location=New-Object System.Drawing.Point(15,880); $pbBuild.Size=New-Object System.Drawing.Size(150,14); $pbBuild.Minimum=0; $pbBuild.Maximum=1000; $pbBuild.Visible=$false; $form.Controls.Add($pbBuild)
+$lblElapsed=New-Object System.Windows.Forms.Label; $lblElapsed.Location=New-Object System.Drawing.Point(15,900); $lblElapsed.Size=New-Object System.Drawing.Size(160,20); $lblElapsed.ForeColor=[System.Drawing.Color]::DimGray; $form.Controls.Add($lblElapsed)
+
+$buildWatch = New-Object System.Diagnostics.Stopwatch
+
+$log = { param($m)
+    $txtLog.AppendText($m + "`r`n")
+    if ($buildWatch.IsRunning) { $lblElapsed.Text = 'Elapsed  ' + (Format-Elapsed $buildWatch.Elapsed) }
+    [System.Windows.Forms.Application]::DoEvents()
+}
+
+# Handed to Invoke-Build, which passes it down to the ISO writer. Called about 200
+# times over a write of any size. DoEvents is the load-bearing line: the build owns
+# the interface thread, and this is the only thing keeping the window painting
+# while the longest step runs.
+$buildProgress = { param($done,$total)
+    if ($total -gt 0) {
+        $v = [int](1000.0 * $done / $total); if ($v -gt 1000) { $v = 1000 }
+        $pbBuild.Value = $v
+        $lblElapsed.Text = 'ISO  {0}%   {1}' -f [int]($v/10), (Format-Elapsed $buildWatch.Elapsed)
+    }
+    [System.Windows.Forms.Application]::DoEvents()
+}
 
 # ---- shared bits ----
 # Everything that will land on the disc, not just the installer - artbooks and
@@ -1599,9 +1683,26 @@ $btnBuild.Add_Click({
          Buttons=$buttons; ManualPath=$(if($cbMan.Checked){$state.ManualPath}else{$null}); ExtrasPath=$(if($cbExtra.Checked){$state.ExtrasPath}else{$null});
          ExtraItems=@($lstExtra.Items); OutDir=$txtOut.Text.Trim() }
     $btnBuild.Enabled=$false
-    try { $iso=Invoke-Build $s $log; [System.Windows.Forms.MessageBox]::Show("Build complete!`n`n$iso","DiscWright") | Out-Null }
-    catch { & $log ('ERROR: '+$_.Exception.Message); Show-Warn ("The build failed:`r`n`r`n" + $_.Exception.Message) }
-    finally { $btnBuild.Enabled=$true; Update-ActionButtons }
+    $pbBuild.Value=0; $pbBuild.Visible=$true
+    $buildWatch.Restart()
+    $lblElapsed.Text='Starting...'
+    try {
+        $iso=Invoke-Build $s $log $buildProgress
+        $buildWatch.Stop()
+        $took = Format-Elapsed $buildWatch.Elapsed
+        $lblElapsed.Text = "Done in $took"
+        & $log "Total time: $took"
+        [System.Windows.Forms.MessageBox]::Show("Build complete in $took`n`n$iso","DiscWright") | Out-Null
+    }
+    catch {
+        $buildWatch.Stop(); $lblElapsed.Text='Failed'
+        & $log ('ERROR: '+$_.Exception.Message); Show-Warn ("The build failed:`r`n`r`n" + $_.Exception.Message)
+    }
+    finally {
+        if ($buildWatch.IsRunning) { $buildWatch.Stop() }
+        $pbBuild.Visible=$false
+        $btnBuild.Enabled=$true; Update-ActionButtons
+    }
 })
 
 # DiscWright.vbs starts this process with STARTUPINFO wShowWindow = SW_HIDE so no

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Play knows whether the game is already installed and greys itself out until it i
 ## What you need
 
 - **Windows 10 or 11**
-- **Windows PowerShell 5.1** — the one that ships with Windows. Not PowerShell 7; the ISO builder uses a compiler option that PowerShell 6 removed. DiscWright checks on startup and tells you if you launch it the wrong way.
+- **Windows PowerShell 5.1** — the one that ships with Windows. DiscWright checks on startup and tells you if you launch it the wrong way. PowerShell 7 is refused: it may well work now that the ISO builder no longer needs a compiler option PowerShell 6 removed, but nobody has tried it, so the check stays until somebody does.
 - **A blank disc and something to burn it with.** DiscWright makes the ISO. Burning is deliberately out of scope — [ImgBurn](https://www.imgburn.com/), Nero, and Windows' own built-in burner all do it well, and there is no reason to write a worse one.
 
 No installation. No dependencies. It is a single PowerShell script.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -54,6 +54,10 @@ editor.
   let a disc look like its own era instead of looking like DiscWright.
 - **A presentation site.** Mainly to give people something plainer than a README to read
   before deciding to run an unsigned script.
+- **PowerShell 7.** The one known blocker is gone: the ISO builder no longer compiles
+  with `/unsafe`, so it no longer needs `Add-Type -CompilerParameters`. Whether anything
+  else stops it — WinForms, the COM interop, apartment state — has not been tested, and
+  the startup guard still refuses PowerShell 7 until somebody actually tries it.
 
 ## Not planned
 
@@ -65,9 +69,9 @@ Stated plainly because these come up.
   reason a tool like this can exist. DiscWright circumvents nothing and never will.
 - **Non-Windows support.** The interface is WinForms and the ISO builder is IMAPI2FS.
   Both are Windows-only and neither has a portable replacement worth the rewrite.
-- **PowerShell 7.** The ISO builder needs `Add-Type -CompilerParameters` with `/unsafe`,
-  which PowerShell 6 removed. Windows PowerShell 5.1 ships with Windows, so requiring it
-  costs nobody an installation.
+(**PowerShell 7** used to be listed here. It was ruled out because the ISO builder
+needed `Add-Type -CompilerParameters` with `/unsafe`, which PowerShell 6 removed. That
+dependency is gone, so the entry moved up to *Considering*.)
 
 ## How this list changes
 


### PR DESCRIPTION
The ISO write reported nothing at all, and because the build owns the interface
thread with only the log's DoEvents keeping the window alive, New-Iso logging
nothing meant nothing pumped the message queue for the whole write. Windows
greyed the window out and marked it "Not Responding" - minutes of looking
exactly like a crash on a full-size game, which is the point at which somebody
force-quits and reports it as one.

ISOFile.Create now takes a callback and calls it about 200 times over a write
of any size - a fixed block interval would fire a handful of times on a CD and
tens of thousands on a BD-R XL. The same callback draws the bar and pumps the
queue, so both problems are solved by one mechanism. Also a stopwatch: elapsed
time while building, total time in the log and in the completion dialog.

Two things found while testing, both worth reading:

The first shape of this would have broken the app on a clean Windows 11.
Smart App Control is enforced there by default, and it refuses an assembly
combining unsafe pointers with a delegate invoked inside the copy loop - fairly,
since that is what a shellcode loader looks like. Measured on a machine with SAC
enforced: pointer plus callback blocked 3/3, published version 3/3 fine, and
replacing the stack pointer with Marshal.AllocHGlobal makes it 3/3 fine with the
callback. So the ISO writer no longer compiles with /unsafe.

That has a consequence beyond this change. /unsafe was why Add-Type needed
-CompilerParameters, and -CompilerParameters going away in PowerShell 6 was the
one known reason DiscWright required Windows PowerShell 5.1. It is still
untested on 7 and the startup guard still refuses it, but the stated reason for
that guard is no longer true, so the README, the roadmap and the guard's own
comment now say what is actually the case.

Second, Format-Elapsed read a minute fast. [int] on a double rounds in
PowerShell rather than truncating, so [int]1.58 is 2 and 95 seconds displayed as
"02:35". Floor is what a clock does.

Verified in a fresh session: 24 checks covering callback count and monotonicity,
the ISO still reading as UDF 2.50 with the right volume id and passing 7-Zip's
integrity test, a build with no callback at all, and the clock across eight
boundary values.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
