### PR TITLE
chore(release): 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ between minor versions.
 
 ## [Unreleased]
 
-## [0.4.0] — 2026-08-21
+## [0.4.0] — 2026-08-23
 
 ### Added
 


### PR DESCRIPTION
Dates the 0.4.0 section for the day it ships. It was written on the 21st when **New disc** was the only thing in it; four more changes and two re-recorded demos landed since.

`$APP_VERSION` is already `0.4.0` and the link refs already point at `v0.4.0`, so this one-line date change is the whole release commit.

## What 0.4.0 contains

**Added** — `New disc`; Play asks which game for a bundle shipping two in one installer (Empire at War Gold Pack).

**Changed** — four buttons in the top row; `Add game...` reopens where a game was last picked from; the icon, background, music, manual and extras pickers are aimed too.

**Fixed** — an add-on's Install button can't run before its game exists; removing the last entry left the disc label and status line behind; `REBUILD ISO` promised to replace a file it never touched.

## Before tagging

`version-matches-tag` fires on the tag push and will check `$APP_VERSION` against it.

The window suite is **not** run by CI and needs a free desktop. It must go green on this tree before the tag — #21 changed what the BUILD/REBUILD button says, and `renames the build button once there is a disc to overwrite` exercises exactly that. It should still pass (the fixture project's label matches its ISO), but "should" is not "does".