### PR TITLE
fix: removing the last entry left the disc label and status line behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,17 @@ between minor versions.
   `Open existing disc...`, `Show disc folder` and `Preview menu` are each somewhat
   narrower. Nothing moved rows and no label is clipped.
 
+- **`Add game...` reopens where a game was last picked from**, and remembers it
+  across `New disc` and across removing every entry — where your GOG downloads
+  live does not change because you started a second disc. On a fresh start with
+  nothing to go on it opens GOG Galaxy's own download folder, if that exists.
+
+  Previously the first pick of a session had no starting folder at all, so Windows
+  opened the tree wherever it happened to be — which on a machine with a
+  OneDrive-redirected Desktop is several expansions away from anything useful. The
+  dialog does not remember on its own: it is the old `SHBrowseForFolder` tree, and
+  opening it once and cancelling teaches it nothing.
+
 ### Fixed
 
 - **An add-on's Install button no longer offers to run before its game exists.**
@@ -67,6 +78,20 @@ between minor versions.
   This does not sequence anything. GOG's patches are incremental and have to be
   applied in order; DiscWright shows them in the order they were added and cannot
   tell which have already been applied. Add them in the order they should be run.
+
+- **Removing the last entry left the disc label and the status line behind.** The
+  size and media summary under the list stayed exactly as it was — still green,
+  still naming a payload and a disc type that nothing on the form accounted for.
+
+  The disc label was worse than untidy. Adding a game to an empty form seeds the
+  label from its name, and seeding only fires into an *empty* box. So removing the
+  game left its name there, the next game added never replaced it, and swapping
+  one game for another built a disc carrying the previous game's name in This PC.
+  DiscWright now takes back only the label it typed itself: one loaded from a
+  project, or typed by hand, survives an empty list even if it happens to match a
+  game's name.
+
+  `New disc` always cleared both of these. `Remove` never did.
 
 ## [0.3.1] — 2026-08-21
 

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -1666,6 +1666,23 @@ function New-FolderDialog([string]$description,[string]$startAt) {
 # GOG Galaxy's own download folder is the best guess there is: DiscWright exists to
 # read GOG offline installers, and that is where Galaxy puts them unless told
 # otherwise. If it is not there, fall back to nothing rather than to a wrong guess.
+
+# Whether the disc label sitting in the box is one DiscWright typed itself, and may
+# therefore be taken back when the last entry goes.
+#
+# A named predicate rather than an inline condition because it is the entire rule,
+# and the click handler that applies it cannot be reached from a test: getting a
+# game onto the form means driving the folder picker, whose tree is invisible to UI
+# Automation. This way the rule is tested even though the wiring is not.
+#
+# Compared against what was SEEDED, never against the entry being removed. A user
+# who types a label that happens to match the game's name still owns it - they typed
+# it, so it survives.
+function Test-LabelIsSeeded([string]$current, [string]$seeded) {
+    if ([string]::IsNullOrEmpty($seeded)) { return $false }
+    return ($current -eq $seeded)
+}
+
 function Get-DefaultGameBrowseFolder {
     foreach ($p in @(
         (Join-Path ${env:ProgramFiles(x86)} 'GOG Galaxy\Games\Offline Installers'),
@@ -2665,8 +2682,7 @@ $btnGameDel.Add_Click({
     # carried the previous game's name. Compared against what was seeded rather
     # than against the game just removed, so a label the user typed survives even
     # if they typed the game's own name.
-    if (@($state.Games).Count -eq 0 -and $state.LabelSeededFrom -and
-        $txtLabel.Text -eq $state.LabelSeededFrom) {
+    if (@($state.Games).Count -eq 0 -and (Test-LabelIsSeeded $txtLabel.Text $state.LabelSeededFrom)) {
         $txtLabel.Clear(); $state.LabelSeededFrom = $null
     }
     Update-GameList; Update-MediaLabel; Update-ActionButtons

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -1592,7 +1592,13 @@ function Invoke-Build([hashtable]$s, [scriptblock]$log, [scriptblock]$progress=$
 }
 
 # =================== UI ===================
-$state = @{ Games=@(); IconPath=$null; IconIsIco=$false; BgPath=$null; MusicFile=$null; ManualPath=$null; ExtrasPath=$null; ExtraItems=@() }
+# LabelSeededFrom records the name DiscWright typed into the disc label itself, so
+# it can tell its own guess from something the user wrote. LastGameBrowse is the
+# folder the game picker should reopen on; it deliberately outlives both New disc
+# and removing every entry, because where your GOG downloads live does not change
+# when you start a second disc.
+$state = @{ Games=@(); IconPath=$null; IconIsIco=$false; BgPath=$null; MusicFile=$null; ManualPath=$null; ExtrasPath=$null; ExtraItems=@()
+            LabelSeededFrom=$null; LastGameBrowse=$null }
 
 # One game per disc is still the common case, so the disc layout, the UI and the
 # menu are unchanged for it. Only sizing, the build's copy step and the menu need
@@ -1646,6 +1652,28 @@ function New-FolderDialog([string]$description,[string]$startAt) {
     if ($description) { $d.Description = $description }
     if ($startAt -and (Test-Path $startAt -PathType Container)) { $d.SelectedPath = $startAt }
     return $d
+}
+
+# Where the game picker opens when nothing on the form points anywhere yet: a fresh
+# start, or straight after New disc emptied the list.
+#
+# It does not simply reopen where it was last time. FolderBrowserDialog is the old
+# SHBrowseForFolder tree, and it does NOT restore the previous folder between
+# openings - opening it once and cancelling teaches it nothing. So the first pick of
+# a session landed wherever the shell felt like, which on a machine with a redirected
+# Desktop is several expansions away from anything useful.
+#
+# GOG Galaxy's own download folder is the best guess there is: DiscWright exists to
+# read GOG offline installers, and that is where Galaxy puts them unless told
+# otherwise. If it is not there, fall back to nothing rather than to a wrong guess.
+function Get-DefaultGameBrowseFolder {
+    foreach ($p in @(
+        (Join-Path ${env:ProgramFiles(x86)} 'GOG Galaxy\Games\Offline Installers'),
+        (Join-Path $env:ProgramFiles        'GOG Galaxy\Games\Offline Installers')
+    )) {
+        if ($p -and (Test-Path $p -PathType Container)) { return $p }
+    }
+    return ''
 }
 
 # --- new / reopen / inspect row ---
@@ -1797,7 +1825,15 @@ function Get-PayloadBytes {
 
 function Update-MediaLabel {
     $games = Get-Games
-    if ($games.Count -eq 0) { return }
+    if ($games.Count -eq 0) {
+        # Removing the last entry has to clear this line, not leave it alone.
+        # Returning early left the previous disc's summary sitting under an empty
+        # list - still green, still naming a size and a disc type that nothing on
+        # the form accounted for any more.
+        $lblGame.Text = ''
+        $lblGame.ForeColor = [System.Drawing.Color]::DimGray
+        return
+    }
     $g = $games[0]
     $p = Get-PayloadBytes
     $m = Get-MediaRec $p.Total
@@ -2404,7 +2440,8 @@ function Reset-Form {
     $null = Set-GameEntries @()
     $lblGame.Text = ''; $lblGame.ForeColor = [System.Drawing.Color]::DimGray
 
-    $txtLabel.Clear()
+    # LastGameBrowse is deliberately NOT reset - see where $state is declared.
+    $txtLabel.Clear(); $state.LabelSeededFrom = $null
 
     $txtIcon.Clear(); $state.IconPath = $null; $state.IconIsIco = $false
     $lblIcon.Text = ''; $lblIcon.ForeColor = [System.Drawing.Color]::DimGray
@@ -2483,7 +2520,9 @@ function Open-Project([string]$folder) {
     }
     foreach ($g in (Set-GameEntries $entries)) { if (-not $g.Ok) { & $log "  WARNING: $($g.Msg)" } }
 
-    $txtLabel.Text = $p.Label
+    # A label out of a project file is the user's, whatever it says - so no seed
+    # marker. Removing the last game must not take it away.
+    $txtLabel.Text = $p.Label; $state.LabelSeededFrom = $null
     if ($p.IconPath -and (Test-Path $p.IconPath)) { Set-IconFile $p.IconPath } else { & $log "  icon missing - pick one again." }
 
     $chkMenu.Checked = $p.Menu
@@ -2568,16 +2607,23 @@ $txtOut.Add_TextChanged({ Update-ActionButtons })
 $btnFolder.Add_Click({
     # Open where the last one came from: several games on a disc usually come
     # from sibling folders in the same download directory.
+    # Beside the last game added, else wherever a game was last picked from - which
+    # survives New disc and survives removing every entry, because where the GOG
+    # downloads live does not change when you start a second disc. Only when neither
+    # exists does it fall back to guessing.
     $start = ''
     $last = @($state.Games) | Select-Object -Last 1
-    if ($last -and $last.Folder) { $start = Split-Path $last.Folder -Parent }
+    if     ($last -and $last.Folder)  { $start = Split-Path $last.Folder -Parent }
+    elseif ($state.LastGameBrowse)    { $start = $state.LastGameBrowse }
+    else                              { $start = Get-DefaultGameBrowseFolder }
     $d = New-FolderDialog 'Pick a folder you downloaded from GOG (it holds setup_*.exe)' $start
     if ($d.ShowDialog() -eq 'OK') {
+        $state.LastGameBrowse = Split-Path $d.SelectedPath -Parent
         $g = Add-GameFolder $d.SelectedPath
         # Label and output folder are seeded from the first game only. Changing
         # them on the second would rename a disc the user had already named.
         if ($g -and @($state.Games).Count -eq 1) {
-            if ([string]::IsNullOrWhiteSpace($txtLabel.Text)) { $txtLabel.Text=$g.GameName }
+            if ([string]::IsNullOrWhiteSpace($txtLabel.Text)) { $txtLabel.Text=$g.GameName; $state.LabelSeededFrom=$g.GameName }
             if ([string]::IsNullOrWhiteSpace($txtOut.Text)) { $txtOut.Text=Join-Path ([Environment]::GetFolderPath('Desktop')) ((($g.GameName -replace '[^A-Za-z0-9_\- ]','_').Trim())+' Disc') }
         }
         Update-ActionButtons
@@ -2612,6 +2658,17 @@ $btnGameDel.Add_Click({
     # entries left a single row whose name was all four remaining names run
     # together. Same trap as Get-Games and Get-FirstGame.
     $state.Games = Remove-GameEntry @($state.Games) $lvGames.SelectedIndices[0]
+    # Take back the label DiscWright typed, but only that one. Adding a game to an
+    # empty form seeds the label from its name; removing that game used to leave
+    # the name behind, and because seeding only fires into an EMPTY box, the next
+    # game added never replaced it - so a disc built after swapping the game out
+    # carried the previous game's name. Compared against what was seeded rather
+    # than against the game just removed, so a label the user typed survives even
+    # if they typed the game's own name.
+    if (@($state.Games).Count -eq 0 -and $state.LabelSeededFrom -and
+        $txtLabel.Text -eq $state.LabelSeededFrom) {
+        $txtLabel.Clear(); $state.LabelSeededFrom = $null
+    }
     Update-GameList; Update-MediaLabel; Update-ActionButtons
 })
 $btnGameEdit.Add_Click({

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -1722,3 +1722,43 @@ Describe 'Where the game picker opens when the form points nowhere' -Tag 'Unit' 
         { Get-DefaultGameBrowseFolder } | Should -Not -Throw
     }
 }
+
+Describe 'Whether the disc label is ours to take back' -Tag 'Unit' {
+
+    # Adding a game to an empty form seeds the disc label from its name. Removing
+    # that game has to take the name back, or the next game added never replaces
+    # it - seeding only fires into an EMPTY box - and the disc is built carrying
+    # the previous game's name in This PC.
+    #
+    # The click handler cannot be driven from a test: getting a game onto the form
+    # means the folder picker, whose tree UI Automation cannot see. So the rule
+    # lives in a function and the function is what is tested here.
+
+    It 'takes back a label it typed itself' {
+        Test-LabelIsSeeded 'Alan Wake' 'Alan Wake' | Should -BeTrue
+    }
+
+    It 'leaves a label the user typed over the top of the seeded one' {
+        Test-LabelIsSeeded 'ALAN WAKE DISC' 'Alan Wake' | Should -BeFalse
+    }
+
+    It 'leaves a label that was never seeded, however it looks' {
+        # A project file's label, or one typed into an empty box before any game
+        # was added. Nothing was seeded, so nothing is ours.
+        Test-LabelIsSeeded 'UI Fixture' ''    | Should -BeFalse
+        Test-LabelIsSeeded 'Alan Wake'  ''    | Should -BeFalse
+        Test-LabelIsSeeded 'Alan Wake'  $null | Should -BeFalse
+    }
+
+    It 'leaves a label the user typed that happens to match the game name' {
+        # They typed it, so they own it - even though the text is identical to
+        # what seeding would have produced. Only a recorded seed makes it ours,
+        # which is why this compares against the seed and not against the entry.
+        Test-LabelIsSeeded 'Alan Wake' $null | Should -BeFalse
+    }
+
+    It 'is not fooled by an empty box' {
+        Test-LabelIsSeeded '' 'Alan Wake' | Should -BeFalse
+        Test-LabelIsSeeded '' ''          | Should -BeFalse
+    }
+}

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -1694,3 +1694,31 @@ Describe 'Removing an entry the way the button does it' -Tag 'Unit' {
         @($after | Where-Object { $_.ParentIndex -ne -1 }).Count | Should -Be 0
     }
 }
+
+Describe 'Where the game picker opens when the form points nowhere' -Tag 'Unit' {
+
+    # FolderBrowserDialog is the old SHBrowseForFolder tree and does NOT remember
+    # its last folder between openings, so the first pick of a session has to be
+    # aimed by the app or it lands wherever the shell feels like. This is the
+    # aiming, and the only part of it that is a function rather than a click
+    # handler.
+
+    It 'names GOG Galaxy own download folder, or nothing at all' {
+        $p = Get-DefaultGameBrowseFolder
+        $p | Should -BeOfType [string]
+        if ($p) {
+            # Never a guess that does not exist - a SelectedPath pointing at a
+            # missing folder is silently ignored, which is the same as no aim at
+            # all but harder to notice.
+            Test-Path $p -PathType Container | Should -BeTrue
+            $p | Should -BeLike '*Offline Installers'
+        }
+    }
+
+    It 'never throws, whatever the machine looks like' {
+        # Runs on CI, where no GOG Galaxy exists and ProgramFiles(x86) may not
+        # either. Returning '' is the answer there; an exception would take the
+        # Add game button down with it.
+        { Get-DefaultGameBrowseFolder } | Should -Not -Throw
+    }
+}

--- a/tests/ui/DiscWright.UI.Tests.ps1
+++ b/tests/ui/DiscWright.UI.Tests.ps1
@@ -464,6 +464,65 @@ Describe 'Removing an entry' -Tag 'UI' -Skip:(-not $script:HaveDesktop) {
         Get-EntryCount $script:Win | Should -Be 1
         (Get-StatusText $script:Win) | Should -Not -Match 'add-on'
     }
+
+    It 'clears the status line when the last entry goes' {
+        # Update-MediaLabel returned early on an empty list without touching the
+        # label, so the previous disc's summary stayed under an empty list - still
+        # green, still naming a size and a disc type that nothing on the form
+        # accounted for any more. New disc always cleared it; Remove never did.
+        (Get-StatusText $script:Win) | Should -Not -BeNullOrEmpty -Because 'one entry is still on the disc'
+        Select-ListRow -Win $script:Win -Index 0
+        Invoke-CtlNamed $script:Win 'Remove' | Out-Null
+        Start-Sleep -Seconds 1
+        Get-EntryCount $script:Win | Should -Be 0
+        Get-StatusText $script:Win | Should -BeNullOrEmpty
+    }
+
+    It 'keeps a disc label that came out of the project file' {
+        # The label is only taken back when DiscWright typed it itself. This one
+        # was loaded from a project, so emptying the list must leave it alone.
+        (Get-BoxAfter $script:Win '2)  Disc label*').Current.Name | Should -Be 'UI Fixture'
+    }
+}
+
+Describe 'The label DiscWright typed itself' -Tag 'UI' -Skip:(-not $script:HaveDesktop) {
+
+    # Adding a game to an empty form seeds the disc label from its name. Removing
+    # that game used to leave the name behind - and because seeding only fires
+    # into an EMPTY box, the next game added never replaced it. Swapping the game
+    # out therefore built a disc carrying the previous game's name in This PC.
+    #
+    # Driven through Open existing disc rather than Add game, because the folder
+    # tree is invisible to UI Automation and Add game is now aimed at wherever a
+    # game was last picked from - which is nowhere, on a freshly started app.
+
+    BeforeAll {
+        $script:App = Start-DiscWright -AppPath $script:AppPath
+        $script:Win = $script:App.Window
+        Set-CtlText -Ctl (Get-BoxAfter $script:Win '6)  Output folder*') -Text $script:ProjOut
+        Invoke-CtlNamed $script:Win 'Open existing disc*' | Out-Null
+        Complete-FolderDialog -Win $script:Win | Out-Null
+        Start-Sleep -Seconds 2
+    }
+    AfterAll { Stop-DiscWright $script:App; $script:App = $null }
+
+    It 'starts from the project label, not from a game name' {
+        (Get-BoxAfter $script:Win '2)  Disc label*').Current.Name | Should -Be 'UI Fixture'
+    }
+
+    It 'survives every entry being removed, because the user owns it' {
+        while ((Get-EntryCount $script:Win) -gt 0) {
+            Select-ListRow -Win $script:Win -Index 0
+            Invoke-CtlNamed $script:Win 'Remove' | Out-Null
+            Start-Sleep -Milliseconds 800
+        }
+        Get-EntryCount $script:Win | Should -Be 0
+        (Get-BoxAfter $script:Win '2)  Disc label*').Current.Name | Should -Be 'UI Fixture'
+    }
+
+    It 'and the status line is gone even though the label stayed' {
+        Get-StatusText $script:Win | Should -BeNullOrEmpty
+    }
 }
 
 Describe 'What the build refuses, and whether it says why' -Tag 'UI' -Skip:(-not $script:HaveDesktop) {

--- a/tests/ui/DiscWright.UI.Tests.ps1
+++ b/tests/ui/DiscWright.UI.Tests.ps1
@@ -470,10 +470,13 @@ Describe 'Removing an entry' -Tag 'UI' -Skip:(-not $script:HaveDesktop) {
         # label, so the previous disc's summary stayed under an empty list - still
         # green, still naming a size and a disc type that nothing on the form
         # accounted for any more. New disc always cleared it; Remove never did.
-        (Get-StatusText $script:Win) | Should -Not -BeNullOrEmpty -Because 'one entry is still on the disc'
-        Select-ListRow -Win $script:Win -Index 0
-        Invoke-CtlNamed $script:Win 'Remove' | Out-Null
-        Start-Sleep -Seconds 1
+        #
+        # Removes until the list is empty rather than assuming a count. The tests
+        # above it in this block leave a different number behind than a filtered
+        # run does, and a test that only passes in sequence is a test that lies
+        # the first time somebody runs it on its own.
+        (Get-StatusText $script:Win) | Should -Not -BeNullOrEmpty -Because 'entries are still on the disc'
+        Clear-AllEntries -Win $script:Win
         Get-EntryCount $script:Win | Should -Be 0
         Get-StatusText $script:Win | Should -BeNullOrEmpty
     }
@@ -511,11 +514,7 @@ Describe 'The label DiscWright typed itself' -Tag 'UI' -Skip:(-not $script:HaveD
     }
 
     It 'survives every entry being removed, because the user owns it' {
-        while ((Get-EntryCount $script:Win) -gt 0) {
-            Select-ListRow -Win $script:Win -Index 0
-            Invoke-CtlNamed $script:Win 'Remove' | Out-Null
-            Start-Sleep -Milliseconds 800
-        }
+        Clear-AllEntries -Win $script:Win
         Get-EntryCount $script:Win | Should -Be 0
         (Get-BoxAfter $script:Win '2)  Disc label*').Current.Name | Should -Be 'UI Fixture'
     }

--- a/tests/ui/UiDriver.psm1
+++ b/tests/ui/UiDriver.psm1
@@ -459,7 +459,34 @@ function Save-WindowShot {
     $bmp.Save($Path, [System.Drawing.Imaging.ImageFormat]::Png); $bmp.Dispose()
 }
 
+function Clear-AllEntries {
+    <#
+    .SYNOPSIS
+        Remove every installer from the list, whatever happens to be in it.
+
+    .DESCRIPTION
+        Selects row 0 and clicks Remove until the list is empty, rather than
+        clicking a counted number of times.
+
+        A test that assumes how many entries the tests above it left behind
+        passes in sequence and fails the first time somebody runs it on its own -
+        which is exactly when they are least likely to believe the failure.
+
+        The guard stops a runaway if Remove ever stops emptying the list. A suite
+        that fails is useful; one that hangs is not.
+    #>
+    param($Win, [int]$Max = 12)
+    $n = 0
+    while ((Get-EntryCount $Win) -gt 0 -and $n -lt $Max) {
+        Select-ListRow -Win $Win -Index 0
+        if (-not (Test-CtlEnabled $Win 'Remove')) { break }
+        Invoke-CtlNamed $Win 'Remove' | Out-Null
+        Start-Sleep -Milliseconds 800
+        $n++
+    }
+}
+
 Export-ModuleMember -Function Test-UiAvailable, Start-DiscWright, Stop-DiscWright, Wait-Win, Wait-WinForProcess,
     Find-Ctl, Set-WindowFocus, Invoke-Ctl, Invoke-CtlNamed, Test-CtlEnabled, Set-CtlText,
-    Send-Keys, Get-BoxAfter, Get-StatusText, Get-EntryCount, Select-ListRow,
+    Send-Keys, Get-BoxAfter, Get-StatusText, Get-EntryCount, Select-ListRow, Clear-AllEntries,
     Complete-FolderDialog, Complete-FileDialog, Read-MessageBox, Save-WindowShot, ConvertTo-SendKeys, Set-DrivenWindow, Test-DrivingOurWindow


### PR DESCRIPTION
Both reported from real use while preparing to record the README GIFs: add a game, remove it, and the form keeps things it should have let go of.

## The status line

`Update-MediaLabel` returned early on an empty list without touching the label, so the previous disc's summary stayed under an empty list — still green, still naming a size and a disc type that nothing on the form accounted for. `New disc` always cleared it. `Remove` never did.

## The disc label

Worse than untidy. Adding a game to an empty form seeds the label from its name, and seeding only fires into an **empty** box. So removing the game left its name there, the next game added never replaced it, and swapping one game for another built a disc carrying the previous game's name in This PC.

DiscWright now takes back only the label it typed itself, compared against what it **seeded** rather than against the entry removed — so a label from a project file, or one the user typed that happens to match a game's name, survives an empty list.

## Also: the game picker had no aim

`FolderBrowserDialog` is the old `SHBrowseForFolder` tree and does **not** restore its last folder between openings — opening it once and cancelling teaches it nothing. I had assumed otherwise and was wrong. Without a starting folder the first pick of a session landed wherever the shell felt like, which on a machine with a OneDrive-redirected Desktop is several expansions from anything useful.

`Add game...` now opens beside the last game added, else wherever a game was last picked from — surviving `New disc` and an emptied list, because where your GOG downloads live doesn't change when you start a second disc — else GOG Galaxy's own download folder if it exists.

## Tests

**232 logic, 46 window** (from 225 / 41).

The label rule is a function, `Test-LabelIsSeeded`, tested directly. It has to be: seeding requires a game added through the folder picker, and that tree is invisible to UI Automation, so the click handler cannot be driven from the window suite.

Verified against the pre-fix app that the two status-line window tests fail without the change. The two removal tests go through a new `Clear-AllEntries` helper rather than assuming how many entries the tests above them left behind — the first version passed in sequence and failed run on its own, which is the kind of test that lies when you most need it.