### PR TITLE
fix: the icon, background, music and manual pickers open somewhere useful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,22 @@ between minor versions.
   dialog does not remember on its own: it is the old `SHBrowseForFolder` tree, and
   opening it once and cancelling teaches it nothing.
 
+- **The disc icon, background, music, manual and extras pickers are aimed too.**
+  They ask, in order: the folder their own box already points at, then wherever a
+  file was last picked from, then the first game's folder — because GOG downloads
+  its extras beside the installer they belong to. A game's *own* manual and extras
+  start in that game's folder rather than the last one touched.
+
+  Only picking a file updates the shared memory; choosing a folder reads it but
+  does not write it, so setting an extras folder cannot quietly move where the icon
+  picker opens next. A box pointing at something since deleted falls back to its
+  parent rather than giving up, which puts you next to where you were.
+
+  This is the same wart as above, on five more dialogs. It is worth naming what it
+  actually cost: recording the two README demos, every one of those pickers opened
+  on the Desktop and put the author's account name on screen, and both recordings
+  had to be re-cut to take it out.
+
 ### Fixed
 
 - **An add-on's Install button no longer offers to run before its game exists.**

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -1594,11 +1594,12 @@ function Invoke-Build([hashtable]$s, [scriptblock]$log, [scriptblock]$progress=$
 # =================== UI ===================
 # LabelSeededFrom records the name DiscWright typed into the disc label itself, so
 # it can tell its own guess from something the user wrote. LastGameBrowse is the
-# folder the game picker should reopen on; it deliberately outlives both New disc
-# and removing every entry, because where your GOG downloads live does not change
+# folder the game picker should reopen on, and LastFileBrowse the same for the icon,
+# background, music and manual pickers. Both deliberately outlive New disc and
+# removing every entry: where your GOG downloads and artwork live does not change
 # when you start a second disc.
 $state = @{ Games=@(); IconPath=$null; IconIsIco=$false; BgPath=$null; MusicFile=$null; ManualPath=$null; ExtrasPath=$null; ExtraItems=@()
-            LabelSeededFrom=$null; LastGameBrowse=$null }
+            LabelSeededFrom=$null; LastGameBrowse=$null; LastFileBrowse=$null }
 
 # One game per disc is still the common case, so the disc layout, the UI and the
 # menu are unchanged for it. Only sizing, the build's copy step and the menu need
@@ -1691,6 +1692,59 @@ function Get-DefaultGameBrowseFolder {
         if ($p -and (Test-Path $p -PathType Container)) { return $p }
     }
     return ''
+}
+
+# The folder a path points into, whether the path is a folder or a file inside one.
+# Returns '' for anything that is not there any more, so a stale box does not aim a
+# dialog at a folder that has been deleted.
+function Get-ExistingFolderOf([string]$path) {
+    if ([string]::IsNullOrWhiteSpace($path)) { return '' }
+    $p = $path.Trim()
+    if (Test-Path $p -PathType Container) { return $p }
+    $dir = Split-Path $p -Parent
+    if ($dir -and (Test-Path $dir -PathType Container)) { return $dir }
+    return ''
+}
+
+# Where a FILE picker should open. Same problem the game picker had, and the same
+# answer: an OpenFileDialog with no InitialDirectory opens wherever the shell last
+# left it, which on a machine with a redirected Desktop is somebody's OneDrive - so
+# the icon, background, music and manual pickers all started there.
+#
+# Asked in order:
+#   1. the folder the picker's own box already points at, so reopening a picker
+#      lands where its current value came from;
+#   2. wherever a file was last picked from - artwork, a manual and a soundtrack
+#      for one disc usually live near each other, and this outlives New disc for
+#      the same reason the game picker's memory does;
+#   3. the first game's folder, because GOG's extras are downloaded beside the
+#      installer they belong to.
+# If none of those exist, no aim is better than a wrong one: a SelectedPath that
+# does not exist is ignored silently, which is indistinguishable from not setting
+# it, only harder to notice later.
+function Get-MediaBrowseFallback {
+    $p = Get-ExistingFolderOf $state.LastFileBrowse
+    if ($p) { return $p }
+    $first = Get-FirstGame
+    if ($first -and $first.Folder) { return (Get-ExistingFolderOf ([string]$first.Folder)) }
+    return ''
+}
+
+function New-FileDialog([string]$title, [string]$filter, [string]$current) {
+    $d = New-Object System.Windows.Forms.OpenFileDialog
+    if ($title)  { $d.Title  = $title }
+    if ($filter) { $d.Filter = $filter }
+
+    $start = Get-ExistingFolderOf $current
+    if (-not $start) { $start = Get-MediaBrowseFallback }
+    if ($start) { $d.InitialDirectory = $start }
+    return $d
+}
+
+# Remembers where a file was just taken from, so the next picker opens there.
+function Set-LastFileBrowse([string]$picked) {
+    $dir = Get-ExistingFolderOf (Split-Path $picked -Parent)
+    if ($dir) { $state.LastFileBrowse = $dir }
 }
 
 # --- new / reopen / inspect row ---
@@ -2318,15 +2372,22 @@ function Show-EntryKindDialog([int]$index) {
     $dlg.Controls.Add($btnExt)
 
     $btnMan.Add_Click({
-        $d=New-Object System.Windows.Forms.OpenFileDialog
-        $d.Filter='Manuals|*.pdf;*.txt;*.htm;*.html;*.rtf;*.doc;*.docx|All files|*.*'
-        $d.Title="Pick the manual for this game"
+        # This entry's own folder before the shared fallback, for the same reason as
+        # its extras below.
+        $cur = $txtMan.Text.Trim()
+        if (-not $cur) { $cur = [string]$me.Folder }
+        $d=New-FileDialog "Pick the manual for this game" 'Manuals|*.pdf;*.txt;*.htm;*.html;*.rtf;*.doc;*.docx|All files|*.*' $cur
         if ($txtMan.Text -and (Test-Path $txtMan.Text)) { $d.FileName = $txtMan.Text }
-        if ($d.ShowDialog() -eq 'OK') { $txtMan.Text = $d.FileName }
+        if ($d.ShowDialog() -eq 'OK') { Set-LastFileBrowse $d.FileName; $txtMan.Text = $d.FileName }
         $d.Dispose()
     }.GetNewClosure())
     $btnExt.Add_Click({
-        $d=New-FolderDialog 'Pick a folder of extras for this game' $txtExt.Text.Trim()
+        # This entry's own folder before the shared fallback: a game's extras were
+        # downloaded beside that game, not beside whichever one was touched last.
+        $start = $txtExt.Text.Trim()
+        if (-not $start) { $start = Get-ExistingFolderOf ([string]$me.Folder) }
+        if (-not $start) { $start = Get-MediaBrowseFallback }
+        $d=New-FolderDialog 'Pick a folder of extras for this game' $start
         if ($d.ShowDialog() -eq 'OK') { $txtExt.Text = $d.SelectedPath }
     }.GetNewClosure())
 
@@ -2457,7 +2518,8 @@ function Reset-Form {
     $null = Set-GameEntries @()
     $lblGame.Text = ''; $lblGame.ForeColor = [System.Drawing.Color]::DimGray
 
-    # LastGameBrowse is deliberately NOT reset - see where $state is declared.
+    # LastGameBrowse and LastFileBrowse are deliberately NOT reset - see where
+    # $state is declared.
     $txtLabel.Clear(); $state.LabelSeededFrom = $null
 
     $txtIcon.Clear(); $state.IconPath = $null; $state.IconIsIco = $false
@@ -2696,20 +2758,26 @@ $btnGameEdit.Add_Click({
 $lvGames.Add_SelectedIndexChanged({ Update-GameButtons })
 $lvGames.Add_DoubleClick({ if ($btnGameEdit.Enabled) { $btnGameEdit.PerformClick() } })
 $btnIcon.Add_Click({
-    $d=New-Object System.Windows.Forms.OpenFileDialog; $d.Filter='Images|*.ico;*.png;*.jpg;*.jpeg;*.bmp'
-    if ($d.ShowDialog() -eq 'OK') { Set-IconFile $d.FileName }
+    $d=New-FileDialog 'Pick the disc icon' 'Images|*.ico;*.png;*.jpg;*.jpeg;*.bmp' $txtIcon.Text
+    if ($d.ShowDialog() -eq 'OK') { Set-LastFileBrowse $d.FileName; Set-IconFile $d.FileName }
 })
-$btnBg.Add_Click({ $d=New-Object System.Windows.Forms.OpenFileDialog; $d.Filter='Images|*.png;*.jpg;*.jpeg;*.bmp'; if($d.ShowDialog() -eq 'OK'){ Set-BgFile $d.FileName } })
-$btnMusic.Add_Click({ $d=New-Object System.Windows.Forms.OpenFileDialog; $d.Filter='Audio|*.mp3;*.wav;*.wma'; if($d.ShowDialog() -eq 'OK'){ $txtMusic.Text=$d.FileName; $state.MusicFile=$d.FileName } })
+$btnBg.Add_Click({ $d=New-FileDialog 'Pick the menu background' 'Images|*.png;*.jpg;*.jpeg;*.bmp' $txtBg.Text; if($d.ShowDialog() -eq 'OK'){ Set-LastFileBrowse $d.FileName; Set-BgFile $d.FileName } })
+$btnMusic.Add_Click({ $d=New-FileDialog 'Pick the background music' 'Audio|*.mp3;*.wav;*.wma' $txtMusic.Text; if($d.ShowDialog() -eq 'OK'){ Set-LastFileBrowse $d.FileName; $txtMusic.Text=$d.FileName; $state.MusicFile=$d.FileName } })
 # Manuals are usually PDF but plenty ship as text or HTML, and the menu just
 # shell-executes whatever it is - nothing in the pipeline needs it to be a PDF.
-$btnMan.Add_Click({ $d=New-Object System.Windows.Forms.OpenFileDialog; $d.Filter='Manuals|*.pdf;*.txt;*.htm;*.html;*.rtf;*.doc;*.docx|All files|*.*'; if($d.ShowDialog() -eq 'OK'){ $txtMan.Text=$d.FileName; $state.ManualPath=$d.FileName; Update-MediaLabel } })
-$btnEx.Add_Click({ $d=New-FolderDialog 'Pick a folder of extras to put on the disc' $txtEx.Text.Trim(); if($d.ShowDialog() -eq 'OK'){ $txtEx.Text=$d.SelectedPath; $state.ExtrasPath=$d.SelectedPath; Update-MediaLabel } })
+$btnMan.Add_Click({ $d=New-FileDialog 'Pick the manual for this disc' 'Manuals|*.pdf;*.txt;*.htm;*.html;*.rtf;*.doc;*.docx|All files|*.*' $txtMan.Text; if($d.ShowDialog() -eq 'OK'){ Set-LastFileBrowse $d.FileName; $txtMan.Text=$d.FileName; $state.ManualPath=$d.FileName; Update-MediaLabel } })
+$btnEx.Add_Click({
+    # Folder pickers READ the shared fallback but never write it. Only a file pick
+    # updates it, so choosing an extras folder cannot quietly move where the icon
+    # picker opens next.
+    $start = $txtEx.Text.Trim(); if (-not $start) { $start = Get-MediaBrowseFallback }
+    $d=New-FolderDialog 'Pick a folder of extras to put on the disc' $start
+    if($d.ShowDialog() -eq 'OK'){ $txtEx.Text=$d.SelectedPath; $state.ExtrasPath=$d.SelectedPath; Update-MediaLabel } })
 $btnOut.Add_Click({ $d=New-FolderDialog 'Pick where the disc folder and the ISO get written' $txtOut.Text.Trim(); if($d.ShowDialog() -eq 'OK'){ $txtOut.Text=$d.SelectedPath } })
 $btnXFile.Add_Click({
-    $d=New-Object System.Windows.Forms.OpenFileDialog; $d.Filter='All files|*.*'; $d.Multiselect=$true
-    $d.Title='Pick any files to put on the disc'
-    if($d.ShowDialog() -eq 'OK'){ foreach($fn in $d.FileNames){ Add-ExtraItem $fn } }
+    $d=New-FileDialog 'Pick any files to put on the disc' 'All files|*.*' ''
+    $d.Multiselect=$true
+    if($d.ShowDialog() -eq 'OK'){ Set-LastFileBrowse $d.FileNames[0]; foreach($fn in $d.FileNames){ Add-ExtraItem $fn } }
 })
 $btnXDir.Add_Click({
     $first = Get-FirstGame

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -1762,3 +1762,54 @@ Describe 'Whether the disc label is ours to take back' -Tag 'Unit' {
         Test-LabelIsSeeded '' ''          | Should -BeFalse
     }
 }
+
+Describe 'Aiming the file pickers' -Tag 'Unit' {
+
+    # Same wart the game picker had, on four more dialogs. An OpenFileDialog with no
+    # InitialDirectory opens wherever the shell last left it - on a machine with a
+    # redirected Desktop that is somebody's OneDrive, which is how a username ends
+    # up on screen in a screen recording.
+    #
+    # The click handlers cannot be driven from a test, so the folder-resolving is a
+    # function and the function is what is tested.
+
+    BeforeAll {
+        $script:PickDir  = Join-Path $script:Sandbox 'pickers'
+        $script:PickFile = Join-Path $script:PickDir 'artwork.png'
+        New-Item -ItemType Directory -Force -Path $script:PickDir | Out-Null
+        Set-Content -LiteralPath $script:PickFile -Value 'x' -Encoding Ascii
+    }
+
+    It 'takes the folder a file sits in' {
+        Get-ExistingFolderOf $script:PickFile | Should -Be $script:PickDir
+    }
+
+    It 'takes a folder as itself' {
+        Get-ExistingFolderOf $script:PickDir | Should -Be $script:PickDir
+    }
+
+    It 'falls back one level when the leaf is gone, rather than giving up' {
+        # A box can hold a path to something since deleted - a manual that moved, a
+        # disc folder cleaned out. Landing in the parent puts you next to where you
+        # were, which beats being dropped wherever the shell feels like.
+        Get-ExistingFolderOf (Join-Path $script:Sandbox 'no-such-folder') | Should -Be $script:Sandbox
+    }
+
+    It 'gives up when the parent is gone too' {
+        # Two levels missing leaves nothing sensible to aim at. A dialog pointed at
+        # a folder that does not exist is silently ignored by Windows, which looks
+        # exactly like not aiming it at all, only harder to notice later - so return
+        # nothing and let the caller fall through to the next guess.
+        Get-ExistingFolderOf (Join-Path $script:Sandbox 'no-such-folder\gone.png') | Should -Be ''
+    }
+
+    It 'ignores nothing at all' {
+        Get-ExistingFolderOf ''      | Should -Be ''
+        Get-ExistingFolderOf '   '   | Should -Be ''
+        Get-ExistingFolderOf $null   | Should -Be ''
+    }
+
+    It 'trims, because a pasted path often carries a space' {
+        Get-ExistingFolderOf ("  $($script:PickDir)  ") | Should -Be $script:PickDir
+    }
+}


### PR DESCRIPTION
#18 aimed the **game** picker and left five other dialogs pointing at wherever the shell last was — which on a machine with a OneDrive-redirected Desktop is the user's profile folder. Shipping half the fix while the changelog announced the other half was the wrong place to stop.

## What changed

The **icon, background, music, manual** and **extra files** pickers now ask, in order:

1. the folder their own box already points at,
2. wherever a file was last picked from — which outlives `New disc`, for the same reason the game picker's memory does,
3. the first game's folder, since GOG downloads extras beside the installer they belong to.

A game's *own* manual and extras (in the **Which game?** dialog) start in **that game's** folder rather than whichever entry was touched last.

Only a file pick writes the shared memory. Folder pickers read it and leave it alone, so choosing an extras folder can't quietly move where the icon picker opens next.

## `Get-ExistingFolderOf`

Resolves a box value to a folder, and **falls back one level when the leaf is gone** — a manual that moved leaves you in its old folder rather than wherever the shell feels like. Two levels missing returns nothing and the caller falls through to the next guess: a dialog aimed at a folder that doesn't exist is silently ignored by Windows, which is indistinguishable from no aim at all and harder to notice later.

That one-level fallback wasn't planned — my first test asserted it returned nothing, the test failed, and the behaviour turned out to be the better of the two. It's now pinned deliberately rather than left as an accident.

## Why this was worth doing before the tag

It's not hypothetical. Recording the two README demos, every one of these pickers opened on the Desktop and put the author's account name on screen. Both recordings had to be re-cut to remove it — twice, because the second recording hit the same dialogs again.

## Tests

**238 logic, 46 window** (from 232 / 46).

The click handlers can't be driven from the window suite, so the folder-resolving is a function and that's what's tested. Separately verified against a real `OpenFileDialog` that all five paths through the chain set `InitialDirectory` correctly:

```
nothing known                     -> (empty, shell default)
box has an existing file          -> F:\DWdemo\artwork
box empty, file picked earlier    -> F:\DWdemo\music
box empty, a game on the disc     -> F:\DWdemo\The Witcher
box points at a deleted file      -> F:\DWdemo\artwork
```