### PR TITLE
Multi-game plumbing, the test suite, and three bugs found testing it

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -44,6 +44,35 @@ jobs:
           }
           if ($failed) { exit 1 }
 
+      # The ISO build tests skip themselves if the runner has no IMAPI2FS, and the
+      # ISO content tests skip if it has no 7-Zip, so the job still means something
+      # on a machine that cannot do either.
+      - name: Pester
+        shell: powershell
+        run: |
+          if (-not (Get-Module -ListAvailable Pester | Where-Object { $_.Version.Major -ge 5 })) {
+              Set-PSRepository PSGallery -InstallationPolicy Trusted
+              Install-Module Pester -Force -SkipPublisherCheck -Scope CurrentUser -MinimumVersion 5.0
+          }
+          Import-Module Pester -MinimumVersion 5.0 -Force
+          Write-Host "Pester $((Get-Module Pester).Version)"
+
+          $cfg = New-PesterConfiguration
+          $cfg.Run.Path             = 'tests'
+          $cfg.Run.Exit             = $true
+          $cfg.Output.Verbosity     = 'Detailed'
+          $cfg.TestResult.Enabled   = $true
+          $cfg.TestResult.OutputPath = 'pester-results.xml'
+          Invoke-Pester -Configuration $cfg
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pester-results
+          path: pester-results.xml
+          if-no-files-found: ignore
+
       # Fails the build on Errors only. Warnings are printed but tolerated: the
       # default rule set has strong opinions about WinForms code that are not
       # worth rewriting a working app over, and a check that always fails is a

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -76,7 +76,8 @@ jobs:
       # Fails the build on Errors only. Warnings are printed but tolerated: the
       # default rule set has strong opinions about WinForms code that are not
       # worth rewriting a working app over, and a check that always fails is a
-      # check everybody learns to ignore.
+      # check everybody learns to ignore. Which rules run is in
+      # PSScriptAnalyzerSettings.psd1, with the reasoning for each exclusion.
       - name: PSScriptAnalyzer
         shell: powershell
         run: |
@@ -84,7 +85,10 @@ jobs:
               Set-PSRepository PSGallery -InstallationPolicy Trusted
               Install-Module PSScriptAnalyzer -Force -Scope CurrentUser
           }
-          $results  = @(Invoke-ScriptAnalyzer -Path . -Recurse)
+          # Invoke-ScriptAnalyzer does find the settings file on its own when it
+          # sits in the analyzed path, but naming it means the result does not
+          # depend on where the job happens to be standing.
+          $results  = @(Invoke-ScriptAnalyzer -Path . -Recurse -Settings .\PSScriptAnalyzerSettings.psd1)
           $errors   = @($results | Where-Object { $_.Severity -eq 'Error' })
           $warnings = @($results | Where-Object { $_.Severity -eq 'Warning' })
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 *.iso
 disc/
 discproject.json
+
+# Pester output
+pester-results.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ between minor versions.
   of scope.
 - `CHANGELOG.md` — this file.
 
+### Fixed
+
+- **Building a disc and then rebuilding it immediately failed**, with "the old disc
+  folder cannot be replaced — something is still using it" and a suggestion to close
+  Explorer or eject a mounted ISO. Neither was the cause: the ISO builder left its
+  COM objects alive, so DiscWright was still holding a handle on every file in its
+  own staging folder. Waiting a minute and trying again worked, which made it look
+  intermittent rather than reproducible.
+
 ## [0.1.0] — 2026-08-16
 
 First public release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ between minor versions.
 
 ## [Unreleased]
 
+### Changed
+
+- **Each Browse button now opens where its own box points.** `FolderBrowserDialog`
+  remembers the last folder used anywhere in the app, so after a build the game-folder
+  Browse reopened on the disc it had just written. The two folders are named alike
+  enough that picking the wrong one looked like the app losing the game.
+- **Picking a built disc folder says so.** Choosing the output folder instead of the GOG
+  download used to give the generic "no `setup_*.exe` here", which sends you looking for
+  a problem with your download. If the folder holds a `disc\` with an installer in it,
+  DiscWright now says it is a disc it built and which folder step 1 actually wants.
+
 ## [0.2.0] — 2026-08-18
 
 ### Added

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -711,26 +711,48 @@ public class ISOFile {
                    "Then build again.`r`n`r`nWindows said: $($_.Exception.Message)")
         }
     }
-    $fsi=New-Object -ComObject IMAPI2FS.MsftFileSystemImage
+    # Every one of these COM objects has to be released by hand. AddTree opens a
+    # handle on each staged file and CreateResultImage holds them until the image
+    # is released, so leaving it to the garbage collector means DiscWright is still
+    # locking its own disc folder when the build returns. Rebuilding then failed
+    # with "something is still using it", pointing the blame at Explorer or a
+    # mounted ISO when the process holding the files was DiscWright itself.
+    $fsi=$null; $rootItem=$null; $img=$null; $stream=$null
+    try {
+        $fsi=New-Object -ComObject IMAPI2FS.MsftFileSystemImage
 
-    # Size the virtual medium to the actual payload. The old fixed 12.5M blocks
-    # (~25 GB) silently capped builds well below the BD-R DL / XL sizes the UI
-    # recommends.
-    $payload = (Get-ChildItem -Recurse -File -Force $stageDir | Measure-Object Length -Sum).Sum
-    $blocks  = [long][math]::Ceiling(($payload * 1.05) / 2048) + 65536
-    if ($blocks -lt 12500000) { $blocks = 12500000 }
-    if ($blocks -gt 2147483000) { $blocks = 2147483000 }
-    $fsi.FreeMediaBlocks=[int]$blocks
+        # Size the virtual medium to the actual payload. The old fixed 12.5M blocks
+        # (~25 GB) silently capped builds well below the BD-R DL / XL sizes the UI
+        # recommends.
+        $payload = (Get-ChildItem -Recurse -File -Force $stageDir | Measure-Object Length -Sum).Sum
+        $blocks  = [long][math]::Ceiling(($payload * 1.05) / 2048) + 65536
+        if ($blocks -lt 12500000) { $blocks = 12500000 }
+        if ($blocks -gt 2147483000) { $blocks = 2147483000 }
+        $fsi.FreeMediaBlocks=[int]$blocks
 
-    # UDF only. GOG part filenames run past 64 chars, which Joliet cannot hold,
-    # and the .bin parts sit at the ISO9660 4 GiB ceiling.
-    $fsi.FileSystemsToCreate=4
-    try { $fsi.UDFRevision=0x250 } catch {}
-    $vn = ($volLabel -replace '[^A-Za-z0-9_]','_'); if($vn.Length -gt 16){$vn=$vn.Substring(0,16)}
-    $fsi.VolumeName=$vn
-    $fsi.Root.AddTree($stageDir,$false)
-    $img=$fsi.CreateResultImage()
-    [ISOFile]::Create($isoPath,$img.ImageStream,$img.BlockSize,$img.TotalBlocks)
+        # UDF only. GOG part filenames run past 64 chars, which Joliet cannot hold,
+        # and the .bin parts sit at the ISO9660 4 GiB ceiling.
+        $fsi.FileSystemsToCreate=4
+        try { $fsi.UDFRevision=0x250 } catch {}
+        $vn = ($volLabel -replace '[^A-Za-z0-9_]','_'); if($vn.Length -gt 16){$vn=$vn.Substring(0,16)}
+        $fsi.VolumeName=$vn
+        # Bind Root once. Reading it creates a fresh wrapper every time, and a
+        # wrapper nobody kept a reference to is a wrapper nobody can release.
+        $rootItem=$fsi.Root
+        $rootItem.AddTree($stageDir,$false)
+        $img=$fsi.CreateResultImage()
+        $stream=$img.ImageStream
+        [ISOFile]::Create($isoPath,$stream,$img.BlockSize,$img.TotalBlocks)
+    }
+    finally {
+        foreach ($o in @($stream,$img,$rootItem,$fsi)) {
+            if ($o) { try { [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($o) } catch {} }
+        }
+        # Releasing drops our references; the handles close when the runtime runs
+        # the finalisers. Waiting for that here is what makes an immediate rebuild
+        # work instead of failing on a lock that clears a few seconds later.
+        [GC]::Collect(); [GC]::WaitForPendingFinalizers()
+    }
 }
 
 # =================== PROJECT SAVE / REOPEN ===================

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -143,7 +143,24 @@ function Get-GameInfo([string]$folder) {
     if (-not (Test-Path $folder)) { $info.Msg='Folder not found.'; return $info }
     $exes = @(Get-ChildItem $folder -Filter 'setup_*.exe' -File -ErrorAction SilentlyContinue |
               Sort-Object Length -Descending)
-    if ($exes.Count -eq 0) { $info.Msg='No GOG "setup_*.exe" found in this folder.'; return $info }
+    if ($exes.Count -eq 0) {
+        # Two folders in a project look alike and sit next to each other: the GOG
+        # download, and the output folder DiscWright writes to. The second holds a
+        # disc\ subfolder with the installer one level down, so picking it lands
+        # here - and the generic message sends people looking for a problem with
+        # their download instead of at which folder they picked. Name it instead.
+        $inner = Join-Path $folder 'disc'
+        $innerExe = @()
+        if (Test-Path $inner) {
+            $innerExe = @(Get-ChildItem $inner -Filter 'setup_*.exe' -File -ErrorAction SilentlyContinue)
+        }
+        if ($innerExe.Count -gt 0) {
+            $info.Msg = 'This looks like a disc DiscWright built, not a GOG download. Step 1 wants the folder you downloaded from GOG; this one is where the ISO gets written.'
+        } else {
+            $info.Msg = 'No GOG "setup_*.exe" found in this folder.'
+        }
+        return $info
+    }
     $exe = $exes[0]
 
     # Parts belong to ONE installer and are named "<installer>-1.bin", "-2.bin"...
@@ -1185,6 +1202,18 @@ function AddLabel($t,$x,$y,$w){ $l=New-Object System.Windows.Forms.Label; $l.Tex
 function AddText($x,$y,$w){ $t=New-Object System.Windows.Forms.TextBox; $t.Location=New-Object System.Drawing.Point($x,$y); $t.Size=New-Object System.Drawing.Size($w,24); $form.Controls.Add($t); return $t }
 function AddBtn($t,$x,$y,$w){ $b=New-Object System.Windows.Forms.Button; $b.Text=$t; $b.Location=New-Object System.Drawing.Point($x,$y); $b.Size=New-Object System.Drawing.Size($w,24); $form.Controls.Add($b); return $b }
 
+# A FolderBrowserDialog with no SelectedPath opens wherever Windows last left it,
+# process-wide. After a build that is the output folder, so Browse for the game
+# folder in step 1 reopened on the disc it had just written - and the two folders
+# are named alike enough that picking the wrong one looks like the app losing the
+# game rather than a misclick. Each Browse now starts where its own box points.
+function New-FolderDialog([string]$description,[string]$startAt) {
+    $d = New-Object System.Windows.Forms.FolderBrowserDialog
+    if ($description) { $d.Description = $description }
+    if ($startAt -and (Test-Path $startAt -PathType Container)) { $d.SelectedPath = $startAt }
+    return $d
+}
+
 # --- reopen / inspect row ---
 $btnOpenProj = AddBtn 'Open existing disc...' 15 8 210
 $btnOpenDisc = AddBtn 'Show disc folder' 235 8 200
@@ -1613,8 +1642,7 @@ function Open-Project([string]$folder) {
 
 # ---- events ----
 $btnOpenProj.Add_Click({
-    $d=New-Object System.Windows.Forms.FolderBrowserDialog
-    $d.Description='Pick the disc output folder (the one holding disc\ and the .iso)'
+    $d = New-FolderDialog 'Pick the disc output folder (the one holding disc\ and the .iso)' $txtOut.Text.Trim()
     if ($d.ShowDialog() -eq 'OK') { Open-Project $d.SelectedPath }
 })
 $btnOpenDisc.Add_Click({
@@ -1638,7 +1666,7 @@ $btnPreview.Add_Click({
 })
 $txtOut.Add_TextChanged({ Update-ActionButtons })
 $btnFolder.Add_Click({
-    $d=New-Object System.Windows.Forms.FolderBrowserDialog
+    $d = New-FolderDialog 'Pick the folder you downloaded from GOG (it holds setup_*.exe)' $txtFolder.Text.Trim()
     if ($d.ShowDialog() -eq 'OK') {
         $g = Set-GameFolder $d.SelectedPath
         if ($g.Ok -and [string]::IsNullOrWhiteSpace($txtLabel.Text)) { $txtLabel.Text=$g.GameName }
@@ -1654,15 +1682,15 @@ $btnMusic.Add_Click({ $d=New-Object System.Windows.Forms.OpenFileDialog; $d.Filt
 # Manuals are usually PDF but plenty ship as text or HTML, and the menu just
 # shell-executes whatever it is - nothing in the pipeline needs it to be a PDF.
 $btnMan.Add_Click({ $d=New-Object System.Windows.Forms.OpenFileDialog; $d.Filter='Manuals|*.pdf;*.txt;*.htm;*.html;*.rtf;*.doc;*.docx|All files|*.*'; if($d.ShowDialog() -eq 'OK'){ $txtMan.Text=$d.FileName; $state.ManualPath=$d.FileName; Update-MediaLabel } })
-$btnEx.Add_Click({ $d=New-Object System.Windows.Forms.FolderBrowserDialog; if($d.ShowDialog() -eq 'OK'){ $txtEx.Text=$d.SelectedPath; $state.ExtrasPath=$d.SelectedPath; Update-MediaLabel } })
-$btnOut.Add_Click({ $d=New-Object System.Windows.Forms.FolderBrowserDialog; if($d.ShowDialog() -eq 'OK'){ $txtOut.Text=$d.SelectedPath } })
+$btnEx.Add_Click({ $d=New-FolderDialog 'Pick a folder of extras to put on the disc' $txtEx.Text.Trim(); if($d.ShowDialog() -eq 'OK'){ $txtEx.Text=$d.SelectedPath; $state.ExtrasPath=$d.SelectedPath; Update-MediaLabel } })
+$btnOut.Add_Click({ $d=New-FolderDialog 'Pick where the disc folder and the ISO get written' $txtOut.Text.Trim(); if($d.ShowDialog() -eq 'OK'){ $txtOut.Text=$d.SelectedPath } })
 $btnXFile.Add_Click({
     $d=New-Object System.Windows.Forms.OpenFileDialog; $d.Filter='All files|*.*'; $d.Multiselect=$true
     $d.Title='Pick any files to put on the disc'
     if($d.ShowDialog() -eq 'OK'){ foreach($fn in $d.FileNames){ Add-ExtraItem $fn } }
 })
 $btnXDir.Add_Click({
-    $d=New-Object System.Windows.Forms.FolderBrowserDialog; $d.Description='Pick a folder to put on the disc'
+    $d = New-FolderDialog 'Pick a folder to put on the disc' $txtFolder.Text.Trim()
     if($d.ShowDialog() -eq 'OK'){ Add-ExtraItem $d.SelectedPath }
 })
 $btnXDel.Add_Click({

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -1476,7 +1476,10 @@ function Set-GameFolders([string[]]$paths) {
 # Callers that still deal in one folder - the Browse button, reopening a v1
 # project - go through here and get the single result back, as before.
 function Set-GameFolder([string]$path) {
-    $found = @(Set-GameFolders @($path))
+    # Not @(Set-GameFolders ...) - it already returns a list, and wrapping it again
+    # yields a one-element array holding that list, so $found[0] would be every
+    # game rather than the first. Same trap as Get-FirstGame.
+    $found = Set-GameFolders @($path)
     if ($found.Count -gt 0) { return $found[0] }
     return (Get-GameInfo $path)
 }

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -1154,10 +1154,21 @@ $state = @{ Games=@(); IconPath=$null; IconIsIco=$false; BgPath=$null; MusicFile
 # One game per disc is still the common case, so the disc layout, the UI and the
 # menu are unchanged for it. Only sizing, the build's copy step and the menu need
 # to think in lists, and they go through these two.
-function Get-Games { return @($state.Games | Where-Object { $_ -and $_.Ok }) }
+# The leading comma is load-bearing. PowerShell unrolls a single-element array on
+# return, so "return @(...)" with one game handed back the bare hashtable instead
+# of a list. Callers then read .Count on a hashtable - which is its number of KEYS,
+# nine - and the media line announced "9 games (0 bytes)" for one game. Get-FirstGame
+# was worse: $g[0] indexed the hashtable by the key 0, found nothing, and returned
+# null, so the preview menu lost the game entirely. Wrapping in an outer array means
+# the unroll gives back the inner one.
+function Get-Games { return ,@($state.Games | Where-Object { $_ -and $_.Ok }) }
+
+# Do NOT write @(Get-Games) here. Get-Games already hands back an array, and wrapping
+# it again gives a one-element array whose element is that array - so $g[0] came back
+# as every game at once. Plain assignment is what preserves it.
 function Get-FirstGame {
     $g = Get-Games
-    if ($g.Count) { return $g[0] }
+    if ($g.Count -gt 0) { return $g[0] }
     return $null
 }
 
@@ -1281,7 +1292,13 @@ $buildProgress = { param($done,$total)
 function Get-PayloadBytes {
     $games = Get-Games
     if ($games.Count -eq 0) { return @{ Installer=[double]0; Extra=[double]0; Total=[double]0 } }
-    $installer = [double](($games | Measure-Object TotalBytes -Sum).Sum)
+    # Summed by hand, not with Measure-Object. Get-GameInfo returns a hashtable, and
+    # Measure-Object -Property looks for a real PROPERTY - a hashtable key is not one,
+    # so it found nothing and reported a total of zero for every disc. $g.TotalBytes
+    # works because member access on a hashtable does read keys; Measure-Object does
+    # not go through that path.
+    $installer = [double]0
+    foreach ($g in $games) { $installer += [double]$g.TotalBytes }
     $side = @()
     $side += @($state.ExtraItems)
     if ($cbMan.Checked   -and $state.ManualPath) { $side += $state.ManualPath }
@@ -1451,14 +1468,16 @@ function Set-GameFolders([string[]]$paths) {
         $lblGame.Text = $bad[0].Msg
         $lblGame.ForeColor = [System.Drawing.Color]::Firebrick
     }
-    return $found
+    # Comma for the same reason as Get-Games: one game would otherwise come back as
+    # a bare hashtable, and Set-GameFolder's $found[0] would hand its caller null.
+    return ,@($found)
 }
 
 # Callers that still deal in one folder - the Browse button, reopening a v1
 # project - go through here and get the single result back, as before.
 function Set-GameFolder([string]$path) {
-    $found = Set-GameFolders @($path)
-    if ($found.Count) { return $found[0] }
+    $found = @(Set-GameFolders @($path))
+    if ($found.Count -gt 0) { return $found[0] }
     return (Get-GameInfo $path)
 }
 

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -246,7 +246,19 @@ function Get-DiscIconName([string]$label) {
 # discs built before the icon was named after the game.
 function Test-ReservedDiscName([string]$name,[string]$iconName='disc.ico') {
     if ($name -like 'setup_*') { return $true }
-    return (@('autorun.inf','disc.ico',$iconName,'AUTORUN','Extras',$PROJECT_FILE) -contains $name)
+    return (@('autorun.inf','disc.ico',$iconName,'AUTORUN','Extras','Games',$PROJECT_FILE) -contains $name)
+}
+
+# Folder name for one game on a multi-game disc. Numbered, so the order in the
+# menu and the order in the disc's own listing agree when someone browses it by
+# hand. Folded to plain ASCII for the same reason the disc label is - a disc that
+# is legible in every file manager is worth more than an exact title.
+function Get-GameFolderName([int]$index,[string]$name) {
+    $n = (ConvertTo-AsciiFold ([string]$name)) -replace '[^A-Za-z0-9 _\-\.]',' '
+    $n = ($n -replace '\s+',' ').Trim(' ','.')
+    if ($n.Length -gt 48) { $n = $n.Substring(0,48).Trim() }
+    if ([string]::IsNullOrWhiteSpace($n)) { $n = 'Game' }
+    return ('{0:D2} - {1}' -f $index, $n)
 }
 
 function Test-IconInput([string]$path) {
@@ -736,11 +748,16 @@ public class ISOFile {
 # =================== PROJECT SAVE / REOPEN ===================
 
 function Save-Project([hashtable]$s,[string]$outDir) {
+    $games = @($s.Games)
     $o = [ordered]@{
-        Version      = 1
+        Version      = 2
         SavedUtc     = (Get-Date).ToUniversalTime().ToString('s')
-        SourceFolder = $s.Game.Folder
-        GameName     = $s.Game.GameName
+        # Version 1 knew about exactly one game and stored it here. Both keys are
+        # still written, pointing at the first game, so a project saved by this
+        # build still opens in 0.1.x instead of failing with no explanation.
+        SourceFolder = $(if ($games.Count) { $games[0].Folder }    else { $null })
+        GameName     = $(if ($games.Count) { $games[0].GameName } else { $null })
+        Games        = @($games | ForEach-Object { [ordered]@{ Folder=$_.Folder; GameName=$_.GameName } })
         Label        = $s.Label
         IconPath     = $s.IconPath
         IconIsIco    = [bool]$s.IconIsIco
@@ -766,8 +783,17 @@ function Save-Project([hashtable]$s,[string]$outDir) {
 function Import-Project([string]$jsonPath) {
     try {
         $j = Get-Content -Raw -LiteralPath $jsonPath | ConvertFrom-Json
+        # v1 stored one game in SourceFolder; v2 stores a Games array. Read either
+        # and always hand back a list, so nothing downstream has to know which
+        # version it came from.
+        $folders = @()
+        if ($j.PSObject.Properties.Name -contains 'Games' -and $j.Games) {
+            $folders = @($j.Games | ForEach-Object { $_.Folder } | Where-Object { $_ })
+        }
+        if ($folders.Count -eq 0 -and $j.SourceFolder) { $folders = @($j.SourceFolder) }
         return @{
-            SourceFolder=$j.SourceFolder; Label=$j.Label; IconPath=$j.IconPath; IconIsIco=[bool]$j.IconIsIco
+            SourceFolder=$j.SourceFolder; GameFolders=$folders
+            Label=$j.Label; IconPath=$j.IconPath; IconIsIco=[bool]$j.IconIsIco
             Menu=[bool]$j.Menu; BgPath=$j.BgPath; BgAsIs=[bool]$j.BgAsIs
             PanelSide=$(if($j.PanelSide){$j.PanelSide}else{'Right'})
             Divider=[bool]$j.Divider; ShowTitle=[bool]$j.ShowTitle; TitleText=[string]$j.TitleText
@@ -789,7 +815,8 @@ function Import-DiscFolder([string]$discDir) {
     $icon  = 'disc.ico'; if ($text -match '(?im)^\s*icon\s*=\s*(.+?)\s*$') { $icon = $Matches[1] }
     $menu  = ($text -match '(?im)^\s*shellexecute\s*=')
 
-    $r = @{ SourceFolder=$discDir; Label=$label; IconPath=(Join-Path $discDir $icon); IconIsIco=$true
+    $r = @{ SourceFolder=$discDir; GameFolders=@($discDir)
+            Label=$label; IconPath=(Join-Path $discDir $icon); IconIsIco=$true
             Menu=$menu; BgPath=$null; BgAsIs=$true; PanelSide='Right'; MusicFile=$null
             Buttons=@(); ManualPath=$null; ExtrasPath=$null; ExtraItems=@()
             Divider=$false; ShowTitle=$false; TitleText=''
@@ -837,9 +864,11 @@ function Invoke-Build([hashtable]$s, [scriptblock]$log) {
     $stage = Join-Path $s.OutDir 'disc'
     $tmpKeep = $null
 
+    $games = @($s.Games)
     # Rebuilding a disc folder in place: the payload already lives in the stage,
-    # so do NOT wipe it.
-    $inPlace = (Test-SamePath $s.Game.Folder $stage)
+    # so do NOT wipe it. Only ever true for a single game - several games live in
+    # Games\ subfolders, so their source folder is never the stage itself.
+    $inPlace = ($games.Count -eq 1) -and (Test-SamePath $games[0].Folder $stage)
 
     if ($inPlace) {
         & $log "Rebuilding in place - installer files left untouched."
@@ -889,13 +918,28 @@ function Invoke-Build([hashtable]$s, [scriptblock]$log) {
         }
         New-Item -ItemType Directory -Force -Path $stage,"$stage\AUTORUN" | Out-Null
 
-        # installer files: hardlink if same volume, else copy
-        $sameVol = ([IO.Path]::GetPathRoot($s.Game.SetupExe.FullName) -eq [IO.Path]::GetPathRoot($stage))
-        foreach ($f in $s.Game.Files) {
-            $dest = Join-Path $stage $f.Name
-            if ($sameVol) { try { New-Item -ItemType HardLink -Path $dest -Target $f.FullName -EA Stop | Out-Null; & $log "  linked $($f.Name)" }
-                            catch { Copy-Item $f.FullName $dest; & $log "  copied $($f.Name)" } }
-            else { & $log "  copying $($f.Name) ..."; Copy-Item $f.FullName $dest }
+        # One game keeps the original layout - installer at the disc root, exactly
+        # as every disc built before this. Several games each get their own folder
+        # under Games\, because a flat root would be unreadable and the menu needs
+        # to be able to name one installer without ambiguity.
+        $stageRoot = [IO.Path]::GetPathRoot($stage)
+        for ($gi = 0; $gi -lt $games.Count; $gi++) {
+            $g = $games[$gi]
+            if ($games.Count -eq 1) { $destDir = $stage }
+            else {
+                $destDir = Join-Path $stage (Join-Path 'Games' (Get-GameFolderName ($gi+1) $g.GameName))
+                New-Item -ItemType Directory -Force -Path $destDir | Out-Null
+                & $log "  $($g.GameName) -> $(Split-Path $destDir -Leaf)"
+            }
+            # Hardlinks are per-volume, so this is decided per game: two games on
+            # different drives can still have one linked and the other copied.
+            $sameVol = ([IO.Path]::GetPathRoot($g.SetupExe.FullName) -eq $stageRoot)
+            foreach ($f in $g.Files) {
+                $dest = Join-Path $destDir $f.Name
+                if ($sameVol) { try { New-Item -ItemType HardLink -Path $dest -Target $f.FullName -EA Stop | Out-Null; & $log "  linked $($f.Name)" }
+                                catch { Copy-Item $f.FullName $dest; & $log "  copied $($f.Name)" } }
+                else { & $log "  copying $($f.Name) ..."; Copy-Item $f.FullName $dest }
+            }
         }
     }
 
@@ -966,7 +1010,14 @@ function Invoke-Build([hashtable]$s, [scriptblock]$log) {
             }
         }
         & $log "Generating autorun menu (menu.hta)..."
-        New-MenuHta @{ GameName=$s.Label; MatchName=$s.Game.GameName; SetupExe=$s.Game.SetupExe.Name; Buttons=$s.Buttons;
+        # The menu still drives one game - the chooser arrives with the UI that can
+        # actually create a multi-game disc. Until then it points at the first, via
+        # the same relative path the disc really has, since the HTA resolves SETUP
+        # with fso.BuildPath(root, SETUP) and copes with a subfolder either way.
+        $mg = $games[0]
+        $mgSetup = if ($games.Count -eq 1) { $mg.SetupExe.Name }
+                   else { Join-Path 'Games' (Join-Path (Get-GameFolderName 1 $mg.GameName) $mg.SetupExe.Name) }
+        New-MenuHta @{ GameName=$s.Label; MatchName=$mg.GameName; SetupExe=$mgSetup; Buttons=$s.Buttons;
                        MusicFile=$musicName; ManualFile=$manualName; PanelSide=$s.PanelSide; IconName=$icoName
                        WindowBorder=[bool]$s.WindowBorder; ButtonStyle=$s.ButtonStyle } (Join-Path $stage 'AUTORUN\menu.hta')
     }
@@ -1007,7 +1058,17 @@ function Invoke-Build([hashtable]$s, [scriptblock]$log) {
 }
 
 # =================== UI ===================
-$state = @{ Game=$null; IconPath=$null; IconIsIco=$false; BgPath=$null; MusicFile=$null; ManualPath=$null; ExtrasPath=$null; ExtraItems=@() }
+$state = @{ Games=@(); IconPath=$null; IconIsIco=$false; BgPath=$null; MusicFile=$null; ManualPath=$null; ExtrasPath=$null; ExtraItems=@() }
+
+# One game per disc is still the common case, so the disc layout, the UI and the
+# menu are unchanged for it. Only sizing, the build's copy step and the menu need
+# to think in lists, and they go through these two.
+function Get-Games { return @($state.Games | Where-Object { $_ -and $_.Ok }) }
+function Get-FirstGame {
+    $g = Get-Games
+    if ($g.Count) { return $g[0] }
+    return $null
+}
 
 $form=New-Object System.Windows.Forms.Form
 $form.Text='DiscWright'
@@ -1099,31 +1160,42 @@ $log = { param($m) $txtLog.AppendText($m + "`r`n"); [System.Windows.Forms.Applic
 # own capacity check both read this, so they cannot disagree about the size and
 # promise a disc the build then refuses.
 function Get-PayloadBytes {
-    $g = $state.Game
-    if (-not $g -or -not $g.Ok) { return @{ Installer=[double]0; Extra=[double]0; Total=[double]0 } }
+    $games = Get-Games
+    if ($games.Count -eq 0) { return @{ Installer=[double]0; Extra=[double]0; Total=[double]0 } }
+    $installer = [double](($games | Measure-Object TotalBytes -Sum).Sum)
     $side = @()
     $side += @($state.ExtraItems)
     if ($cbMan.Checked   -and $state.ManualPath) { $side += $state.ManualPath }
     if ($cbExtra.Checked -and $state.ExtrasPath) { $side += $state.ExtrasPath }
     if ($chkMusic.Checked -and $state.MusicFile) { $side += $state.MusicFile }
     $extra = [double](Get-ItemsSize $side)
-    return @{ Installer=[double]$g.TotalBytes; Extra=$extra; Total=([double]$g.TotalBytes + $extra) }
+    return @{ Installer=$installer; Extra=$extra; Total=($installer + $extra) }
 }
 
 function Update-MediaLabel {
-    $g = $state.Game
-    if (-not $g -or -not $g.Ok) { return }
+    $games = Get-Games
+    if ($games.Count -eq 0) { return }
+    $g = $games[0]
     $p = Get-PayloadBytes
     $m = Get-MediaRec $p.Total
-    $txt = $g.Msg
+    # One game keeps its own detection line. Several get a summary instead - the
+    # per-game detail would not fit, and the total is what decides the disc.
+    $txt = if ($games.Count -eq 1) { $g.Msg }
+           else { "$($games.Count) games ($(Format-Size $p.Installer))" }
     if ($p.Extra -gt 0) { $txt += " + $(Format-Size $p.Extra) extra" }
     $lblGame.Text = "$txt   ->   Disc: $($m.Text)"
     $lblGame.ForeColor = if($m.Fit){[System.Drawing.Color]::Green}else{[System.Drawing.Color]::DarkOrange}
     # A missing installer part outranks the media advice - it is the thing that
     # makes the disc useless, so it takes the label and the colour.
-    if ($g.Warning) {
-        $lblGame.Text = $g.Warning
-        $lblGame.ForeColor = if($g.MissingParts.Count -gt 0){[System.Drawing.Color]::Firebrick}else{[System.Drawing.Color]::DarkOrange}
+    # With several games the label can only carry one warning, so take the first -
+    # but prefer a missing installer part over a "picked the largest installer"
+    # note, since only the first one makes the disc useless.
+    $warned = @($games | Where-Object { $_.MissingParts.Count -gt 0 })
+    if ($warned.Count -eq 0) { $warned = @($games | Where-Object { $_.Warning }) }
+    if ($warned.Count -gt 0) {
+        $w = $warned[0]
+        $lblGame.Text = if ($games.Count -eq 1) { $w.Warning } else { "$($w.GameName): $($w.Warning)" }
+        $lblGame.ForeColor = if($w.MissingParts.Count -gt 0){[System.Drawing.Color]::Firebrick}else{[System.Drawing.Color]::DarkOrange}
     }
 }
 
@@ -1214,7 +1286,8 @@ function New-PreviewMenu {
     New-Item -ItemType Directory -Force -Path "$prev\AUTORUN" | Out-Null
 
     $title = $txtLabel.Text.Trim()
-    if (-not $title -and $state.Game -and $state.Game.Ok) { $title = $state.Game.GameName }
+    $first = Get-FirstGame
+    if (-not $title -and $first) { $title = $first.GameName }
     if (-not $title) { $title = 'Preview' }
     # A custom title overrides the label; blank falls back to it.
     $bgTitle = $txtTitle.Text.Trim(); if (-not $bgTitle) { $bgTitle = $title }
@@ -1229,8 +1302,8 @@ function New-PreviewMenu {
         Copy-Item $state.MusicFile "$prev\AUTORUN\$musicName" -Force
     }
 
-    $setupName = if ($state.Game -and $state.Game.Ok) { $state.Game.SetupExe.Name } else { 'setup.exe' }
-    $matchName = if ($state.Game -and $state.Game.Ok) { $state.Game.GameName } else { $title }
+    $setupName = if ($first) { $first.SetupExe.Name } else { 'setup.exe' }
+    $matchName = if ($first) { $first.GameName } else { $title }
     # Stage the icon too, so the preview's taskbar icon matches the built disc.
     $prevIco = Get-DiscIconName $title
     if ($state.IconPath -and (Test-Path $state.IconPath) -and $state.IconIsIco) {
@@ -1245,12 +1318,29 @@ function New-PreviewMenu {
     return "$prev\AUTORUN\menu.hta"
 }
 
+function Set-GameFolders([string[]]$paths) {
+    $given = @(@($paths) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    $found = @()
+    foreach ($p in $given) { $found += ,(Get-GameInfo $p) }
+    $state.Games = @($found)
+    # Get-GameInfo only fills Folder when it found an installer, so fall back to
+    # what was actually picked - blanking the box on a bad path hides the mistake.
+    $txtFolder.Text = $(if ($given.Count) { if ($found[0].Folder) { $found[0].Folder } else { $given[0] } } else { '' })
+    $bad = @($found | Where-Object { -not $_.Ok })
+    if ($found.Count -and $bad.Count -eq 0) { Update-MediaLabel }
+    elseif ($bad.Count) {
+        $lblGame.Text = $bad[0].Msg
+        $lblGame.ForeColor = [System.Drawing.Color]::Firebrick
+    }
+    return $found
+}
+
+# Callers that still deal in one folder - the Browse button, reopening a v1
+# project - go through here and get the single result back, as before.
 function Set-GameFolder([string]$path) {
-    $txtFolder.Text=$path
-    $g=Get-GameInfo $path; $state.Game=$g
-    if ($g.Ok) { Update-MediaLabel }
-    else { $lblGame.Text=$g.Msg; $lblGame.ForeColor=[System.Drawing.Color]::Firebrick }
-    return $g
+    $found = Set-GameFolders @($path)
+    if ($found.Count) { return $found[0] }
+    return (Get-GameInfo $path)
 }
 
 function Add-ExtraItem([string]$path) {
@@ -1319,13 +1409,19 @@ function Open-Project([string]$folder) {
 
     & $log "Loaded from $($p.Origin)."
 
-    $src = $p.SourceFolder
-    if (-not $src -or -not (Test-Path $src)) {
+    # Import-Project has already folded v1's single SourceFolder and v2's Games
+    # array into one list, so only the list is read from here on.
+    $srcs = @(@($p.GameFolders) | Where-Object { $_ })
+    if ($srcs.Count -eq 0 -and $p.SourceFolder) { $srcs = @($p.SourceFolder) }
+    $gone = @($srcs | Where-Object { -not (Test-Path $_) })
+    if ($srcs.Count -eq 0 -or $gone.Count -eq $srcs.Count) {
         & $log "  original GOG folder is gone - using the disc folder itself (rebuild in place)."
-        $src = $disc
+        $srcs = @($disc)
+    } elseif ($gone.Count -gt 0) {
+        & $log "  $($gone.Count) of $($srcs.Count) game folders are gone - leaving those out."
+        $srcs = @($srcs | Where-Object { Test-Path $_ })
     }
-    $g = Set-GameFolder $src
-    if (-not $g.Ok) { & $log "  WARNING: $($g.Msg)" }
+    foreach ($g in (Set-GameFolders $srcs)) { if (-not $g.Ok) { & $log "  WARNING: $($g.Msg)" } }
 
     $txtLabel.Text = $p.Label
     if ($p.IconPath -and (Test-Path $p.IconPath)) { Set-IconFile $p.IconPath } else { & $log "  icon missing - pick one again." }
@@ -1458,7 +1554,7 @@ $chkMenu.Add_CheckedChanged({
 
 $btnBuild.Add_Click({
     $txtLog.Clear()
-    if (-not $state.Game -or -not $state.Game.Ok) { Deny-Build 'no valid GOG game folder.' 'Pick a valid GOG game folder first (step 1).'; return }
+    if ((Get-Games).Count -eq 0) { Deny-Build 'no valid GOG game folder.' 'Pick a valid GOG game folder first (step 1).'; return }
     if ([string]::IsNullOrWhiteSpace($txtLabel.Text)) { Deny-Build 'no disc label.' 'Enter a disc label (step 2). It is the name This PC shows for the disc.'; return }
     if (-not $state.IconPath) { Deny-Build 'no disc icon.' 'Choose a disc icon (step 3).'; return }
     if ([string]::IsNullOrWhiteSpace($txtOut.Text)) { Deny-Build 'no output folder.' 'Choose an output folder (step 6). The disc folder and the ISO are written there.'; return }
@@ -1485,8 +1581,14 @@ $btnBuild.Add_Click({
     # An unfinished download burns a disc that fails only at install time. Confirm
     # rather than block outright: the part numbering is a convention, not a promise,
     # so a false positive must not be able to stop a legitimate build.
-    if ($state.Game.MissingParts.Count -gt 0) {
-        $miss = ($state.Game.MissingParts | ForEach-Object { "$($state.Game.SetupExe.BaseName)-$_.bin" }) -join "`r`n"
+    $incomplete = @(Get-Games | Where-Object { $_.MissingParts.Count -gt 0 })
+    if ($incomplete.Count -gt 0) {
+        # $gm is captured before the inner loop: the nested ForEach-Object rebinds
+        # $_ to the part number, so the outer game would be unreachable otherwise.
+        $miss = ($incomplete | ForEach-Object {
+                    $gm = $_
+                    $gm.MissingParts | ForEach-Object { "$($gm.SetupExe.BaseName)-$_.bin" }
+                 }) -join "`r`n"
         if (-not (Show-Confirm ("This GOG download looks incomplete. These installer parts are missing:`r`n`r`n$miss" +
                                 "`r`n`r`nA disc built from it will look fine but fail when the installer runs, " +
                                 "and by then the disc is spent.`r`n`r`nRe-download the game from GOG first." +
@@ -1520,8 +1622,10 @@ $btnBuild.Add_Click({
         if ($outRoot) {
             $di       = New-Object System.IO.DriveInfo($outRoot)
             $free     = [double]$di.AvailableFreeSpace
-            $srcRoot  = [IO.Path]::GetPathRoot($state.Game.SetupExe.FullName)
-            $linkable = ($di.DriveFormat -ieq 'NTFS') -and ($srcRoot -ieq $outRoot)
+            # Hardlinking needs every installer on the same volume as the stage.
+            # With games spread across drives, some get copied, so budget for the lot.
+            $srcRoots = @(Get-Games | ForEach-Object { [IO.Path]::GetPathRoot($_.SetupExe.FullName) } | Sort-Object -Unique)
+            $linkable = ($di.DriveFormat -ieq 'NTFS') -and ($srcRoots.Count -eq 1) -and ($srcRoots[0] -ieq $outRoot)
             # Assign the branch, do not inline it: "(if ...)" parses as a command
             # invocation and only blows up at run time, which would hide here.
             $stageCost = if ($linkable) { $pay.Extra } else { $pay.Total }
@@ -1544,7 +1648,10 @@ $btnBuild.Add_Click({
     # A rebuild replaces work that already exists - say exactly what goes.
     if (Test-AlreadyBuilt $outDir) {
         $stage   = Join-Path $outDir 'disc'
-        $inPlace = Test-SamePath $state.Game.Folder $stage
+        # Rebuilding in place only applies to a single game whose folder IS the
+        # stage. Several games always live in Games\ subfolders, never at the root.
+        $bGames  = Get-Games
+        $inPlace = ($bGames.Count -eq 1) -and (Test-SamePath $bGames[0].Folder $stage)
         $msg = "Rebuild the disc in:`r`n$outDir`r`n`r`nThe existing ISO will be replaced."
         if ((Test-Path $stage) -and -not $inPlace) {
             $msg += "`r`n`r`nThe 'disc' folder will be rebuilt from scratch. Anything you added to it by hand that is not listed under Extra content will be lost."
@@ -1557,7 +1664,7 @@ $btnBuild.Add_Click({
 
     New-Item -ItemType Directory -Force -Path $txtOut.Text | Out-Null
     $buttons=@(); if($cbPlay.Checked){$buttons+='Play'}; if($cbInst.Checked){$buttons+='Install'}; if($cbMan.Checked){$buttons+='Manual'}; if($cbExtra.Checked){$buttons+='Extras'}; if($cbExit.Checked){$buttons+='Exit'}
-    $s=@{ Game=$state.Game; Label=$txtLabel.Text.Trim(); IconPath=$state.IconPath; IconIsIco=$state.IconIsIco;
+    $s=@{ Games=(Get-Games); Label=$txtLabel.Text.Trim(); IconPath=$state.IconPath; IconIsIco=$state.IconIsIco;
          Menu=$chkMenu.Checked; BgPath=$state.BgPath; BgAsIs=$chkBgAsIs.Checked; PanelSide=[string]$cmbSide.SelectedItem;
          Divider=$chkDivider.Checked; ShowTitle=$chkTitle.Checked; TitleText=$txtTitle.Text.Trim();
          WindowBorder=$chkWinBorder.Checked; ButtonStyle=[string]$cmbBtnStyle.SelectedItem;

--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -1,0 +1,26 @@
+@{
+    # Two rules are switched off, both because they encode conventions for cmdlets
+    # people type at a prompt - and nothing here is that. DiscWright is a WinForms
+    # app whose functions are internal helpers, called from event handlers and from
+    # each other, never from a command line and never down a pipeline.
+    #
+    # Everything else stays on. The point of switching these two off is that what
+    # is left is worth reading: the repo reports 31 warnings with every rule
+    # enabled and 6 with these two excluded, and a list of 31 is a list nobody
+    # checks. Notably PSAvoidUsingEmptyCatchBlock stays enabled - the empty catches
+    # in the app are deliberate and have been reviewed one at a time, so those 6
+    # are the known set and a careless new one arrives as a seventh rather than
+    # hiding among thirty.
+    ExcludeRules = @(
+
+        # Wants New-*/Set-*/Remove-* functions to declare SupportsShouldProcess so
+        # they honour -WhatIf and -Confirm. That matters for a module someone
+        # scripts against. New-TitleFont builds a font object.
+        'PSUseShouldProcessForStateChangingFunctions'
+
+        # Wants singular nouns: Get-PayloadByte rather than Get-PayloadBytes.
+        # These functions genuinely deal in plurals, and renaming them would make
+        # both the English and the code worse.
+        'PSUseSingularNouns'
+    )
+}

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -1,0 +1,489 @@
+# Pester tests for DiscWright.
+#
+#   Invoke-Pester tests
+#   Invoke-Pester tests -ExcludeTagFilter Build     # skip the slow ISO builds
+#
+# DiscWright.ps1 cannot be dot-sourced: its last statement shows a WinForms
+# window. So the file is parsed and only its function definitions are evaluated.
+# That runs the real functions rather than copies, which is the point - a test
+# that exercises a copy of the code proves nothing about the app.
+
+BeforeDiscovery {
+    # Whether the build tests can run at all is decided during discovery, so the
+    # whole block can be marked skipped rather than failing on a machine (or a CI
+    # runner) that has no IMAPI2FS.
+    $script:CanBuildIso = $false
+    try {
+        $probe = New-Object -ComObject IMAPI2FS.MsftFileSystemImage
+        [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($probe)
+        $script:CanBuildIso = $true
+    } catch { }
+
+    # 7-Zip reads UDF, so a finished ISO can be inspected without mounting it and
+    # without an elevated shell.
+    $script:SevenZip = @(
+        'C:\Program Files\7-Zip\7z.exe'
+        'C:\Program Files (x86)\7-Zip\7z.exe'
+        (Get-Command 7z.exe -ErrorAction SilentlyContinue | ForEach-Object { $_.Source })
+    ) | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
+}
+
+BeforeAll {
+    Add-Type -AssemblyName System.Drawing
+
+    # Discovery and execution are separate phases with separate state, so anything
+    # BeforeDiscovery worked out for a -Skip decision has to be worked out again
+    # here before the tests can actually use it.
+    $script:SevenZip = @(
+        'C:\Program Files\7-Zip\7z.exe'
+        'C:\Program Files (x86)\7-Zip\7z.exe'
+        (Get-Command 7z.exe -ErrorAction SilentlyContinue | ForEach-Object { $_.Source })
+    ) | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
+
+    $appScript = Join-Path (Split-Path $PSScriptRoot -Parent) 'DiscWright.ps1'
+    $parseErrors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($appScript, [ref]$null, [ref]$parseErrors)
+    if ($parseErrors -and $parseErrors.Count) { throw "DiscWright.ps1 has $($parseErrors.Count) parse errors" }
+    foreach ($f in $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $false)) {
+        . ([scriptblock]::Create($f.Extent.Text))
+    }
+
+    # Script-scope constants the functions read. Script scope, not local: the
+    # functions look $PROJECT_FILE up dynamically from whichever It block calls
+    # them, and a local here would not be on that chain.
+    $script:PROJECT_FILE = 'discproject.json'
+
+    $script:Sandbox = Join-Path ([IO.Path]::GetTempPath()) ('dwpester_' + [Guid]::NewGuid().ToString('N').Substring(0,8))
+    New-Item -ItemType Directory -Force -Path $script:Sandbox | Out-Null
+
+    # A GOG folder is an installer plus its numbered .bin parts. Sparse files keep
+    # the fixtures instant and cost no disk.
+    function New-FixtureGame {
+        param([string]$Slug, [double]$ExeMb = 3, [int]$Parts = 0, [int[]]$SkipParts = @())
+        $dir = Join-Path $script:Sandbox ('src\' + $Slug)
+        New-Item -ItemType Directory -Force -Path $dir | Out-Null
+        $stem = "setup_${Slug}_1.0_(90210)"
+        $fs = [IO.File]::Create((Join-Path $dir "$stem.exe")); $fs.SetLength([long]($ExeMb * 1MB)); $fs.Close()
+        for ($i = 1; $i -le $Parts; $i++) {
+            if ($SkipParts -contains $i) { continue }
+            $fs = [IO.File]::Create((Join-Path $dir "$stem-$i.bin")); $fs.SetLength(1MB); $fs.Close()
+        }
+        return $dir
+    }
+
+    function New-FixturePng {
+        param([string]$Path, [int]$W = 1280, [int]$H = 720)
+        $bmp = New-Object System.Drawing.Bitmap($W, $H)
+        $g = [System.Drawing.Graphics]::FromImage($bmp)
+        $g.Clear([System.Drawing.Color]::FromArgb(18, 38, 58)); $g.Dispose()
+        $bmp.Save($Path, [System.Drawing.Imaging.ImageFormat]::Png); $bmp.Dispose()
+        return $Path
+    }
+
+    $script:Bg  = New-FixturePng (Join-Path $script:Sandbox 'bg.png')
+    $script:Art = New-FixturePng (Join-Path $script:Sandbox 'art.png') 512 512
+
+    function New-BuildSettings {
+        param([array]$Games, [string]$Label, [string]$OutDir)
+        return @{
+            Games=$Games; Label=$Label; IconPath=$script:Art; IconIsIco=$false
+            Menu=$true; BgPath=$script:Bg; BgAsIs=$false; PanelSide='Right'
+            Divider=$false; ShowTitle=$false; TitleText=''
+            WindowBorder=$true; ButtonStyle='Minimal'; MusicFile=$null
+            Buttons=@('Play','Install','Exit'); ManualPath=$null; ExtrasPath=$null
+            ExtraItems=@(); OutDir=$OutDir
+        }
+    }
+
+    # 7-Zip reads UDF, so an ISO can be inspected without mounting it and without
+    # an elevated shell. Returns the paths inside the image.
+    function Get-IsoEntries {
+        param([string]$IsoPath, [string]$SevenZip)
+        $raw = & $SevenZip l -slt $IsoPath 2>&1
+        return @($raw | Where-Object { $_ -match '^Path = ' } |
+                 ForEach-Object { $_ -replace '^Path = ','' } |
+                 Where-Object { $_ -ne $IsoPath })
+    }
+
+    function Get-IsoVolumeId {
+        param([string]$IsoPath, [string]$SevenZip)
+        $line = (& $SevenZip l -slt $IsoPath 2>&1 | Where-Object { $_ -match '^\s*VolumeId:' } | Select-Object -First 1)
+        if ($line) { return ($line -replace '^\s*VolumeId:\s*','').Trim() }
+        return $null
+    }
+
+    $script:LogSink = { param($m) }
+}
+
+AfterAll {
+    if ($script:Sandbox -and (Test-Path $script:Sandbox)) {
+        Remove-Item $script:Sandbox -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Describe 'Get-GameFolderName' -Tag 'Unit' {
+
+    It 'numbers from one and pads to two digits' {
+        Get-GameFolderName 1 'Hollow Knight' | Should -Be '01 - Hollow Knight'
+    }
+
+    It 'keeps two-digit numbers intact' {
+        Get-GameFolderName 12 'Doom' | Should -Be '12 - Doom'
+    }
+
+    It 'folds accents rather than deleting the letter' {
+        # The Polish spelling of Wiedzmin must not come back as "Wiedmin".
+        # Built from a code point so this file stays pure ASCII - the same rule
+        # checks.yml enforces on every .ps1 in the repo.
+        $polish = 'Wied' + [char]0x017A + 'min'
+        Get-GameFolderName 2 $polish | Should -Be '02 - Wiedzmin'
+    }
+
+    It 'removes characters Windows will not accept in a folder name' {
+        $n = Get-GameFolderName 3 'A/B\C:D*E?F"G<H>I|J'
+        $n | Should -Not -Match '[\\/:*?"<>|]'
+    }
+
+    It 'collapses runs of whitespace' {
+        Get-GameFolderName 4 "A     B" | Should -Be '04 - A B'
+    }
+
+    It 'never ends in a dot, which Windows silently strips' {
+        Get-GameFolderName 5 'Fallout...' | Should -Not -Match '\.$'
+    }
+
+    It 'caps a very long title' {
+        (Get-GameFolderName 6 ('X' * 300)).Length | Should -BeLessOrEqual 53
+    }
+
+    It 'still produces a folder for an empty title' {
+        Get-GameFolderName 7 '' | Should -Be '07 - Game'
+    }
+
+    It 'still produces a folder for a title with no usable characters' {
+        Get-GameFolderName 8 '???' | Should -Be '08 - Game'
+    }
+
+    It 'gives identically-titled games distinct folders' {
+        $names = 1..3 | ForEach-Object { Get-GameFolderName $_ 'Same Title' }
+        @($names | Sort-Object -Unique).Count | Should -Be 3
+    }
+}
+
+Describe 'Test-ReservedDiscName' -Tag 'Unit' {
+
+    It 'reserves <Name>' -ForEach @(
+        @{ Name = 'autorun.inf' }
+        @{ Name = 'AUTORUN' }
+        @{ Name = 'Extras' }
+        @{ Name = 'Games' }
+        @{ Name = 'discproject.json' }
+        @{ Name = 'disc.ico' }
+    ) {
+        Test-ReservedDiscName $Name 'Witcher.ico' | Should -BeTrue
+    }
+
+    It 'reserves the disc icon itself' {
+        Test-ReservedDiscName 'Witcher.ico' 'Witcher.ico' | Should -BeTrue
+    }
+
+    It 'reserves anything that looks like a GOG installer' {
+        Test-ReservedDiscName 'setup_doom_1.0.exe' 'Witcher.ico' | Should -BeTrue
+    }
+
+    It 'leaves ordinary extra content alone' {
+        Test-ReservedDiscName 'Soundtrack' 'Witcher.ico' | Should -BeFalse
+    }
+}
+
+Describe 'Get-GameInfo' -Tag 'Unit' {
+
+    BeforeAll {
+        $script:GameA = New-FixtureGame -Slug 'hollow_knight' -ExeMb 6 -Parts 2
+        $script:GameB = New-FixtureGame -Slug 'deus_ex'       -ExeMb 4
+        $script:Torn  = New-FixtureGame -Slug 'torn_download' -ExeMb 2 -Parts 4 -SkipParts @(2,3)
+    }
+
+    It 'finds the installer' {
+        (Get-GameInfo $script:GameA).Ok | Should -BeTrue
+    }
+
+    It 'collects the installer and its parts' {
+        (Get-GameInfo $script:GameA).Files.Count | Should -Be 3
+    }
+
+    It 'totals the payload across every file' {
+        (Get-GameInfo $script:GameA).TotalBytes | Should -Be (8MB)
+    }
+
+    It 'reports no missing parts for a complete download' {
+        (Get-GameInfo $script:GameA).MissingParts.Count | Should -Be 0
+    }
+
+    It 'reports no missing parts for a game that has none' {
+        (Get-GameInfo $script:GameB).MissingParts.Count | Should -Be 0
+    }
+
+    It 'spots a gap in the part numbering' {
+        # -1 and -4 present, -2 and -3 absent: an unfinished download, which would
+        # otherwise build a disc that only fails once the installer runs.
+        ((Get-GameInfo $script:Torn).MissingParts -join ',') | Should -Be '2,3'
+    }
+
+    It 'is not Ok for a folder that does not exist' {
+        (Get-GameInfo (Join-Path $script:Sandbox 'no-such-folder')).Ok | Should -BeFalse
+    }
+
+    It 'leaves Folder null when it found nothing' {
+        (Get-GameInfo (Join-Path $script:Sandbox 'no-such-folder')).Folder | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Project file' -Tag 'Unit' {
+
+    BeforeAll {
+        $script:PGames = @(
+            (Get-GameInfo (New-FixtureGame -Slug 'game_one')),
+            (Get-GameInfo (New-FixtureGame -Slug 'game_two')),
+            (Get-GameInfo (New-FixtureGame -Slug 'game_three'))
+        )
+        $script:POut = Join-Path $script:Sandbox 'proj-v2'
+        New-Item -ItemType Directory -Force -Path $script:POut | Out-Null
+        Save-Project (New-BuildSettings -Games $script:PGames -Label 'Trilogy' -OutDir $script:POut) $script:POut
+        $script:PJson = Get-Content -Raw (Join-Path $script:POut 'discproject.json') | ConvertFrom-Json
+    }
+
+    Context 'writing' {
+
+        It 'declares schema version 2' {
+            $script:PJson.Version | Should -Be 2
+        }
+
+        It 'records every game' {
+            @($script:PJson.Games).Count | Should -Be 3
+        }
+
+        It 'still writes v1 SourceFolder so the file opens in 0.1.x' {
+            $script:PJson.SourceFolder | Should -Be $script:PGames[0].Folder
+        }
+
+        It 'still writes v1 GameName so the file opens in 0.1.x' {
+            $script:PJson.GameName | Should -Be $script:PGames[0].GameName
+        }
+    }
+
+    Context 'reading back' {
+
+        It 'returns all three folders' {
+            @((Import-Project (Join-Path $script:POut 'discproject.json')).GameFolders).Count | Should -Be 3
+        }
+
+        It 'preserves their order' {
+            $back = Import-Project (Join-Path $script:POut 'discproject.json')
+            (@($back.GameFolders) -join '|') | Should -Be (($script:PGames | ForEach-Object { $_.Folder }) -join '|')
+        }
+    }
+
+    Context 'a project written by v0.1.0' {
+
+        BeforeAll {
+            # Written by hand exactly as the old Save-Project did, so this is a
+            # real compatibility test rather than a round-trip of our own output.
+            $script:V1Out = Join-Path $script:Sandbox 'proj-v1'
+            New-Item -ItemType Directory -Force -Path $script:V1Out | Out-Null
+            @{ Version=1; SavedUtc='2026-08-16T20:30:55'
+               SourceFolder=$script:PGames[1].Folder; GameName='Game Two'; Label='Game Two'
+               IconPath=$script:Art; IconIsIco=$false; Menu=$true; BgPath=$script:Bg; BgAsIs=$false
+               PanelSide='Left'; Divider=$true; ShowTitle=$true; TitleText='G2'
+               WindowBorder=$false; ButtonStyle='Bordered'; MusicFile=$null
+               Buttons=@('Play','Exit'); ManualPath=$null; ExtrasPath=$null; ExtraItems=@()
+               OutDir=$script:V1Out } | ConvertTo-Json -Depth 4 |
+                Set-Content (Join-Path $script:V1Out 'discproject.json') -Encoding UTF8
+            $script:V1Back = Import-Project (Join-Path $script:V1Out 'discproject.json')
+        }
+
+        It 'still opens' {
+            $script:V1Back | Should -Not -BeNullOrEmpty
+        }
+
+        It 'upconverts its single game into a one-element list' {
+            @($script:V1Back.GameFolders).Count | Should -Be 1
+        }
+
+        It 'points at the folder the old file named' {
+            @($script:V1Back.GameFolders)[0] | Should -Be $script:PGames[1].Folder
+        }
+
+        It 'carries the rest of the settings across' {
+            $script:V1Back.PanelSide   | Should -Be 'Left'
+            $script:V1Back.Divider     | Should -BeTrue
+            $script:V1Back.ButtonStyle | Should -Be 'Bordered'
+        }
+    }
+
+    It 'survives a project file that is not valid JSON' {
+        $junk = Join-Path $script:Sandbox 'junk'
+        New-Item -ItemType Directory -Force -Path $junk | Out-Null
+        Set-Content (Join-Path $junk 'discproject.json') -Value '{ this is not json' -Encoding UTF8
+        Import-Project (Join-Path $junk 'discproject.json') | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Building a disc' -Tag 'Build' -Skip:(-not $script:CanBuildIso) {
+
+    Context 'one game' {
+
+        BeforeAll {
+            $script:One    = Get-GameInfo (New-FixtureGame -Slug 'single_game' -ExeMb 3 -Parts 1)
+            $script:OneOut = Join-Path $script:Sandbox 'build-one'
+            New-Item -ItemType Directory -Force -Path $script:OneOut | Out-Null
+            $script:OneIso   = Invoke-Build (New-BuildSettings -Games @($script:One) -Label 'Single Game' -OutDir $script:OneOut) $script:LogSink
+            $script:OneStage = Join-Path $script:OneOut 'disc'
+        }
+
+        It 'writes an ISO' {
+            Test-Path $script:OneIso | Should -BeTrue
+        }
+
+        It 'leaves the installer at the disc root, as it always has' {
+            Test-Path (Join-Path $script:OneStage $script:One.SetupExe.Name) | Should -BeTrue
+        }
+
+        It 'creates no Games folder for a single game' {
+            Test-Path (Join-Path $script:OneStage 'Games') | Should -BeFalse
+        }
+
+        It 'writes autorun.inf' {
+            Test-Path (Join-Path $script:OneStage 'autorun.inf') | Should -BeTrue
+        }
+
+        It 'writes the menu' {
+            Test-Path (Join-Path $script:OneStage 'AUTORUN\menu.hta') | Should -BeTrue
+        }
+
+        It 'points the menu at a bare installer filename' {
+            $hta = Get-Content -Raw (Join-Path $script:OneStage 'AUTORUN\menu.hta')
+            $hta | Should -Match ('var SETUP="' + [regex]::Escape($script:One.SetupExe.Name) + '"')
+        }
+
+        It 'names the icon after the disc, not disc.ico' {
+            # Explorer caches drive icons by path, so a fixed name would serve the
+            # previous disc's icon for the same drive letter.
+            Test-Path (Join-Path $script:OneStage 'SingleGame.ico') | Should -BeTrue
+        }
+
+        It 'rebuilds immediately without a file lock' {
+            # Regression test: the ISO builder used to hold COM handles on its own
+            # staged files, so a second build failed until a GC happened to run.
+            { Invoke-Build (New-BuildSettings -Games @($script:One) -Label 'Single Game' -OutDir $script:OneOut) $script:LogSink } |
+                Should -Not -Throw
+        }
+    }
+
+    Context 'three games' {
+
+        BeforeAll {
+            $script:Many = @(
+                (Get-GameInfo (New-FixtureGame -Slug 'first_game'  -ExeMb 2 -Parts 1)),
+                (Get-GameInfo (New-FixtureGame -Slug 'second_game' -ExeMb 2)),
+                (Get-GameInfo (New-FixtureGame -Slug 'third_game'  -ExeMb 2 -Parts 2))
+            )
+            $script:ManyOut = Join-Path $script:Sandbox 'build-many'
+            New-Item -ItemType Directory -Force -Path $script:ManyOut | Out-Null
+            $script:ManyIso   = Invoke-Build (New-BuildSettings -Games $script:Many -Label 'Test Trilogy' -OutDir $script:ManyOut) $script:LogSink
+            $script:ManyStage = Join-Path $script:ManyOut 'disc'
+        }
+
+        It 'writes an ISO' {
+            Test-Path $script:ManyIso | Should -BeTrue
+        }
+
+        It 'moves the installers into Games' {
+            Test-Path (Join-Path $script:ManyStage 'Games') | Should -BeTrue
+        }
+
+        It 'leaves no installer at the disc root' {
+            @(Get-ChildItem $script:ManyStage -Filter 'setup_*' -File).Count | Should -Be 0
+        }
+
+        It 'gives each game its own folder' {
+            @(Get-ChildItem (Join-Path $script:ManyStage 'Games') -Directory).Count | Should -Be 3
+        }
+
+        It 'numbers the folders in order' {
+            $names = @(Get-ChildItem (Join-Path $script:ManyStage 'Games') -Directory | Sort-Object Name | ForEach-Object { $_.Name })
+            $names[0] | Should -BeLike '01 - *'
+            $names[1] | Should -BeLike '02 - *'
+            $names[2] | Should -BeLike '03 - *'
+        }
+
+        It 'copies every installer file' {
+            $expected = ($script:Many | ForEach-Object { $_.Files.Count } | Measure-Object -Sum).Sum
+            @(Get-ChildItem (Join-Path $script:ManyStage 'Games') -Recurse -File).Count | Should -Be $expected
+        }
+
+        It 'points the menu into the first game folder' {
+            $hta = Get-Content -Raw (Join-Path $script:ManyStage 'AUTORUN\menu.hta')
+            $hta | Should -Match 'var SETUP="Games\\\\01 - '
+        }
+
+        It 'saves a project naming all three games' {
+            @((Import-Project (Join-Path $script:ManyOut 'discproject.json')).GameFolders).Count | Should -Be 3
+        }
+
+        It 'rebuilds without duplicating the game folders' {
+            $null = Invoke-Build (New-BuildSettings -Games $script:Many -Label 'Test Trilogy' -OutDir $script:ManyOut) $script:LogSink
+            @(Get-ChildItem (Join-Path $script:ManyStage 'Games') -Directory).Count | Should -Be 3
+        }
+    }
+
+    Context 'inside the finished ISO' -Skip:(-not $script:SevenZip) {
+
+        BeforeAll {
+            $script:IsoGames = @(
+                (Get-GameInfo (New-FixtureGame -Slug 'iso_one' -ExeMb 2)),
+                (Get-GameInfo (New-FixtureGame -Slug 'iso_two' -ExeMb 2 -Parts 1))
+            )
+            $script:IsoOut = Join-Path $script:Sandbox 'build-iso'
+            New-Item -ItemType Directory -Force -Path $script:IsoOut | Out-Null
+            $script:IsoPath  = Invoke-Build (New-BuildSettings -Games $script:IsoGames -Label 'Iso Check' -OutDir $script:IsoOut) $script:LogSink
+            $script:IsoFiles = Get-IsoEntries -IsoPath $script:IsoPath -SevenZip $script:SevenZip
+        }
+
+        It 'is a real UDF image, not just a file that exists' {
+            $info = & $script:SevenZip l -slt $script:IsoPath 2>&1
+            ($info | Where-Object { $_ -match '^Type = Udf' }) | Should -Not -BeNullOrEmpty
+        }
+
+        It 'uses UDF 2.50, so long GOG filenames survive' {
+            $info = & $script:SevenZip l -slt $script:IsoPath 2>&1
+            ($info | Where-Object { $_ -match '^Version = 2\.50' }) | Should -Not -BeNullOrEmpty
+        }
+
+        It 'carries the disc label as the volume id' {
+            Get-IsoVolumeId -IsoPath $script:IsoPath -SevenZip $script:SevenZip | Should -Be 'Iso_Check'
+        }
+
+        It 'contains autorun.inf at the root' {
+            $script:IsoFiles | Should -Contain 'autorun.inf'
+        }
+
+        It 'contains the menu' {
+            $script:IsoFiles | Should -Contain 'AUTORUN\menu.hta'
+        }
+
+        It 'contains the composed background' {
+            $script:IsoFiles | Should -Contain 'AUTORUN\bg.png'
+        }
+
+        It 'contains both game folders' {
+            @($script:IsoFiles | Where-Object { $_ -match '^Games\\\d\d - ' -and $_ -notmatch '\.' }).Count |
+                Should -BeGreaterOrEqual 2
+        }
+
+        It 'contains every installer file' {
+            $expected = ($script:IsoGames | ForEach-Object { $_.Files.Count } | Measure-Object -Sum).Sum
+            @($script:IsoFiles | Where-Object { $_ -match '^Games\\.*(setup_.*\.exe|\.bin)$' }).Count | Should -Be $expected
+        }
+    }
+}

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -112,7 +112,10 @@ BeforeAll {
         return $null
     }
 
-    $script:LogSink = { param($m) }
+    # Invoke-Build reports progress through a callback. The tests do not care what
+    # it says, only that the build runs - discarding the message is the point, and
+    # consuming it keeps the analyzer from reading $m as an oversight.
+    $script:LogSink = { param($m) $null = $m }
 }
 
 AfterAll {

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -278,6 +278,66 @@ Describe 'Reading the game list out of UI state' -Tag 'Unit' {
     }
 }
 
+Describe 'Recovering from a bad folder choice' -Tag 'Unit' {
+
+    # Reported from the window: after picking a folder with no installer in it,
+    # going back to a good one left the message red and the build refusing, with
+    # the right path still in the box. A selection that fails must not be able to
+    # poison the next one.
+
+    BeforeAll {
+        $script:GoodFolder = New-FixtureGame -Slug 'recover_game' -ExeMb 9
+        $script:EmptyFolder = Join-Path $script:Sandbox 'no-installer-here'
+        New-Item -ItemType Directory -Force -Path $script:EmptyFolder | Out-Null
+
+        # Stand-ins for the controls Set-GameFolders and Update-MediaLabel write to.
+        $script:txtFolder = [pscustomobject]@{ Text = '' }
+        $script:lblGame   = [pscustomobject]@{ Text = ''; ForeColor = $null }
+        $script:cbMan     = [pscustomobject]@{ Checked = $false }
+        $script:cbExtra   = [pscustomobject]@{ Checked = $false }
+        $script:chkMusic  = [pscustomobject]@{ Checked = $false }
+        $script:state     = @{ Games=@(); ExtraItems=@(); ManualPath=$null; ExtrasPath=$null; MusicFile=$null }
+    }
+
+    It 'accepts a good folder' {
+        $g = Set-GameFolder $script:GoodFolder
+        $g.Ok | Should -BeTrue
+        (Get-Games).Count | Should -Be 1
+    }
+
+    It 'rejects a folder with no installer' {
+        $g = Set-GameFolder $script:EmptyFolder
+        $g.Ok | Should -BeFalse
+        (Get-Games).Count | Should -Be 0
+    }
+
+    It 'keeps the rejected path visible rather than blanking the box' {
+        $script:txtFolder.Text | Should -Be $script:EmptyFolder
+    }
+
+    It 'recovers when a good folder is picked again' {
+        $g = Set-GameFolder $script:GoodFolder
+        $g.Ok             | Should -BeTrue
+        (Get-Games).Count | Should -Be 1
+        Get-FirstGame     | Should -Not -BeNullOrEmpty
+    }
+
+    It 'clears the red message on recovery' {
+        $script:lblGame.ForeColor | Should -Not -Be ([System.Drawing.Color]::Firebrick)
+        $script:lblGame.Text      | Should -Match 'Detected:'
+    }
+
+    It 'lets the build run again' {
+        # The build handler refuses on (Get-Games).Count -eq 0.
+        (Get-Games).Count | Should -BeGreaterThan 0
+    }
+
+    It 'returns one game from Set-GameFolder, not a list' {
+        $g = Set-GameFolder $script:GoodFolder
+        $g -is [System.Collections.Hashtable] | Should -BeTrue
+    }
+}
+
 Describe 'Format-Elapsed' -Tag 'Unit' {
 
     # Casting a double to [int] ROUNDS in PowerShell rather than truncating, so

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -449,6 +449,25 @@ Describe 'Get-GameInfo' -Tag 'Unit' {
         ((Get-GameInfo $script:Torn).MissingParts -join ',') | Should -Be '2,3'
     }
 
+    It 'recognises a built disc folder and says so' {
+        # The output folder sits next to the GOG download and is named alike, so it
+        # gets picked by mistake - and the generic "no installer here" sends people
+        # looking for a problem with their download rather than at which folder they
+        # chose. It has the installer one level down in disc\.
+        $built = Join-Path $script:Sandbox 'Some Game Disc'
+        New-Item -ItemType Directory -Force -Path (Join-Path $built 'disc') | Out-Null
+        $fs = [IO.File]::Create((Join-Path $built 'disc\setup_some_game_1.0_(1).exe')); $fs.SetLength(1MB); $fs.Close()
+        $info = Get-GameInfo $built
+        $info.Ok  | Should -BeFalse
+        $info.Msg | Should -Match 'disc DiscWright built'
+    }
+
+    It 'still gives the plain message for a folder with nothing in it' {
+        $bare = Join-Path $script:Sandbox 'just-an-empty-folder'
+        New-Item -ItemType Directory -Force -Path $bare | Out-Null
+        (Get-GameInfo $bare).Msg | Should -Match 'No GOG'
+    }
+
     It 'is not Ok for a folder that does not exist' {
         (Get-GameInfo (Join-Path $script:Sandbox 'no-such-folder')).Ok | Should -BeFalse
     }

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -205,6 +205,79 @@ Describe 'Test-ReservedDiscName' -Tag 'Unit' {
     }
 }
 
+Describe 'Reading the game list out of UI state' -Tag 'Unit' {
+
+    # These three read $state, which only the running window populates - which is
+    # exactly why nothing here touched them, and exactly how the media line came to
+    # announce "9 games (0 bytes)" for one game. Two separate faults produced that:
+    #
+    #   PowerShell unrolls a single-element array on return, so Get-Games handed back
+    #   the bare hashtable. .Count on a Hashtable is its number of KEYS - Get-GameInfo
+    #   has nine - and Get-FirstGame's $g[0] indexed it by the key 0 and found nothing.
+    #
+    #   Measure-Object -Property looks for a real property, and a hashtable key is not
+    #   one, so the installer total was always zero.
+    #
+    # Counts of 1 are the interesting case: 0, 2 and 3 all behaved correctly while 1
+    # was broken.
+
+    BeforeAll {
+        $script:StateGames = @(
+            (Get-GameInfo (New-FixtureGame -Slug 'state_one'   -ExeMb 5)),
+            (Get-GameInfo (New-FixtureGame -Slug 'state_two'   -ExeMb 5)),
+            (Get-GameInfo (New-FixtureGame -Slug 'state_three' -ExeMb 5))
+        )
+        # Get-PayloadBytes reads these three controls to decide what extras to count.
+        $script:cbMan    = [pscustomobject]@{ Checked = $false }
+        $script:cbExtra  = [pscustomobject]@{ Checked = $false }
+        $script:chkMusic = [pscustomobject]@{ Checked = $false }
+
+        function Set-TestState([int]$n) {
+            $script:state = @{
+                Games      = @($script:StateGames | Select-Object -First $n)
+                ExtraItems = @(); ManualPath = $null; ExtrasPath = $null; MusicFile = $null
+            }
+        }
+    }
+
+    It 'Get-Games counts <N> game(s) correctly' -ForEach @(
+        @{ N = 0 }, @{ N = 1 }, @{ N = 2 }, @{ N = 3 }
+    ) {
+        Set-TestState $N
+        # (Get-Games).Count, not @(Get-Games).Count - the second wraps an array that
+        # is already an array and always reports 1. The first version of this test
+        # made exactly that mistake, three lines below a comment warning against it.
+        (Get-Games).Count | Should -Be $N
+    }
+
+    It 'Get-Games returns a list, never a bare hashtable' {
+        Set-TestState 1
+        (Get-Games) -is [System.Collections.Hashtable] | Should -BeFalse
+    }
+
+    It 'Get-FirstGame returns one game, not all of them' -ForEach @(
+        @{ N = 1 }, @{ N = 2 }, @{ N = 3 }
+    ) {
+        Set-TestState $N
+        $first = Get-FirstGame
+        $first        | Should -Not -BeNullOrEmpty
+        $first.GameName | Should -Not -BeOfType [array]
+        $first.GameName | Should -Be $script:StateGames[0].GameName
+    }
+
+    It 'Get-FirstGame is null when there are no games' {
+        Set-TestState 0
+        Get-FirstGame | Should -BeNullOrEmpty
+    }
+
+    It 'Get-PayloadBytes totals <N> game(s) as <Mb> MB' -ForEach @(
+        @{ N = 0; Mb = 0 }, @{ N = 1; Mb = 5 }, @{ N = 2; Mb = 10 }, @{ N = 3; Mb = 15 }
+    ) {
+        Set-TestState $N
+        [int]((Get-PayloadBytes).Installer / 1MB) | Should -Be $Mb
+    }
+}
+
 Describe 'Format-Elapsed' -Tag 'Unit' {
 
     # Casting a double to [int] ROUNDS in PowerShell rather than truncating, so


### PR DESCRIPTION
Groundwork for putting several games on one disc, the test suite that should have landed days ago, and three bugs found while testing it.

## The refactor (no user-visible change)

`$state.Game` becomes `$state.Games`, a list, read through `Get-Games` / `Get-FirstGame`. The UI still accepts exactly one game, so every disc built today is identical to what 0.2.0 builds. This is deliberately separate from the menu chooser, so the risky plumbing lands without also carrying a UI rewrite.

- project schema goes to `Version = 2` with a `Games` array, while still writing v1's `SourceFolder`/`GameName` so a file saved here opens in 0.1.x
- `Import-Project` reads either version and always returns one shape
- one game keeps the installer at the disc root exactly as now; several move to `Games\01 - Name\`, and `Games` becomes a reserved disc name
- sizing, free-space and the torn-download check work across all games; hardlinking is decided per game, since they can be on different volumes

## The test suite

**109 tests, five seconds.** Every PR since #3 has run CI with no tests at all, because the only suite was stranded on this branch.

It parses `DiscWright.ps1` and evaluates only its function definitions — the script's last statement shows a window, so it cannot be dot-sourced. That runs the real functions rather than copies.

Covers the build pipeline, a genuine v0.1.0 project file still opening, ISO integrity through 7-Zip rather than a directory listing, the progress callback, `Format-Elapsed`'s rounding boundaries, and a guard on the Smart App Control shape that cannot be reproduced on a runner.

`PSScriptAnalyzerSettings.psd1` cuts CI's warning annotations from 31 to 6, keeping only findings worth reading.

## Three bugs, all found by hand

**One game reported as nine, with a payload of zero.** Two independent faults. PowerShell unrolls a single-element array on return, so `Get-Games` handed back the bare hashtable — and `.Count` on a Hashtable is its number of keys, which is nine. `Get-FirstGame` then indexed it by the key `0`, found nothing, and returned null, so the preview menu lost the game entirely. Separately, `Measure-Object -Property` cannot see hashtable keys, so the installer total was always zero. Only a count of one was broken; zero, two and three all behaved.

**`Set-GameFolder` re-wrapped a list that was already a list**, so `$found[0]` would have been every game rather than the first. Latent — it happens to behave for the single path the UI passes.

**The folder pickers wandered.** `FolderBrowserDialog` remembers the last folder used anywhere in the process, so after a build the game-folder Browse reopened on the disc it had just written. Each Browse now starts where its own box points. And picking that output folder gave the generic "no `setup_*.exe` here", which sends you looking for a problem with your download — it now says it is a disc DiscWright built and which folder step 1 wants.

## Tested by hand

Open an existing v0.1.0 project, browse to a valid folder, browse to one with no installer and back, preview the menu, build, rebuild, mount. Those are the paths no automated test can reach, and they are where all three bugs turned up.
