### PR TITLE
fix: an add-on cannot be installed before the game it belongs to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ between minor versions.
 
 ## [Unreleased]
 
+### Fixed
+
+- **An add-on's Install button no longer offers to run before its game exists.**
+  A patch, a piece of DLC or a mod is applied *on top of* the game it belongs to.
+  The menu enabled those buttons purely on whether the file was present on the
+  disc, so on a freshly inserted disc every one of them was live — and clicking one
+  produced an error from GOG's installer several clicks later, which is a poor place
+  to learn the rule. They now need the game installed as well, using the same
+  registry check `Play` already relies on, and the tooltip distinguishes the two
+  reasons a button can be grey: the installer is missing from the disc, or the game
+  is not installed yet.
+
+  This does not sequence anything. GOG's patches are incremental and have to be
+  applied in order; DiscWright shows them in the order they were added and cannot
+  tell which have already been applied. Add them in the order they should be run.
+
 ## [0.3.1] — 2026-08-21
 
 ### Fixed

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -886,17 +886,26 @@ function New-MenuHta([hashtable]$cfg,[string]$out) {
     var g=GAMES[cur];
     setEnabled("btn_Install", (PREVIEW || (g.s!="" && fso.FileExists(fso.BuildPath(root,g.s)))),
                "The installer is not next to this menu.");
+    // Registry-based, so it tells the truth in preview as well. Worked out once
+    // and used by both the add-ons and Play below.
+    var parentOn = (findGame(g.m)!=null);
+    // An add-on - a patch, a piece of DLC, a mod - is applied ON TOP of the game
+    // it belongs to and needs that game installed first. A GOG patch in
+    // particular refuses outright, and the error comes from GOG's installer
+    // several clicks later rather than from the menu, which is a poor place to
+    // discover the rule. Being on the disc is necessary but not sufficient.
     for(var j=0;j<g.a.length;j++){
-      setEnabled("btn_addon_"+j, (PREVIEW || fso.FileExists(fso.BuildPath(root,g.a[j].s))),
-                 "This add-on's installer is not on the disc.");
+      var here = fso.FileExists(fso.BuildPath(root,g.a[j].s));
+      setEnabled("btn_addon_"+j, (PREVIEW || (here && parentOn)),
+                 here ? (g.n+" is not installed yet - use Install first.")
+                      : "This add-on's installer is not on the disc.");
     }
     var gman = manualOf(g), gext = extrasOf(g);
     setEnabled("btn_Manual", (PREVIEW || (gman!="" && fso.FileExists(fso.BuildPath(root,gman)))),
                "There is no manual for " + g.n + " on this disc.");
     setEnabled("btn_Extras", (PREVIEW || fso.FolderExists(fso.BuildPath(root,gext))),
                "There is nothing extra for " + g.n + " on this disc.");
-    // Play is registry-based, so it tells the truth even in preview.
-    setEnabled("btn_Play", (findGame(g.m)!=null),
+    setEnabled("btn_Play", parentOn,
                g.n+" is not installed yet - use Install first.");
     if(PREVIEW){
       var ids=["btn_Install","btn_Manual","btn_Extras"];

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -976,6 +976,25 @@ Describe 'Building a disc that has an add-on on it' {
         ([regex]::Matches($script:AoHta,',a:\[\{n:"')).Count | Should -Be 1
     }
 
+    It 'greys an add-on until the game it belongs to is installed' {
+        # A patch, a piece of DLC or a mod goes ON TOP of its game. An Install
+        # button that is live before the game exists can only produce an error
+        # from GOG's installer, several clicks later - the worst place to learn
+        # the rule. Being present on the disc is necessary, not sufficient.
+        $call = [regex]::Match($script:AoHta, 'setEnabled\("btn_addon_"\+j,[^;]*;')
+        $call.Success | Should -BeTrue -Because 'the add-on buttons must be enabled somewhere'
+        $call.Value   | Should -Match 'parentOn' -Because 'the game being installed has to be part of the condition'
+        $script:AoHta | Should -Match 'var parentOn = \(findGame\(g\.m\)!=null\)'
+    }
+
+    It 'says which of the two reasons an add-on is greyed out' {
+        # "Not on the disc" and "the game is not installed yet" send you to
+        # completely different places. One message for both would be wrong half
+        # the time.
+        $script:AoHta | Should -Match "is not installed yet - use Install first"
+        $script:AoHta | Should -Match "This add-on's installer is not on the disc"
+    }
+
     It 'points every path in the menu at a file that is really there' {
         foreach ($m in [regex]::Matches($script:AoHta,'s:"([^"]+)"')) {
             $rel = $m.Groups[1].Value -replace '\\\\','\'


### PR DESCRIPTION
Came out of a direct question: *"are we absolutely sure that patches, DLCs and add-ons will work as a separate installation and won't interfere with each other?"*

The **file-level** answer was already yes, and tested — an add-on takes only its own `.exe` and its own `.bin` parts (`tests/DiscWright.Tests.ps1:1267`), every entry stages into its own numbered folder, and every path in the generated menu is checked against a file that really exists. Nothing bleeds between installers.

The **behavioural** answer was no, and this fixes it.

## The problem

An add-on is applied *on top of* the game it belongs to. The menu enabled those Install buttons purely on `fso.FileExists` — which on a freshly inserted disc is always true. So on a disc holding Hollow Knight plus its patches, all four patch buttons were live before the game had been installed at all.

Clicking one produced an error from GOG's installer several clicks later, rather than from the menu. That is the worst place to learn the rule.

## The fix

Add-on buttons now require the game to be installed as well, via the same registry lookup `Play` already uses. The lookup is computed once and shared by both.

The greyed-out tooltip distinguishes the two reasons:

- *"This add-on's installer is not on the disc."*
- *"Hollow Knight is not installed yet - use Install first."*

Those send you to completely different places, so one message for both would be wrong half the time.

## What this deliberately does not do

**It does not sequence anything.** GOG's patches are incremental — your Hollow Knight folder has four, each expecting the previous one — and nothing on a read-only disc can tell which have already been applied. They appear in the order they were added. That is now stated in the changelog rather than left to be discovered.

## Tests

```
logic    220 passed, 0 failed, 0 skipped     (was 218)
```

Two new tests: that the add-on enable condition includes the parent-installed check, and that both greyed-out reasons are present and distinct. Note these assert on the **generated** HTA text, which is the established idiom in that file — the JavaScript is not executed by any test. The real verification is mounting a disc and looking, which is on the manual list.

## Notes

Branched from main, independent of #14 and #15. It touches `CHANGELOG.md` under `## [Unreleased]`, as does #15 — expect a small conflict there depending on merge order; I will resolve it.

No version bump: this is unreleased and folds into 0.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
