### PR TITLE
feat: add New disc, to start over without restarting the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ between minor versions.
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-08-21
+
+### Added
+
+- **`New disc` — start a fresh disc without restarting the app.** There has always
+  been an `Open existing disc...` with no counterpart: the only way back to an empty
+  form was to close DiscWright and open it again. That is fine once and tiresome by
+  the third disc of an evening.
+
+  It clears the installer list, the disc label, the icon, every menu setting and the
+  extra content, and puts the log back to the line a fresh window opens with. It asks
+  first, and it is greyed out when there is nothing to clear, so the dialog only ever
+  appears when something would actually be discarded. Nothing on disk is touched — a
+  disc already built stays where it is.
+
+  **The output folder is deliberately kept.** Three discs made in one sitting go to
+  the same place, and it is the one field that would have to be retyped every time.
+
+### Changed
+
+- The top row now holds four buttons in the width that held three, so
+  `Open existing disc...`, `Show disc folder` and `Preview menu` are each somewhat
+  narrower. Nothing moved rows and no label is clipped.
+
 ## [0.3.1] — 2026-08-21
 
 ### Fixed
@@ -157,7 +181,8 @@ First public release.
 - `extras/DiscLabel.ps1`, a parked printable disc-face generator, kept out of the app to
   keep the tool to one job.
 
-[Unreleased]: https://github.com/lazardjokovic/discwright/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/lazardjokovic/discwright/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/lazardjokovic/discwright/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/lazardjokovic/discwright/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/lazardjokovic/discwright/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/lazardjokovic/discwright/compare/v0.1.1...v0.2.0

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -61,7 +61,7 @@ $PROJECT_FILE = 'discproject.json'
 # this cannot quietly drift a release behind. Shown in the title bar and the log,
 # and written into every project file - a bug report that comes with a project
 # file then says for itself which version built the disc.
-$APP_VERSION  = '0.3.1'
+$APP_VERSION  = '0.4.0'
 
 # =================== SMALL HELPERS ===================
 
@@ -1560,10 +1560,14 @@ function New-FolderDialog([string]$description,[string]$startAt) {
     return $d
 }
 
-# --- reopen / inspect row ---
-$btnOpenProj = AddBtn 'Open existing disc...' 15 8 210
-$btnOpenDisc = AddBtn 'Show disc folder' 235 8 200
-$btnPreview  = AddBtn 'Preview menu' 445 8 210
+# --- new / reopen / inspect row ---
+# Four buttons in the width that held three, so they are narrower than they were.
+# Each is still wider than its own longest label at 9pt with room to spare; the
+# window test that no two controls overlap is what guards the arithmetic.
+$btnNew      = AddBtn 'New disc' 15 8 110
+$btnOpenProj = AddBtn 'Open existing disc...' 135 8 185
+$btnOpenDisc = AddBtn 'Show disc folder' 330 8 160
+$btnPreview  = AddBtn 'Preview menu' 500 8 155
 
 # Step 1 was one text box holding one folder. It is a list now, because a disc
 # can carry several games and their add-ons, and the one thing the old box could
@@ -1767,6 +1771,29 @@ function Test-AlreadyBuilt([string]$outDir) {
     return (@(Get-ChildItem -LiteralPath $outDir -Filter '*.iso' -File -EA SilentlyContinue).Count -gt 0)
 }
 
+# Whether anything on the form differs from how it opens, which is what decides
+# if "New disc" has anything to do.
+#
+# The output folder is deliberately NOT part of this. New disc keeps it - if you
+# are making three discs in an evening they all go to the same place, and clearing
+# it is the one field you would have to retype every time. Counting it as dirty
+# would leave the button enabled straight after a reset, so clicking it again
+# would do nothing visible and look broken.
+function Test-FormDirty {
+    if (@($state.Games).Count) { return $true }
+    foreach ($box in $txtLabel,$txtIcon,$txtBg,$txtMusic,$txtMan,$txtEx,$txtTitle) {
+        if ($box.Text.Trim()) { return $true }
+    }
+    if ($lstExtra.Items.Count) { return $true }
+    # Anything switched away from its opening position, in either direction.
+    if (-not $chkMenu.Checked -or -not $chkWinBorder.Checked) { return $true }
+    if ($chkBgAsIs.Checked -or $chkTitle.Checked -or $chkMusic.Checked -or $chkDivider.Checked) { return $true }
+    if ($cmbSide.SelectedIndex -ne 0 -or $cmbBtnStyle.SelectedIndex -ne 0) { return $true }
+    if (-not $cbPlay.Checked -or -not $cbInst.Checked -or -not $cbExit.Checked) { return $true }
+    if ($cbMan.Checked -or $cbExtra.Checked) { return $true }
+    return $false
+}
+
 # Grey out the two inspect buttons when there is nothing for them to open, and
 # make the build button say what it will actually do.
 function Update-ActionButtons {
@@ -1774,8 +1801,11 @@ function Update-ActionButtons {
     $hasOut  = $t -and (Test-Path $t)
     # Preview renders current settings, so it needs no build - only a menu and a background.
     $canPreview = $chkMenu.Checked -and $state.BgPath -and (Test-Path $state.BgPath)
+    $isDirty = Test-FormDirty
     $btnOpenDisc.Enabled = [bool]$hasOut
     $btnPreview.Enabled  = [bool]$canPreview
+    $btnNew.Enabled      = [bool]$isDirty
+    $tips.SetToolTip($btnNew, $(if($isDirty){'Clear everything and start a new disc. The output folder is kept.'}else{'Nothing to clear - this is already a new disc'}))
     $tips.SetToolTip($btnOpenDisc, $(if($hasOut){'Open the disc staging folder in Explorer'}else{'Set an output folder first (step 6)'}))
     $tips.SetToolTip($btnPreview,  $(if($canPreview){'Show the menu using the current settings - no rebuild needed'}else{'Turn the menu on and choose a background first (step 4)'}))
     $tips.SetToolTip($btnOpenProj, 'Load a disc you already built, to edit and rebuild it')
@@ -2227,6 +2257,10 @@ function Add-ExtraItem([string]$path) {
     [void]$lstExtra.Items.Add($full)
     $state.ExtraItems = @($lstExtra.Items)
     Update-MediaLabel
+    # A ListBox raises nothing when its Items collection changes, so the two places
+    # that change it say so themselves - otherwise a disc holding nothing but extra
+    # content would leave "New disc" greyed out with plenty to clear.
+    Update-ActionButtons
 }
 
 function Set-IconFile([string]$path) {
@@ -2260,6 +2294,59 @@ function Set-BgFile([string]$path) {
     # Set BOTH ways: picking a fresh source must clear a previously-ticked as-is,
     # or the divider and panel side stay greyed out with no way to reach them.
     $chkBgAsIs.Checked = [bool](Test-ComposedBg $path)
+    Update-ActionButtons
+}
+
+# Put every control back where it opens. The counterpart to Open-Project: the app
+# has always had a way to load a disc and no way to start a fresh one short of
+# closing and reopening it, which is a real gap once you are making more than one
+# disc in a sitting.
+#
+# The values here are the control defaults from the UI section above, repeated
+# rather than read back from the controls - there is nowhere else to read them
+# from, since a WinForms control does not remember what it was constructed with.
+# If a default changes up there and not here, the window test that a reset form
+# matches a freshly opened one is what says so.
+#
+# Nothing on disk is touched. A disc already built stays built; this clears the
+# form, not the output.
+function Reset-Form {
+    $state.Loading = $true   # same reason as Open-Project: no dialogs mid-reset
+
+    $null = Set-GameEntries @()
+    $lblGame.Text = ''; $lblGame.ForeColor = [System.Drawing.Color]::DimGray
+
+    $txtLabel.Clear()
+
+    $txtIcon.Clear(); $state.IconPath = $null; $state.IconIsIco = $false
+    $lblIcon.Text = ''; $lblIcon.ForeColor = [System.Drawing.Color]::DimGray
+    # Disposed the same way Set-IconFile does it - the preview holds the bitmap
+    # open, and a reset that leaked one per disc would add up over an evening.
+    if ($picIcon.Image) { $old = $picIcon.Image; $picIcon.Image = $null; $old.Dispose() }
+
+    $chkMenu.Checked = $true
+    $txtBg.Clear(); $state.BgPath = $null
+    $chkBgAsIs.Checked = $false
+    $cmbSide.SelectedIndex = 0
+    $chkTitle.Checked = $false; $txtTitle.Clear()
+    $chkMusic.Checked = $false; $txtMusic.Clear(); $state.MusicFile = $null
+    $cbPlay.Checked = $true; $cbInst.Checked = $true; $cbExit.Checked = $true
+    $cbMan.Checked = $false; $cbExtra.Checked = $false
+    $txtMan.Clear(); $state.ManualPath = $null
+    $txtEx.Clear();  $state.ExtrasPath = $null
+    $chkDivider.Checked = $false
+    $chkWinBorder.Checked = $true
+    $cmbBtnStyle.SelectedIndex = 0
+
+    $lstExtra.Items.Clear(); $state.ExtraItems = @()
+
+    $state.Loading = $false
+    $txtLog.Clear()
+    # Same first line a fresh window writes, so a pasted log still says which
+    # version and which PowerShell produced it.
+    & $log "DiscWright $APP_VERSION  -  Windows PowerShell $($PSVersionTable.PSVersion)"
+    if ($txtOut.Text.Trim()) { & $log "New disc. The output folder was kept." }
+    else { & $log "New disc." }
     Update-ActionButtons
 }
 
@@ -2356,6 +2443,16 @@ function Open-Project([string]$folder) {
 }
 
 # ---- events ----
+$btnNew.Add_Click({
+    # Asked before, not undone after: everything on the form goes, and there is no
+    # undo. The button is greyed out when there is nothing to lose, so reaching
+    # this dialog always means something would actually be discarded.
+    $msg = "Clear everything and start a new disc?" + "`r`n`r`n" +
+           "The installer list, disc label, icon, menu settings and extra content are all reset." + "`r`n`r`n" +
+           "Nothing on disk is touched - a disc you have already built stays where it is, and the output folder is kept."
+    if (-not (Show-Confirm $msg 'New disc')) { return }
+    Reset-Form
+})
 $btnOpenProj.Add_Click({
     $d = New-FolderDialog 'Pick the disc output folder (the one holding disc\ and the .iso)' $txtOut.Text.Trim()
     if ($d.ShowDialog() -eq 'OK') { Open-Project $d.SelectedPath }
@@ -2460,7 +2557,7 @@ $btnXDir.Add_Click({
 })
 $btnXDel.Add_Click({
     foreach($i in @($lstExtra.SelectedIndices | Sort-Object -Descending)){ $lstExtra.Items.RemoveAt($i) }
-    $state.ExtraItems = @($lstExtra.Items); Update-MediaLabel
+    $state.ExtraItems = @($lstExtra.Items); Update-MediaLabel; Update-ActionButtons
 })
 $chkMusic.Add_CheckedChanged({ $txtMusic.Enabled=$chkMusic.Checked; $btnMusic.Enabled=$chkMusic.Checked; Update-MediaLabel })
 $cbMan.Add_CheckedChanged({ $txtMan.Enabled=$cbMan.Checked; $btnMan.Enabled=$cbMan.Checked; Update-MediaLabel })
@@ -2635,6 +2732,22 @@ Add-Type -Namespace GDA -Name Win -MemberDefinition @'
 [DllImport("user32.dll")] public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
 [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr hWnd);
 '@
+# "New disc" greys itself out when there is nothing to clear, so every edit that
+# can make the form dirty has to refresh it. Most already run through
+# Update-ActionButtons for their own reasons - the background, the output folder,
+# the installer list - but the plain fields and toggles did not, because until now
+# nothing depended on them. Wired in one loop rather than appended to fifteen
+# separate handlers, which is where one would eventually get missed.
+foreach ($c in @($txtLabel,$txtIcon,$txtMusic,$txtMan,$txtEx,$txtTitle)) {
+    $c.Add_TextChanged({ Update-ActionButtons })
+}
+foreach ($c in @($chkBgAsIs,$chkMusic,$chkDivider,$chkWinBorder,$cbPlay,$cbInst,$cbMan,$cbExtra,$cbExit)) {
+    $c.Add_CheckedChanged({ Update-ActionButtons })
+}
+foreach ($c in @($cmbSide,$cmbBtnStyle)) {
+    $c.Add_SelectedIndexChanged({ Update-ActionButtons })
+}
+
 Update-ActionButtons   # start greyed out - nothing to open yet
 Update-GameList        # and the same for Change.../Remove, with an empty list
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ The launchers run the script with `-ExecutionPolicy Bypass`, the flag Windows re
 
 Every build writes a `discproject.json` next to the ISO. **Open existing disc...** loads it back so you can change one thing and rebuild, months later.
 
+**New disc** clears the form and starts over without restarting the app — useful when you are making several discs in one sitting. It asks first, and it keeps the output folder, since that is the one field you would otherwise retype every time.
+
 ### Where to get artwork
 
 The disc icon wants something square-ish and at least 256px. The menu background wants something around 760×480 or larger — it gets cropped to fill.

--- a/tests/ui/DiscWright.UI.Tests.ps1
+++ b/tests/ui/DiscWright.UI.Tests.ps1
@@ -169,7 +169,7 @@ Describe 'The window as it opens' -Tag 'UI' -Skip:(-not $script:HaveDesktop) {
     }
 
     It 'leaves <_> greyed until there is something for it to act on' -ForEach @(
-        'Add-on*', 'Change*', 'Remove', 'Show disc folder', 'Preview menu'
+        'Add-on*', 'Change*', 'Remove', 'Show disc folder', 'Preview menu', 'New disc'
     ) {
         Test-CtlEnabled $script:Win $_ | Should -BeFalse
     }
@@ -223,6 +223,71 @@ Describe 'Opening a disc that was already built' -Tag 'UI' -Skip:(-not $script:H
         Select-ListRow -Win $script:Win -Index 0
         Test-CtlEnabled $script:Win 'Change*' | Should -BeTrue
         Test-CtlEnabled $script:Win 'Remove'  | Should -BeTrue
+    }
+}
+
+Describe 'Starting a new disc' -Tag 'UI' -Skip:(-not $script:HaveDesktop) {
+
+    # Loaded rather than typed in, so every field this has to clear is genuinely
+    # populated - list, label, icon, background, output folder - and the test is
+    # about the reset rather than about how the form got filled.
+    BeforeAll {
+        $script:App = Start-DiscWright -AppPath $script:AppPath
+        $script:Win = $script:App.Window
+        Set-CtlText -Ctl (Get-BoxAfter $script:Win '6)  Output folder*') -Text $script:ProjOut
+        Invoke-CtlNamed $script:Win 'Open existing disc*' | Out-Null
+        Complete-FolderDialog -Win $script:Win | Out-Null
+        Start-Sleep -Seconds 2
+    }
+    AfterAll { Stop-DiscWright $script:App; $script:App = $null }
+
+    It 'wakes New disc once there is something to clear' {
+        Test-CtlEnabled $script:Win 'New disc' | Should -BeTrue
+    }
+
+    It 'asks before discarding, and says nothing on disk is touched' {
+        Invoke-CtlNamed $script:Win 'New disc' | Out-Null
+        # Dismissed with No: the confirmation has to be a real gate, not a
+        # formality that clears the form whichever button is pressed.
+        $script:Asked = Read-MessageBox -Win $script:Win -TitleLike 'New disc' -Button 'No'
+        $script:Asked | Should -Match 'Nothing on disk is touched'
+        Get-EntryCount $script:Win | Should -BeGreaterThan 0
+    }
+
+    It 'clears the installer list when confirmed' {
+        Invoke-CtlNamed $script:Win 'New disc' | Out-Null
+        Read-MessageBox -Win $script:Win -TitleLike 'New disc' -Button 'Yes' | Out-Null
+        Start-Sleep -Seconds 1
+        Get-EntryCount $script:Win | Should -Be 0
+    }
+
+    It 'clears the disc label and the icon' {
+        (Get-BoxAfter $script:Win '2)  Disc label*').Current.Name | Should -BeNullOrEmpty
+        (Get-BoxAfter $script:Win '3)  Disc icon*').Current.Name  | Should -BeNullOrEmpty
+    }
+
+    It 'keeps the output folder, which is the one field you would retype' {
+        (Get-BoxAfter $script:Win '6)  Output folder*').Current.Name | Should -Be $script:ProjOut
+    }
+
+    It 'greys itself out again, having nothing left to clear' {
+        # The output folder survives on purpose, so it must not count as dirty -
+        # otherwise this stays lit and a second click does nothing visible.
+        Test-CtlEnabled $script:Win 'New disc' | Should -BeFalse
+    }
+
+    It 'greys the buttons that need an entry, and leaves Add game available' {
+        Test-CtlEnabled $script:Win 'Add-on*'      | Should -BeFalse
+        Test-CtlEnabled $script:Win 'Preview menu' | Should -BeFalse
+        Test-CtlEnabled $script:Win 'Add game*'    | Should -BeTrue
+    }
+
+    It 'ends up looking like a window that just opened' {
+        Save-WindowShot $script:Win (Join-Path $script:ShotDir 'after-new-disc.png')
+        # The status line under the list is blank on a fresh window. Leaving the
+        # previous disc's "2 games + 1 add-on" sitting under an empty list is
+        # exactly the kind of stale text that makes a reset look like a failure.
+        Get-StatusText $script:Win | Should -BeNullOrEmpty
     }
 }
 


### PR DESCRIPTION
There has always been an `Open existing disc...` with no counterpart. The only way back to an empty form was to close DiscWright and open it again — fine once, tiresome by the third disc of an evening.

`New disc` clears the installer list, the disc label, the icon, every menu setting and the extra content, and puts the log back to the line a fresh window opens with. Nothing on disk is touched: a disc already built stays where it is.

## Decisions worth reviewing

**The output folder is kept.** Three discs made in one sitting go to the same place, and it is the one field you would retype every time. That is also why it does not count towards "is there anything to clear" — counting it would leave the button lit straight after a reset, so a second click would do nothing visible and look broken.

**It greys itself out when there is nothing to discard**, so the confirmation only appears when something would actually be lost. Making that honest meant refreshing `Update-ActionButtons` from the plain fields and toggles, which nothing depended on until now. They are wired in one loop rather than appended to fifteen separate handlers — that is where one would eventually get missed. A `ListBox` raises nothing when its `Items` change, so the two places that change the extra-content list call it themselves.

**The top row now holds four buttons in the width that held three.** The existing window test that no two controls overlap guards the arithmetic — that is the test that caught the 0.3.1 icon-preview bug, and re-laying a row is exactly when it earns its keep.

**Defaults are repeated in `Reset-Form` rather than read back**, because a WinForms control does not remember what it was constructed with. If a default changes in the UI section and not here, the window tests are what say so.

## Tests

Nine new window tests: greyed on open, lit once a project is loaded, dismissing with **No** leaves the list alone, confirming empties it, label and icon cleared, output folder survives, the button greys itself out again, and the status line goes blank rather than leaving the previous disc's "2 games + 1 add-on" under an empty list.

```
logic    218 passed, 0 failed, 0 skipped
window    41 passed, 0 failed, 0 skipped     (was 32)
```

Screenshot after a reset is written to `tests/ui/shots/after-new-disc.png` by the suite itself.

## Version

0.4.0 — new capability rather than a fix. Someone on 0.3.1 seeing a patch release and finding the toolbar rearranged would be right to be annoyed.

Independent of #14; both are branched from main and touch different parts of the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
