### PR TITLE
feat: Play asks which game, for a bundle with two in one installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ between minor versions.
 
 ## [Unreleased]
 
+### Added
+
+- **Play asks which one, for a bundle that ships two games in a single installer.**
+  Star Wars: Empire at War Gold Pack installs both the base game and the Forces of
+  Corruption expansion, and registers **one** GOG game name with **one** executable.
+  Play could therefore only ever launch Empire at War; Forces of Corruption sat in
+  the next folder with nothing able to reach it. Reported by someone who did a full
+  build and install and said exactly what they saw, which is why it could be fixed
+  at all.
+
+  GOG writes a `goggame-<id>.info` beside every installed game listing its play
+  tasks, and a bundle lists both games there. DiscWright now reads it: two or more
+  launchable entries and Play opens a chooser, the same way the disc asks which game
+  when it holds more than one. Back returns to the game's screen.
+
+  **A game with one launch target is completely unaffected** — Play launches it
+  directly, exactly as before. Checked against real installs: The Witcher Enhanced
+  Edition and Resident Evil 0 both report a single target, with the manual, the
+  hidden raw executable behind GOG's launcher and the Safe Mode variant all
+  correctly left out.
+
 ## [0.3.1] — 2026-08-21
 
 ### Fixed

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -716,6 +716,10 @@ function New-MenuHta([hashtable]$cfg,[string]$out) {
   // A disc holding one game has nothing to choose, so it opens on that game and
   // never shows a Back button.
   var cur = (GAMES.length==1) ? 0 : -1;
+  // Non-null while the "which one?" screen is up, for a game whose single installer
+  // put more than one launchable thing on the machine. It sits on top of whatever
+  // screen was showing rather than replacing it, so Back returns there.
+  var tasks = null;
   var player=null, musicOn=false;
   // Where this .hta actually lives. document.URL is always an absolute file: URL,
   // unlike app.commandLine - AutoRun can launch the menu with a path relative to the
@@ -869,11 +873,13 @@ function New-MenuHta([hashtable]$cfg,[string]$out) {
     if(has("Exit"))    h+=btnHtml("btn_Exit","exit","Exit","doExit()","");
     setPanel(h);
   }
-  function show(){ if(cur<0) renderChooser(); else renderGame(); }
+  function show(){ if(tasks) renderTasks(); else if(cur<0) renderChooser(); else renderGame(); }
   function pick(i){ cur=i; show(); }
-  function goBack(){ cur=-1; show(); }
+  function goBack(){ tasks=null; cur=-1; show(); }
   function refreshButtons(){
-    if(!root) return;
+    // The launch chooser's buttons are built already enabled and none of the ids
+    // below exist while it is up.
+    if(!root || tasks) return;
     // In preview the game files are not beside the menu, so the existence checks
     // would grey out buttons that will be fine on the real disc. Show them live.
     if(cur<0){
@@ -947,18 +953,91 @@ function New-MenuHta([hashtable]$cfg,[string]$out) {
   // Takes the name to match rather than reading a global: on a multi-game disc
   // each game asks this about itself, and Play has to light up for the ones that
   // are installed while staying grey for the ones that are not.
+  // Returns {exe,dir} for an installed copy, or null. The folder matters as much as
+  // the executable: it is where GOG's own goggame-<id>.info sits, and that file is
+  // the only place a bundle admits to containing more than one game.
   function findGame(match){ try{ var HKLM=0x80000002; var svc=GetObject("winmgmts:\\\\.\\root\\default"); var reg=svc.Get("StdRegProv");
     var bases=["SOFTWARE\\WOW6432Node\\GOG.com\\Games","SOFTWARE\\GOG.com\\Games"];
     for(var b=0;b<bases.length;b++){ var mi=reg.Methods_.Item("EnumKey").InParameters.SpawnInstance_(); mi.hDefKey=HKLM; mi.sSubKeyName=bases[b];
       var mo=reg.ExecMethod_("EnumKey",mi); if(mo.ReturnValue!=0||mo.sNames==null)continue; var ids=new VBArray(mo.sNames).toArray();
       for(var k=0;k<ids.length;k++){ var sub=bases[b]+"\\"+ids[k]; var nm=regGet(reg,HKLM,sub,"gameName");
-        if(nm && nameHit(nm,match)){ var exe=regGet(reg,HKLM,sub,"exe");
-          if(exe && fso.FileExists(exe))return exe; var p=regGet(reg,HKLM,sub,"path"), ef=regGet(reg,HKLM,sub,"exeFile");
-          if(p&&ef&&fso.FileExists(fso.BuildPath(p,ef)))return fso.BuildPath(p,ef); } } } }catch(e){} return null; }
+        if(nm && nameHit(nm,match)){ var p=regGet(reg,HKLM,sub,"path"); var exe=regGet(reg,HKLM,sub,"exe");
+          if(exe && fso.FileExists(exe)) return {exe:exe, dir:(p||fso.GetParentFolderName(exe))};
+          var ef=regGet(reg,HKLM,sub,"exeFile");
+          if(p&&ef&&fso.FileExists(fso.BuildPath(p,ef))) return {exe:fso.BuildPath(p,ef), dir:p}; } } } }catch(e){} return null; }
+
+  // One string out of a JSON object, unescaped. Picked apart with a regular
+  // expression rather than JSON.parse, which the quirks-mode engine an HTA gets
+  // does not have.
+  function jsonStr(block,key){
+    var m=block.match(new RegExp('"'+key+'"\\s*:\\s*"((?:[^"\\\\]|\\\\.)*)"'));
+    if(!m) return "";
+    return m[1].replace(/\\\\/g,"\\").replace(/\\"/g,'"').replace(/\\\//g,"/");
+  }
+  // Real .info files contain both "System\\witcher.exe" and "System//witcher.exe".
+  function relPath(s){ return String(s).replace(/\//g,"\\").replace(/\\+/g,"\\"); }
+
+  // GOG writes a goggame-<id>.info beside every installed game, listing its play
+  // tasks. This exists because a bundle that ships two games in ONE installer -
+  // Star Wars: Empire at War Gold Pack, which is what turned this up - registers a
+  // single gameName and a single exe. The registry can therefore only ever point at
+  // the base game, and the expansion sitting in the next folder is unreachable. The
+  // .info file lists both.
+  //
+  // Every {...} in that file is a play task: the rest is scalars and arrays of
+  // strings, so brace pairs containing no braces find exactly the tasks and nothing
+  // else. Only the ones that start the game count - "document" is the manual and the
+  // readme, which this menu already has its own buttons for, and a hidden task is the
+  // raw exe GOG keeps behind its own launcher.
+  function playTasks(dir){
+    var out=[];
+    try{
+      if(!dir || !fso.FolderExists(dir)) return out;
+      var info=null, en=new Enumerator(fso.GetFolder(dir).Files);
+      for(;!en.atEnd();en.moveNext()){ if(/^goggame-\d+\.info$/i.test(en.item().Name)){ info=en.item().Path; break; } }
+      if(!info) return out;
+      var st=fso.OpenTextFile(info,1), txt=st.ReadAll(); st.Close();
+      var re=/\{[^{}]*\}/g, m;
+      while((m=re.exec(txt))!=null){
+        var b=m[0];
+        if(!/"type"\s*:\s*"FileTask"/.test(b)) continue;
+        if(/"isHidden"\s*:\s*true/.test(b)) continue;
+        var cat=jsonStr(b,"category");
+        if(cat!="game" && cat!="launcher") continue;
+        var rel=jsonStr(b,"path"); if(!rel) continue;
+        var full=fso.BuildPath(dir,relPath(rel));
+        if(!fso.FileExists(full)) continue;
+        var wd=jsonStr(b,"workingDir");
+        out[out.length]={ n:(jsonStr(b,"name")||fso.GetFileName(full)), p:full,
+                          a:jsonStr(b,"arguments"),
+                          w:(wd ? fso.BuildPath(dir,relPath(wd)) : fso.GetParentFolderName(full)) };
+      }
+    }catch(ex){}
+    return out;
+  }
+  function launchExe(p,args,wd){
+    try{ shell.ShellExecute(p,args||"",wd||fso.GetParentFolderName(p),"open",1); window.close(); }
+    catch(ex){ alert(ex.message); }
+  }
+  function renderTasks(){
+    var h="";
+    for(var i=0;i<tasks.length;i++){ h+=btnHtml("btn_task_"+i,"play",tasks[i].n,"playTask("+i+")",tasks[i].n); }
+    h+=btnHtml("btn_TaskBack","","Back","tasksBack()","Back to "+GAMES[cur].n);
+    if(has("Exit")) h+=btnHtml("btn_Exit","exit","Exit","doExit()","");
+    setPanel(h);
+  }
+  function playTask(i){ var t=tasks[i]; launchExe(t.p,t.a,t.w); }
+  function tasksBack(){ tasks=null; show(); }
   function doPlay(){ if(off("btn_Play")) return;
     var g=GAMES[cur];
-    var exe=findGame(g.m); if(exe){ try{ shell.ShellExecute(exe,"",fso.GetParentFolderName(exe),"open",1); window.close(); }catch(e){alert(e.message);} }
-    else { alert(g.n+" isn't installed yet.\n\nUse INSTALL first, then PLAY."); } }
+    var hit=findGame(g.m);
+    if(!hit){ alert(g.n+" isn't installed yet.\n\nUse INSTALL first, then PLAY."); return; }
+    // Two or more launch targets means a bundle, so ask which - the same way the
+    // disc asks which game when it holds more than one. One target, or an install
+    // with no .info file at all, behaves exactly as it always has.
+    var t=playTasks(hit.dir);
+    if(t.length>1){ tasks=t; show(); return; }
+    launchExe(hit.exe,"",fso.GetParentFolderName(hit.exe)); }
   // Re-check when the menu regains focus, so Play lights up after the installer finishes.
   window.onfocus = refreshButtons;
   document.onkeydown=function(){ if(window.event.keyCode==27) window.close(); };

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -1247,8 +1247,23 @@ Describe "Reading GOG's play tasks out of an installed game" -Tag 'Unit' {
         }
 
         # A stand-in for Star Wars: Empire at War Gold Pack - one installer, two
-        # games. Both path spellings that turn up in real .info files are used on
-        # purpose: GOG writes "a\\b.exe" in some and "a//b.exe" in others.
+        # games. Nobody here owns that game, so this is a reconstruction; what
+        # makes it worth trusting is that its SHAPE is copied from the two real
+        # .info files on hand rather than invented:
+        #
+        #   - pretty-printed, one key per line, a space after every colon. GOG
+        #     never writes compact JSON, and an earlier version of this fixture
+        #     did - so it agreed with the parser about a format that does not
+        #     occur.
+        #   - "languages" is a multi-line array. It is the reason playTasks may
+        #     not simply split on braces: the task-matching regex only takes
+        #     innermost braces, which is safe precisely because a real task holds
+        #     arrays and never a nested object. Both real files confirm that.
+        #   - both path spellings, because The Witcher's own file carries both:
+        #     "System\\witcher.exe" on one task and "System//witcher.exe" on the
+        #     next.
+        #   - a task with NO "category" key at all, which is how The Witcher
+        #     ships its Safe Mode entry. It must not become a third choice.
         $script:TaskDir = Join-Path $script:Sandbox 'installed-bundle'
         New-Item -ItemType Directory -Force -Path (Join-Path $script:TaskDir 'GameData') | Out-Null
         New-Item -ItemType Directory -Force -Path (Join-Path $script:TaskDir 'corruption') | Out-Null
@@ -1257,19 +1272,87 @@ Describe "Reading GOG's play tasks out of an installed game" -Tag 'Unit' {
         }
         $info = @'
 {
+    "buildId": "58076094395251196",
     "gameId": "1421404887",
+    "language": "English",
+    "languages": [
+        "en-US"
+    ],
     "name": "STAR WARS Empire at War - Gold Pack",
     "playTasks": [
-        { "category":"game", "isPrimary":true, "languages":["*"], "name":"Empire at War",
-          "path":"GameData\\sweaw.exe", "type":"FileTask", "workingDir":"GameData" },
-        { "category":"game", "languages":["*"], "name":"Forces of Corruption",
-          "path":"corruption//swfoc.exe", "type":"FileTask", "workingDir":"corruption" },
-        { "category":"game", "isHidden":true, "name":"Raw exe",
-          "path":"GameData\\hidden.exe", "type":"FileTask" },
-        { "category":"game", "name":"Gone missing", "path":"GameData\\notthere.exe", "type":"FileTask" },
-        { "category":"document", "name":"Manual", "path":"Manual.pdf", "type":"FileTask" },
-        { "category":"document", "name":"Support", "link":"http://example.invalid", "type":"URLTask" }
+        {
+            "category": "game",
+            "isPrimary": true,
+            "languages": [
+                "en-US",
+                "de-DE",
+                "fr-FR"
+            ],
+            "name": "Empire at War",
+            "path": "GameData\\sweaw.exe",
+            "type": "FileTask",
+            "workingDir": "GameData"
+        },
+        {
+            "category": "game",
+            "languages": [
+                "*"
+            ],
+            "name": "Forces of Corruption",
+            "path": "corruption//swfoc.exe",
+            "type": "FileTask",
+            "workingDir": "corruption"
+        },
+        {
+            "category": "game",
+            "isHidden": true,
+            "languages": [
+                "*"
+            ],
+            "name": "Raw exe",
+            "path": "GameData\\hidden.exe",
+            "type": "FileTask"
+        },
+        {
+            "category": "game",
+            "languages": [
+                "*"
+            ],
+            "name": "Gone missing",
+            "path": "GameData\\notthere.exe",
+            "type": "FileTask"
+        },
+        {
+            "arguments": "-dontForceMinReqs",
+            "icon": "goggame-1421404887.dll",
+            "languages": [
+                "*"
+            ],
+            "name": "Safe Mode",
+            "path": "GameData//sweaw.exe",
+            "type": "FileTask",
+            "workingDir": "GameData"
+        },
+        {
+            "category": "document",
+            "languages": [
+                "en-US"
+            ],
+            "name": "Manual",
+            "path": "Manual.pdf",
+            "type": "FileTask"
+        },
+        {
+            "category": "document",
+            "languages": [
+                "*"
+            ],
+            "link": "http://example.invalid",
+            "name": "Support",
+            "type": "URLTask"
+        }
     ],
+    "rootGameId": "1421404887",
     "version": 1
 }
 '@
@@ -1313,6 +1396,15 @@ Describe "Reading GOG's play tasks out of an installed game" -Tag 'Unit' {
     It 'leaves out the manual, the hidden exe and a task whose file is gone' -Skip:(-not $script:HaveCScript) {
         $t = Invoke-PlayTasks $script:TaskDir
         @($t | Where-Object { $_.Name -in @('Manual','Support','Raw exe','Gone missing') }).Count | Should -Be 0
+    }
+
+    It 'leaves out a task with no category, the way Safe Mode ships' -Skip:(-not $script:HaveCScript) {
+        # The Witcher's Safe Mode entry has no "category" key at all. It points at
+        # the same executable as the real one with an extra argument, so treating
+        # it as a game would offer the same game twice - and would put a chooser
+        # in front of a single-game disc that never had one before.
+        $t = Invoke-PlayTasks $script:TaskDir
+        @($t | Where-Object { $_.Name -eq 'Safe Mode' }).Count | Should -Be 0
     }
 
     It 'reports nothing for an install with no .info file, so Play is unchanged' -Skip:(-not $script:HaveCScript) {

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -1248,7 +1248,7 @@ Describe "Reading GOG's play tasks out of an installed game" -Tag 'Unit' {
 
         # A stand-in for Star Wars: Empire at War Gold Pack - one installer, two
         # games. Nobody here owns that game, so this is a reconstruction; what
-        # makes it worth trusting is that its SHAPE is copied from the two real
+        # makes it worth trusting is that its SHAPE is copied from the four real
         # .info files on hand rather than invented:
         #
         #   - pretty-printed, one key per line, a space after every colon. GOG
@@ -1264,10 +1264,23 @@ Describe "Reading GOG's play tasks out of an installed game" -Tag 'Unit' {
         #     next.
         #   - a task with NO "category" key at all, which is how The Witcher
         #     ships its Safe Mode entry. It must not become a third choice.
+        #
+        # The folder names and executables are not guesses either. GOG's own
+        # public build manifest for product 1421404887 lists GameData\sweaw.exe
+        # and EAWX\swfoc.exe under an install directory called "Star Wars -
+        # Empire At War Gold", and the whole depot holds exactly one .info file.
+        # EAWX is not a folder name anybody would invent.
+        #
+        # What that manifest cannot give is the CONTENTS of the .info: it ships
+        # inside the depot, and the depot answers 403 without an ownership token.
+        # So the playTasks below are still the reconstructed part, and one thing
+        # is still unconfirmed - whether the real file marks Forces of Corruption
+        # with category "game". If it does not, playTasks drops it and Play goes
+        # on launching only the base game.
         $script:TaskDir = Join-Path $script:Sandbox 'installed-bundle'
         New-Item -ItemType Directory -Force -Path (Join-Path $script:TaskDir 'GameData') | Out-Null
-        New-Item -ItemType Directory -Force -Path (Join-Path $script:TaskDir 'corruption') | Out-Null
-        foreach ($f in 'GameData\sweaw.exe','corruption\swfoc.exe','GameData\hidden.exe','Manual.pdf') {
+        New-Item -ItemType Directory -Force -Path (Join-Path $script:TaskDir 'EAWX') | Out-Null
+        foreach ($f in 'GameData\sweaw.exe','EAWX\swfoc.exe','GameData\hidden.exe','Manual.pdf') {
             Set-Content -LiteralPath (Join-Path $script:TaskDir $f) -Value 'x' -Encoding Ascii
         }
         $info = @'
@@ -1299,9 +1312,9 @@ Describe "Reading GOG's play tasks out of an installed game" -Tag 'Unit' {
                 "*"
             ],
             "name": "Forces of Corruption",
-            "path": "corruption//swfoc.exe",
+            "path": "EAWX//swfoc.exe",
             "type": "FileTask",
-            "workingDir": "corruption"
+            "workingDir": "EAWX"
         },
         {
             "category": "game",
@@ -1389,8 +1402,8 @@ Describe "Reading GOG's play tasks out of an installed game" -Tag 'Unit' {
     It 'resolves both spellings of a relative path' -Skip:(-not $script:HaveCScript) {
         $t = Invoke-PlayTasks $script:TaskDir
         $t[0].Path | Should -Be (Join-Path $script:TaskDir 'GameData\sweaw.exe')
-        # Written "corruption//swfoc.exe" in the fixture, as GOG really does.
-        $t[1].Path | Should -Be (Join-Path $script:TaskDir 'corruption\swfoc.exe')
+        # Written "EAWX//swfoc.exe" in the fixture, as GOG really does.
+        $t[1].Path | Should -Be (Join-Path $script:TaskDir 'EAWX\swfoc.exe')
     }
 
     It 'leaves out the manual, the hidden exe and a task whose file is gone' -Skip:(-not $script:HaveCScript) {

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -1206,6 +1206,122 @@ Describe 'Reading a real GOG download' -Tag 'Real' -Skip:($script:GogFolders.Cou
 
 
 
+Describe "Reading GOG's play tasks out of an installed game" -Tag 'Unit' {
+
+    # The only tests in this file that RUN the menu's JavaScript rather than
+    # reading it. The play-task reader is a regular expression picking apart JSON
+    # written by somebody else, which is exactly the kind of code that passes a
+    # text assertion and fails on a real file - and the case it exists for, a
+    # bundle holding two games, cannot be reproduced by owning the game unless you
+    # happen to own that one.
+    #
+    # The functions are lifted out of DiscWright.ps1 and handed to cscript, so this
+    # exercises the code that ships. A copy pasted in here would prove nothing.
+    #
+    # Worked out twice, deliberately. -Skip: is decided during discovery and
+    # BeforeAll does not run until afterwards, so a value set only there leaves
+    # every test in this block skipped on a machine that has cscript. Same reason
+    # $script:CanBuildIso is computed in both phases at the top of this file.
+    BeforeDiscovery {
+        $script:HaveCScript = @(
+            "$env:SystemRoot\System32\cscript.exe"
+            (Get-Command cscript.exe -ErrorAction SilentlyContinue | ForEach-Object { $_.Source })
+        ) | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
+    }
+
+    BeforeAll {
+        $script:CScript = @(
+            "$env:SystemRoot\System32\cscript.exe"
+            (Get-Command cscript.exe -ErrorAction SilentlyContinue | ForEach-Object { $_.Source })
+        ) | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
+
+        function Get-JsFunction([string]$text, [string]$name) {
+            $start = $text.IndexOf("function $name(")
+            if ($start -lt 0) { throw "DiscWright.ps1 has no JScript function called $name" }
+            $i = $text.IndexOf('{', $start); $depth = 0
+            for ($j = $i; $j -lt $text.Length; $j++) {
+                if ($text[$j] -eq '{') { $depth++ }
+                elseif ($text[$j] -eq '}') { $depth--; if ($depth -eq 0) { return $text.Substring($start, $j - $start + 1) } }
+            }
+            throw "unbalanced braces in $name"
+        }
+
+        # A stand-in for Star Wars: Empire at War Gold Pack - one installer, two
+        # games. Both path spellings that turn up in real .info files are used on
+        # purpose: GOG writes "a\\b.exe" in some and "a//b.exe" in others.
+        $script:TaskDir = Join-Path $script:Sandbox 'installed-bundle'
+        New-Item -ItemType Directory -Force -Path (Join-Path $script:TaskDir 'GameData') | Out-Null
+        New-Item -ItemType Directory -Force -Path (Join-Path $script:TaskDir 'corruption') | Out-Null
+        foreach ($f in 'GameData\sweaw.exe','corruption\swfoc.exe','GameData\hidden.exe','Manual.pdf') {
+            Set-Content -LiteralPath (Join-Path $script:TaskDir $f) -Value 'x' -Encoding Ascii
+        }
+        $info = @'
+{
+    "gameId": "1421404887",
+    "name": "STAR WARS Empire at War - Gold Pack",
+    "playTasks": [
+        { "category":"game", "isPrimary":true, "languages":["*"], "name":"Empire at War",
+          "path":"GameData\\sweaw.exe", "type":"FileTask", "workingDir":"GameData" },
+        { "category":"game", "languages":["*"], "name":"Forces of Corruption",
+          "path":"corruption//swfoc.exe", "type":"FileTask", "workingDir":"corruption" },
+        { "category":"game", "isHidden":true, "name":"Raw exe",
+          "path":"GameData\\hidden.exe", "type":"FileTask" },
+        { "category":"game", "name":"Gone missing", "path":"GameData\\notthere.exe", "type":"FileTask" },
+        { "category":"document", "name":"Manual", "path":"Manual.pdf", "type":"FileTask" },
+        { "category":"document", "name":"Support", "link":"http://example.invalid", "type":"URLTask" }
+    ],
+    "version": 1
+}
+'@
+        # No BOM: GOG's files have none, and OpenTextFile would read one as content.
+        [IO.File]::WriteAllText((Join-Path $script:TaskDir 'goggame-1421404887.info'),
+                                $info, (New-Object Text.UTF8Encoding($false)))
+
+        $script:PlainDir = Join-Path $script:Sandbox 'installed-plain'
+        New-Item -ItemType Directory -Force -Path $script:PlainDir | Out-Null
+
+        function Invoke-PlayTasks([string]$dir) {
+            $src = Get-Content -Raw (Join-Path (Split-Path $PSScriptRoot -Parent) 'DiscWright.ps1')
+            $js = @('var fso=new ActiveXObject("Scripting.FileSystemObject");')
+            foreach ($fn in 'jsonStr','relPath','playTasks') { $js += (Get-JsFunction $src $fn) }
+            $js += 'var t=playTasks(WScript.Arguments(0));'
+            $js += 'for(var i=0;i<t.length;i++){ WScript.Echo(t[i].n+"|"+t[i].p+"|"+t[i].a+"|"+t[i].w); }'
+            $tmp = Join-Path $script:Sandbox ('tasks_' + [Guid]::NewGuid().ToString('N').Substring(0,6) + '.js')
+            Set-Content -LiteralPath $tmp -Value ($js -join "`r`n") -Encoding Ascii
+            $out = & $script:CScript //Nologo //E:JScript $tmp $dir 2>&1
+            return @($out | Where-Object { $_ -and $_ -notmatch '^\s*$' } | ForEach-Object {
+                $p = ([string]$_).Split('|')
+                [pscustomobject]@{ Name=$p[0]; Path=$p[1]; Args=$p[2]; WorkDir=$p[3] }
+            })
+        }
+    }
+
+    It 'finds both games in a bundle that ships them in one installer' -Skip:(-not $script:HaveCScript) {
+        $t = Invoke-PlayTasks $script:TaskDir
+        $t.Count | Should -Be 2
+        $t[0].Name | Should -Be 'Empire at War'
+        $t[1].Name | Should -Be 'Forces of Corruption'
+    }
+
+    It 'resolves both spellings of a relative path' -Skip:(-not $script:HaveCScript) {
+        $t = Invoke-PlayTasks $script:TaskDir
+        $t[0].Path | Should -Be (Join-Path $script:TaskDir 'GameData\sweaw.exe')
+        # Written "corruption//swfoc.exe" in the fixture, as GOG really does.
+        $t[1].Path | Should -Be (Join-Path $script:TaskDir 'corruption\swfoc.exe')
+    }
+
+    It 'leaves out the manual, the hidden exe and a task whose file is gone' -Skip:(-not $script:HaveCScript) {
+        $t = Invoke-PlayTasks $script:TaskDir
+        @($t | Where-Object { $_.Name -in @('Manual','Support','Raw exe','Gone missing') }).Count | Should -Be 0
+    }
+
+    It 'reports nothing for an install with no .info file, so Play is unchanged' -Skip:(-not $script:HaveCScript) {
+        # Fewer than two tasks means doPlay uses the registry exe exactly as it
+        # always has. Every disc built before this keeps behaving identically.
+        (Invoke-PlayTasks $script:PlainDir).Count | Should -Be 0
+    }
+}
+
 Describe 'Naming an add-on' -Tag 'Unit' {
 
     It 'puts the version a GOG patch moves TO at the front' {


### PR DESCRIPTION
Reported by a user who did a full test build **and install** of Star Wars: Empire at War Gold Pack:

> it's a single installer for both the base game and the Forces of Corruption expansion. And unlike other game + expansion pack bundles, there's no launcher that comes up to select which one you want. They're functionally two separate games that share an installer. […] the Play button just launches base Empire at War.

Confirmed, and not related to the multi-game work in 0.3.0 — that solved *several installers on one disc*. This is *one installer producing two games*, and the gap has been there since 0.1.0.

## Cause

`findGame()` walks `HKLM\SOFTWARE\WOW6432Node\GOG.com\Games`, matches on `gameName`, and returns a single `exe`. The Gold Pack registers one game name and one executable, so the expansion is unreachable by construction.

## Fix

GOG writes a `goggame-<id>.info` beside every installed game with a `playTasks` array. A bundle lists both games there. `findGame` now returns the install folder alongside the exe, and `doPlay` reads that file:

- **Two or more launchable tasks** → a chooser, the same shape as the disc's own game chooser, with Back to the game screen.
- **Fewer than two, or no `.info` at all** → the old registry-exe path, unchanged.

A task counts as launchable only if it is a `FileTask`, not `isHidden`, categorised `game` or `launcher`, and its file actually exists. That drops the manual, the readme, the support URL, and the raw executable GOG keeps hidden behind its own launcher.

Parsed with a regular expression rather than `JSON.parse`, which the quirks-mode engine an HTA gets does not have. Every `{...}` in a goggame `.info` is a play task — the rest is scalars and arrays of strings — so brace pairs containing no braces find exactly the tasks.

## Tests

```
logic    222 passed, 0 failed, 0 skipped     (was 218)
```

The four new ones are **the only tests in the repo that execute the menu's JavaScript.** Everything else asserts on the generated HTA as text, which is fine for structure and useless for a regex parsing somebody else's JSON. They lift `jsonStr`, `relPath` and `playTasks` out of `DiscWright.ps1` and run them under `cscript`, so the code under test is the code that ships. They cover a synthesised Gold Pack, both relative-path spellings GOG really writes (`a\b.exe` and `a//b.exe`), the exclusions, and an install with no `.info` file. They skip themselves where `cscript` is absent.

## What I could not verify

**I do not have the Gold Pack.** The two-game path is proven against a synthesised `.info` shaped like one, not the real article. What is verified against real installs is the no-change case: The Witcher Enhanced Edition and Resident Evil 0 both report exactly one launch target, so neither would ever see a chooser.

The window suite was not run — this touches no WinForms code. The disc-build tests that generate the HTA are in the logic suite and pass.

Branched from main, independent of #14, #15 and #16. Touches `CHANGELOG.md` under `## [Unreleased]`, as does #16 — expect a small conflict depending on merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
