### PR TITLE
chore(release): 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,22 @@ between minor versions.
 
 ## [Unreleased]
 
+## [0.3.1] — 2026-08-21
+
 ### Fixed
 
 - **The disc icon preview was drawn on top of its own Browse button.** Step 3's
   44px preview square and the 24px Browse button were placed in the same column on
   the same row, so whichever Windows painted last covered the other. The preview now
   sits on the row below the button.
+
+  The window test suite checks that no two controls overlap and would have caught
+  this immediately. It could not run: `tests\Invoke-Tests.ps1` asked for "Pester 5 or
+  later" and got Pester 6.1.0, under which every file in the suite hangs before
+  running anything — while opening a DiscWright window, so it looked like the
+  application freezing on startup rather than the tests failing to start. The runner
+  now asks for Pester 5.x specifically, and the suite reported the overlap on the
+  first run afterwards.
 
 ## [0.3.0] — 2026-08-20
 
@@ -147,7 +157,8 @@ First public release.
 - `extras/DiscLabel.ps1`, a parked printable disc-face generator, kept out of the app to
   keep the tool to one job.
 
-[Unreleased]: https://github.com/lazardjokovic/discwright/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/lazardjokovic/discwright/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/lazardjokovic/discwright/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/lazardjokovic/discwright/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/lazardjokovic/discwright/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/lazardjokovic/discwright/compare/v0.1.0...v0.1.1

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -61,7 +61,7 @@ $PROJECT_FILE = 'discproject.json'
 # this cannot quietly drift a release behind. Shown in the title bar and the log,
 # and written into every project file - a bug report that comes with a project
 # file then says for itself which version built the disc.
-$APP_VERSION  = '0.3.0'
+$APP_VERSION  = '0.3.1'
 
 # =================== SMALL HELPERS ===================
 


### PR DESCRIPTION
Bumps `$APP_VERSION` to `0.3.1` and closes out the changelog's `[Unreleased]` block. No behaviour change beyond what merged in #12.

## What 0.3.1 is

One visible fix: **the disc icon preview was drawn on top of its own Browse button.** Step 3 placed a 44px preview square and a 24px button in the same column on the same row, so whichever Windows painted last covered the other. Discs built by 0.3.0 are unaffected and project files are unchanged — for anyone whom 0.3.0 is working for, this is a redraw and nothing more.

The changelog entry also records *why a released version shipped with a visible layout bug*, since that is the more useful half: the window suite checks that no two controls overlap and would have caught it immediately, but the runner asked for "Pester 5 or later" and got Pester 6.1.0, under which every file hangs before running anything — while opening a DiscWright window, so it read as the app freezing rather than the tests failing to start.

## Verification

- Full suite on this branch, with the bump in place: **218 logic + 32 window, 0 failed**
- `$APP_VERSION` read through the exact regex the `version-matches-tag` job uses: **`0.3.1`**

Once this merges I'll tag `v0.3.1`, confirm `version-matches-tag` goes green on the tag, and publish the release as `DiscWright 0.3.1 - the icon preview stops covering Browse`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
