### PR TITLE
chore(release): 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ between minor versions.
 
 ## [Unreleased]
 
+## [0.3.0] — 2026-08-20
+
 ### Added
 
 - **A disc can hold more than one game, and the menu asks which.** Step 1 is a list
@@ -138,7 +140,8 @@ First public release.
 - `extras/DiscLabel.ps1`, a parked printable disc-face generator, kept out of the app to
   keep the tool to one job.
 
-[Unreleased]: https://github.com/lazardjokovic/discwright/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/lazardjokovic/discwright/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/lazardjokovic/discwright/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/lazardjokovic/discwright/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/lazardjokovic/discwright/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/lazardjokovic/discwright/releases/tag/v0.1.0

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -61,7 +61,7 @@ $PROJECT_FILE = 'discproject.json'
 # this cannot quietly drift a release behind. Shown in the title bar and the log,
 # and written into every project file - a bug report that comes with a project
 # file then says for itself which version built the disc.
-$APP_VERSION  = '0.2.0'
+$APP_VERSION  = '0.3.0'
 
 # =================== SMALL HELPERS ===================
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,30 +15,24 @@ feature only creates pressure to cram things in to justify it.
 
 ## Next
 
-**More than one installer on a disc.** This arrived as two separate requests that turn out
-to be one feature. Several games on a single disc — a 25 GB BD-R holds a lot of older
-games, and somebody asked for the Resident Evil trilogy on one. And DLC, expansions or a
-mod that ships as its own installer, which today has to go in Extras where it is just a
-file in a folder, and which deserves a button next to Install instead.
+**Multi-disc splitting.** The largest thing still outstanding, and the one most likely to
+be asked for next: anything bigger than a single disc is a known limitation today. It was
+requested twice, independently, within hours of the first release. Needs a splitting
+strategy, a volume label convention, and a menu that can ask for disc 2 — which is,
+admittedly, most of what made the original experience feel like the original experience.
 
-Both are the same thing underneath: this disc holds more than one installer, and each gets
-its own entry in the menu. The only difference is whether the entry is labelled a game or
-an add-on.
+## Delivered
 
-Half of it is already built. A disc can stage any number of installers into numbered
-`NN - Name` folders, and the project file records them. What is missing is the interface
-for adding them and a menu that presents the choice — plus a rethink of how Play decides a
-game is already installed when there is more than one candidate.
+**More than one installer on a disc** — shipped in 0.3.0, and it was the most-asked-for
+thing on this page. Several games on one disc with a chooser in the menu; DLC, expansions,
+patches and mods as their own Install button on the game they belong to; and each game's
+manual and extras filed with that game rather than with the disc.
 
-Three people asked for some form of this, more than for anything else on this page.
+The one thing it does not cover is a mod or an installer from somewhere other than GOG
+being the *game* on a disc. Add-ons accept any `.exe`, but detecting a game still means
+finding a `setup_*.exe` — see *Installers that are not from GOG* under Considering.
 
 ## Later
-
-**Multi-disc splitting.** Listed today as a known limitation: anything larger than a
-single disc is out of scope. It was requested twice, independently, within hours of the
-first release, so it moves onto the list. Needs a splitting strategy, a volume label
-convention, and a menu that can ask for disc 2 — which is, admittedly, most of what made
-the original experience feel like the original experience.
 
 **Artwork without the detour through an image editor.** Two requests that meet in the
 middle. One: fetch the game's icon and cover art automatically rather than making you hunt


### PR DESCRIPTION
Cuts 0.3.0. Three files, no code changes beyond the version constant.

## Why a minor

It adds features and removes nothing, so a minor rather than a patch. Below 1.0.0 that is also what the changelog warns a minor may carry: the project file schema moved from 3 to 4. Files written by 0.1.x, 0.2.0 and every schema before this still open, and read back as plain games with nothing of their own — which is what those discs were.

## What is in it

- **Several games on one disc**, with a chooser in the menu and Back from a game's own screen. A one-game disc shows neither, exactly as before.
- **Add-ons** — DLC, expansions, GOG patches, mods — as their own Install button on the game they belong to, never in the chooser. Picked as a *file*, and **any `.exe`**: the `setup_*.exe` rule exists to recognise a GOG game folder, and applying it to add-ons excluded the two things people actually own.
- **A game's manual and extras belong to that game**, not to the whole disc. Before this one manual served every game, so on a two-game disc one of them opened the other's.
- The window fits a 1080p screen without scrolling.

## The version constant

`$APP_VERSION` goes to `0.3.0`. This is not cosmetic — `version-matches-tag` reads it back out of the source when a tag is pushed and fails the tag if the app would report a version it is not.

## The roadmap needed the same pass

"More than one installer on a disc" was still sitting under **Next**, describing itself as half built. That is what anyone following the link from the launch thread would have read, and it shipped weeks of work ago in this branch.

It moves to **Delivered**, with the one thing it still does not cover stated plainly: a mod or a non-GOG installer being the *game* on a disc. Add-ons take any `.exe`, but detecting a game still means finding a `setup_*.exe`.

**Multi-disc splitting** takes its place as the largest thing outstanding — asked for twice, independently, within hours of the first release.

## Checks

CI verifies this on Pester 5.9.0, which is what the runner installs: the last run on the feature branch was 193 passed, 0 failed, 7 skipped in 24 seconds.

Not run locally: Pester 6.1.0 on my machine hangs during a test file's `BeforeAll` and has to be killed — reproducible with a five-line test file that only parses `DiscWright.ps1`. That is a local tooling problem, not a fault in the app, and it is worth pinning the runner to 5.x afterwards so local matches CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
