### PR TITLE
Fix the local test run, and the three faults it was hiding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ between minor versions.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The disc icon preview was drawn on top of its own Browse button.** Step 3's
+  44px preview square and the 24px Browse button were placed in the same column on
+  the same row, so whichever Windows painted last covered the other. The preview now
+  sits on the row below the button.
+
 ## [0.3.0] — 2026-08-20
 
 ### Added

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -1593,7 +1593,11 @@ AddLabel '3)  Disc icon (.ico, or .png/.jpg to auto-convert):' 15 268 520 | Out-
 $txtIcon=AddText 15 290 520
 $btnIcon=AddBtn 'Browse...' 545 290 110
 $lblIcon=AddLabel '' 15 318 500; $lblIcon.ForeColor=[System.Drawing.Color]::DimGray
-$picIcon=New-Object System.Windows.Forms.PictureBox; $picIcon.Location=New-Object System.Drawing.Point(560,290); $picIcon.Size=New-Object System.Drawing.Size(44,44); $picIcon.SizeMode='Zoom'; $picIcon.BorderStyle='FixedSingle'; $form.Controls.Add($picIcon)
+# Below the Browse button, not beside it: at y=290 this 44px-tall preview sat on
+# top of a 24px-tall button in the same 110px column, and whichever Windows drew
+# last won. Nothing lines up on this row at x=560, and 318+44 clears the step 4
+# group box at y=372.
+$picIcon=New-Object System.Windows.Forms.PictureBox; $picIcon.Location=New-Object System.Drawing.Point(560,318); $picIcon.Size=New-Object System.Drawing.Size(44,44); $picIcon.SizeMode='Zoom'; $picIcon.BorderStyle='FixedSingle'; $form.Controls.Add($picIcon)
 
 $grp=New-Object System.Windows.Forms.GroupBox; $grp.Text='4)  Autorun menu'; $grp.Location=New-Object System.Drawing.Point(15,372); $grp.Size=New-Object System.Drawing.Size(645,286); $form.Controls.Add($grp)
 $chkMenu=New-Object System.Windows.Forms.CheckBox; $chkMenu.Text='Run splash menu when disc is inserted'; $chkMenu.Location=New-Object System.Drawing.Point(15,24); $chkMenu.Size=New-Object System.Drawing.Size(400,22); $chkMenu.Checked=$true; $grp.Controls.Add($chkMenu)

--- a/tests/Invoke-Tests.ps1
+++ b/tests/Invoke-Tests.ps1
@@ -44,10 +44,33 @@ param(
 $ErrorActionPreference = 'Stop'
 $root = Split-Path $PSScriptRoot -Parent
 
-if (-not (Get-Module -ListAvailable Pester | Where-Object { $_.Version.Major -ge 5 })) {
-    throw 'Pester 5 or later is needed. Install-Module Pester -Force -SkipPublisherCheck -Scope CurrentUser'
+# Pester 5, deliberately, and not merely "5 or later".
+#
+# Under Pester 6.1.0 every file in this suite hangs in BeforeAll and launches a
+# DiscWright window while doing it - including a file that only calls
+# Parser::ParseFile on DiscWright.ps1 and dot-sources nothing at all. The same
+# code runs in well under a second in a plain script. Measured on this suite:
+# 6.1.0 never finishes, 5.9.1 finishes in 18 seconds with everything passing.
+#
+# Picking the highest 5.x rather than one exact build, so this does not need
+# editing for every patch release. If only 6.x is installed, say what to do
+# rather than importing it and hanging.
+$pester5 = Get-Module -ListAvailable Pester |
+    Where-Object { $_.Version.Major -eq 5 } |
+    Sort-Object Version -Descending |
+    Select-Object -First 1
+
+if (-not $pester5) {
+    throw @'
+Pester 5.x is needed and was not found.
+
+    Install-Module Pester -RequiredVersion 5.9.1 -Force -SkipPublisherCheck -Scope CurrentUser
+
+Pester 6 can stay installed alongside it; this runner asks for 5.x by version.
+'@
 }
-Import-Module Pester -MinimumVersion 5.0 -Force
+Import-Module Pester -RequiredVersion $pester5.Version -Force
+Write-Host "Pester $((Get-Module Pester).Version)" -ForegroundColor DarkGray
 
 $unit = $null
 $ui   = $null

--- a/tests/ui/DiscWright.UI.Tests.ps1
+++ b/tests/ui/DiscWright.UI.Tests.ps1
@@ -135,6 +135,12 @@ Describe 'The window as it opens' -Tag 'UI' -Skip:(-not $script:HaveDesktop) {
         for ($i = 0; $i -lt $kids.Count; $i++) {
             try {
                 $c = $kids.Item($i); $r = $c.Current.BoundingRectangle
+                # A tooltip is a floating window that appears over whatever the
+                # pointer is resting on, and covering things is its entire job.
+                # It shows up as a child in the automation tree all the same, so
+                # if the mouse happens to be over BUILD ISO when this runs it
+                # reports a collision with the log box that is not a fault.
+                if ($c.Current.ClassName -match 'tooltips_class') { continue }
                 if ($r.Width -gt 0 -and $r.Height -gt 0) {
                     $boxes += [pscustomobject]@{ Name = $c.Current.Name; R = $r }
                 }

--- a/tests/ui/UiDriver.psm1
+++ b/tests/ui/UiDriver.psm1
@@ -297,10 +297,23 @@ function Get-BoxAfter {
         behind a modal dialog: from the outside, an app that starts and then does
         nothing at all.
 
-        A step's box is the unnamed control on the row directly below the label,
-        starting at the same left edge. Buttons carry names, so the empty name is
-        what separates the box from the Browse beside it, and the geometry is
-        what separates this step's box from the next step's.
+        A step's input is the control on the row directly below the label,
+        starting at the same left edge - a text box for most steps, the installer
+        ListView for step 1.
+
+        Which control that is gets decided by ClassName, which the WinForms
+        accessibility bridge fills in accurately even though it exposes every
+        control as a pattern-less Pane: boxes are WindowsForms10.EDIT, the list
+        is .SysListView32, buttons are .BUTTON, labels are .STATIC and the icon
+        preview is .Window.8.
+
+        That distinction used to be made by looking for an EMPTY name, on the
+        reasoning that buttons are named and boxes are not - which is true only
+        while the box is empty. A WinForms text box reports its CONTENTS as its
+        accessible name, so the moment a project was loaded and the boxes had
+        text in them, every one of them was skipped as though it were a button
+        and this returned nothing. That looked like the app failing to open a
+        disc; it was the harness failing to find the box.
     #>
     param($Win, [string]$LabelLike)
     $kids = $Win.FindAll($script:UiScope::Children, $script:UiAny)
@@ -315,7 +328,8 @@ function Get-BoxAfter {
     for ($i = 0; $i -lt $kids.Count; $i++) {
         try {
             $c = $kids.Item($i)
-            if (-not [string]::IsNullOrEmpty($c.Current.Name)) { continue }   # buttons are named
+            # Something you can type in or pick from, not a button, label or picture.
+            if ($c.Current.ClassName -notmatch '\.(EDIT|SysListView32|COMBOBOX)\.') { continue }
             $r = $c.Current.BoundingRectangle
             if ($r.Width -lt 60 -or $r.Height -lt 10) { continue }
             if ([Math]::Abs($r.Left - $lr.Left) -gt 8) { continue }           # same left edge


### PR DESCRIPTION
`.\tests\Invoke-Tests.ps1` opened a DiscWright window and then did nothing, for minutes, every time. It was Pester.

The runner asked for **"Pester 5 or later"** and this machine had **6.1.0**. Under 6.1.0 every file in the suite hangs in `BeforeAll` and launches a DiscWright window while doing it — including a file that only calls `Parser::ParseFile` on `DiscWright.ps1` and dot-sources nothing at all. The same code runs in under a second in a plain script. CI never saw it because a fresh runner installs 5.x.

Measured on this suite, same machine, same files:

| Pester | Result |
|---|---|
| 6.1.0 | never finishes, opens a window |
| 5.9.1 | **18s, 218 passed, 0 failed** |

The runner now takes the highest installed **5.x** by version, and if there is none it says what to install. Pester 6 can stay installed alongside.

## What the suite found once it could run

Three faults had been sitting behind the hang.

**The disc icon preview was drawn on top of its own Browse button.** Step 3 placed a 44px preview square and a 24px button in the same column on the same row, so whichever Windows painted last covered the other. This is a real, visible bug in 0.3.0. The overlap test had been trying to report it since it was written — it just stopped being reachable.

**`Get-BoxAfter` broke as soon as a project was loaded.** It identified a step's box as the *unnamed* control below the label, on the reasoning that buttons are named and boxes are not. That holds only while the box is empty: a WinForms text box reports its **contents** as its accessible name. So every box was skipped as though it were a button, and three tests failed with "given nothing to click". It now selects on `ClassName`, which the accessibility bridge fills in accurately — `EDIT`, the `SysListView32` for step 1, or a `COMBOBOX`; never a `BUTTON`, `STATIC` or picture box.

**The overlap check counted the tooltip.** A tooltip floats over whatever the pointer is resting on — that is its job — but it still appears as a child in the automation tree. With the mouse left over BUILD ISO it reported a 72x20 collision with the log box that was not a fault. Excluded by class.

## Verification

Two consecutive full runs, both **218 logic + 32 window, 0 failed**. The window half takes about 115 seconds and drives the real app on a real desktop.

The first two of those three were only findable by running the window suite; the logic tests pass either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
