### PR TITLE
fix: strip control characters from everything a build writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,49 @@ between minor versions.
 
 ## [Unreleased]
 
+## [0.4.1] — 2026-08-23
+
+### Fixed
+
+- **A project file could put extra directives into `autorun.inf`.** Found by
+  auditing the repo before pointing more people at it. Nobody has reported it, and
+  it is not reachable through the window.
+
+  `New-AutorunInf` wrote the disc label straight into a line-based file, so a label
+  carrying a carriage return did not stay a label:
+
+  ```ini
+  label=My Game
+  open=Extras\payload.exe        <- came from inside the "label"
+  action=Run My Game
+  open=Extras\payload.exe        <- and again, the label is reused here
+  ```
+
+  The label box is a single line and cannot produce this. A `discproject.json` can
+  — and assigning to a single-line text box does **not** strip control characters,
+  so a loaded project carried them all the way to the build. That assumption, "the
+  box is single line so it cannot happen", is what let it through.
+
+  Windows 7 and later will not silently run an `open=` from optical media; it
+  offers it in the AutoPlay prompt. But the wording of that prompt and the file it
+  points at would both have been chosen by whoever wrote the project file, on a
+  disc the person burning it believed was theirs — and project files are meant to
+  travel. This repo suggests attaching one to a bug report.
+
+  Control characters are now stripped by every writer: `autorun.inf`, the menu's
+  JScript strings and the HTML title. They are stripped on load as well, so the box
+  shows the label that will actually be built rather than one thing on screen and
+  another on the disc.
+
+- **A game name containing a newline broke the whole menu.** Same cause, duller
+  consequence: a newline inside a JScript string literal is not a character to
+  encode, it ends the literal — so JScript refused the file and the disc opened to
+  nothing. One bad name took the entire menu with it.
+
+  Quoting was never the problem. `"`, `\`, `<` and `>` were already escaped
+  correctly and the HTA is written as ASCII. It was only the characters that end a
+  line, in both writers.
+
 ## [0.4.0] — 2026-08-23
 
 ### Added
@@ -278,7 +321,8 @@ First public release.
 - `extras/DiscLabel.ps1`, a parked printable disc-face generator, kept out of the app to
   keep the tool to one job.
 
-[Unreleased]: https://github.com/lazardjokovic/discwright/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/lazardjokovic/discwright/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/lazardjokovic/discwright/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/lazardjokovic/discwright/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/lazardjokovic/discwright/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/lazardjokovic/discwright/compare/v0.2.0...v0.3.0

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -61,7 +61,7 @@ $PROJECT_FILE = 'discproject.json'
 # this cannot quietly drift a release behind. Shown in the title bar and the log,
 # and written into every project file - a bug report that comes with a project
 # file then says for itself which version built the disc.
-$APP_VERSION  = '0.4.0'
+$APP_VERSION  = '0.4.1'
 
 # =================== SMALL HELPERS ===================
 
@@ -125,12 +125,24 @@ function Format-Size([double]$bytes) {
 # For text that lands in HTML markup (title, button captions).
 function ConvertTo-HtmlText([string]$s) {
     if ([string]::IsNullOrEmpty($s)) { return '' }
+    # Harmless in HTML, where a newline is just whitespace - stripped anyway so that
+    # every writer in the build treats them the same way. A rule with an exception
+    # is a rule somebody has to remember.
+    $s = Remove-ControlChars $s
+    if ([string]::IsNullOrEmpty($s)) { return '' }
     return ($s -replace '&','&amp;' -replace '<','&lt;' -replace '>','&gt;' -replace '"','&quot;')
 }
 
 # For text that lands inside a JS string literal. HTML entities are NOT decoded
 # inside <script>, so these must be backslash-escaped, not entity-escaped.
 function ConvertTo-JsString([string]$s) {
+    if ([string]::IsNullOrEmpty($s)) { return '' }
+    # Control characters first, and by removal rather than by escaping. A newline
+    # inside a JS string literal is not a character to encode, it is the end of the
+    # literal - JScript treats it as an unterminated string and refuses the whole
+    # file, so one bad name takes the entire menu with it. Nothing in a game name
+    # needs them.
+    $s = Remove-ControlChars $s
     if ([string]::IsNullOrEmpty($s)) { return '' }
     return ($s -replace '\\','\\' -replace '"','\"' -replace '<','\x3c' -replace '>','\x3e')
 }
@@ -605,6 +617,34 @@ function New-Background([string]$imgPath,[string]$title,[string]$outPng,[string]
     $g.Dispose(); Save-PngAtomic $bmp $outPng; $bmp.Dispose()
 }
 
+# Control characters, gone. Everything a build writes goes into a line-based or a
+# quoted format - autorun.inf is one directive per line, the menu's JScript puts
+# names inside string literals - so a stray CR or LF does not corrupt the text, it
+# ends the line and starts a new one.
+#
+# In autorun.inf that means a label carrying a newline writes further directives:
+#
+#     label=My Game
+#     open=Extras\payload.exe        <- came from inside the "label"
+#
+# Windows 7 and later will not silently run an open= from optical media; it offers
+# it in the AutoPlay prompt. But the wording of that prompt and what it points at
+# would both be chosen by whoever wrote the project file, on a disc the person
+# burning it believed was theirs. Project files do get passed around - this repo's
+# own README suggests attaching one to a bug report.
+#
+# In the menu's JScript a newline is an unterminated string literal, so the whole
+# HTA fails to parse and the disc opens to nothing.
+#
+# This is not a restriction on what may be typed. The label box is single line and
+# the UI cannot produce these. It is a filter on what a FILE may carry: assigning
+# to a single-line TextBox does not strip them, which is exactly the path a loaded
+# project takes to reach the build.
+function Remove-ControlChars([string]$s) {
+    if ([string]::IsNullOrEmpty($s)) { return $s }
+    return ($s -replace '[\x00-\x1F\x7F]','')
+}
+
 # What a label will actually look like once it has been through autorun.inf.
 # AutoRun reads the file in the system ANSI codepage - it has no Unicode mode at
 # all - so this is a property of Windows, not something the tool can fix. Returns
@@ -617,6 +657,10 @@ function Get-AutorunLabelPreview([string]$label) {
 }
 
 function New-AutorunInf([string]$label,[string]$iconName,[bool]$menu,[string]$out) {
+    # Stripped here rather than only at the call site: this function is what turns
+    # text into directives, so it is the last place that can be sure.
+    $label    = Remove-ControlChars $label
+    $iconName = Remove-ControlChars $iconName
     $lines = @('[autorun]')
     if ($menu) { $lines += 'shellexecute=AUTORUN\menu.hta' }
     $lines += "icon=$iconName"
@@ -2632,7 +2676,12 @@ function Open-Project([string]$folder) {
 
     # A label out of a project file is the user's, whatever it says - so no seed
     # marker. Removing the last game must not take it away.
-    $txtLabel.Text = $p.Label; $state.LabelSeededFrom = $null
+    #
+    # Cleaned on the way in as well as on the way out, so the box shows the label
+    # that will actually be built. The writers strip control characters regardless;
+    # doing it here too means a poisoned project file cannot present one thing in
+    # the window and put another on the disc.
+    $txtLabel.Text = Remove-ControlChars $p.Label; $state.LabelSeededFrom = $null
     if ($p.IconPath -and (Test-Path $p.IconPath)) { Set-IconFile $p.IconPath } else { & $log "  icon missing - pick one again." }
 
     $chkMenu.Checked = $p.Menu

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -1877,3 +1877,69 @@ Describe 'Whether BUILD is about to overwrite anything' -Tag 'Unit' {
         Test-AlreadyBuilt (Join-Path $script:Sandbox 'never-made') 'ALAN WAKE' | Should -BeFalse
     }
 }
+
+Describe 'Control characters cannot escape into what a disc carries' -Tag 'Unit' {
+
+    # Everything the build writes is line-based or quoted. autorun.inf is one
+    # directive per line; the menu's JScript puts names inside string literals. So a
+    # CR or LF does not corrupt the text - it ends the line and starts a new one.
+    #
+    # The UI cannot produce one: the label box is single line. A project file can,
+    # and assigning to a single-line TextBox does NOT strip them, which is the exact
+    # path a loaded project takes to reach the build. That assumption - "the box is
+    # single line, so it cannot happen" - is what let this through in the first
+    # place.
+
+    It 'strips the characters that end a line' {
+        Remove-ControlChars ("a" + [char]13 + [char]10 + "b") | Should -Be 'ab'
+        Remove-ControlChars ("a" + [char]9  + "b")            | Should -Be 'ab'
+        Remove-ControlChars ("a" + [char]0  + "b")            | Should -Be 'ab'
+        Remove-ControlChars ("a" + [char]27 + "b")            | Should -Be 'ab'
+        Remove-ControlChars ("a" + [char]127 + "b")           | Should -Be 'ab'
+    }
+
+    It 'leaves everything a real disc label needs' {
+        # Accents and typographic dashes are all over GOG titles and must survive.
+        Remove-ControlChars 'The Witcher - Enhanced Edition' | Should -Be 'The Witcher - Enhanced Edition'
+        Remove-ControlChars 'Uber Alles'                     | Should -Be 'Uber Alles'
+        Remove-ControlChars 'STAR WARS: Empire at War'       | Should -Be 'STAR WARS: Empire at War'
+    }
+
+    It 'survives nothing at all' {
+        Remove-ControlChars ''    | Should -Be ''
+        Remove-ControlChars $null | Should -BeNullOrEmpty
+    }
+
+    It 'writes no extra directive when the label carries a newline' {
+        # The proof. Before this, "label=<newline>open=..." wrote open= as a
+        # directive of its own - twice, because the label is also used for
+        # action=Run.
+        $out = Join-Path $script:Sandbox 'poisoned-autorun.inf'
+        New-AutorunInf ("My Game" + [char]13 + [char]10 + "open=Extras\payload.exe") 'game.ico' $true $out
+        $txt = Get-Content -LiteralPath $out -Raw
+        $txt | Should -Not -Match '(?m)^open='
+        # Compared as whole lines, not by regex. The payload is full of backslashes
+        # and dots, and a pattern that has to escape them is a pattern that can be
+        # wrong in a way the test cannot see - which is exactly what happened on the
+        # first attempt at this test.
+        $lines = @($txt -split "`r`n")
+        $lines | Should -Contain 'label=My Gameopen=Extras\payload.exe'
+        $lines | Should -Contain 'action=Run My Gameopen=Extras\payload.exe'
+        @($lines | Where-Object { $_ -eq '[autorun]' }).Count | Should -Be 1
+    }
+
+    It 'keeps the menu parsable when a name carries a newline' {
+        # A newline inside a JS string literal is not a character to encode, it is
+        # the end of the literal - JScript rejects the whole file, so one bad name
+        # would take the entire menu with it.
+        $js = ConvertTo-JsString ("Hollow" + [char]13 + [char]10 + "Knight")
+        $js | Should -Be 'HollowKnight'
+        $js | Should -Not -Match "[`r`n]"
+    }
+
+    It 'still escapes the characters that matter, unchanged' {
+        # The stripping is additive - it must not have loosened anything.
+        ConvertTo-JsString 'He said "hi" \ <script>' | Should -Be 'He said \"hi\" \\ \x3cscript\x3e'
+        ConvertTo-HtmlText '<b>&"'                   | Should -Be '&lt;b&gt;&amp;&quot;'
+    }
+}


### PR DESCRIPTION
Found auditing the repo before pointing more people at it. **Not reported by anyone, and not reachable through the window.**

## What could happen

`New-AutorunInf` wrote the disc label straight into a line-based file. A label carrying a carriage return therefore stopped being a label:

```ini
label=My Game
open=Extras\payload.exe        <- came from inside the "label"
action=Run My Game
open=Extras\payload.exe        <- and again, the label is reused here
```

The label box is single line and cannot produce this. A `discproject.json` can — and **assigning to a single-line TextBox does not strip control characters**, so a loaded project carried them all the way to the build.

That last point is the whole bug. I assumed the opposite ("the box is single line, so it can't happen"), tested the assumption rather than shipping it, and the test disagreed with me.

## Severity: low, not nil

Windows 7 and later will not silently run an `open=` from optical media — it offers it in the AutoPlay prompt. But the wording of that prompt and the file it points at would both belong to whoever wrote the project file, on a disc the person burning it believed was theirs. Project files are meant to travel; this repo's README suggests attaching one to a bug report.

## Same cause, duller consequence

A newline in a game name lands inside a JScript string literal, where it isn't a character to encode — it ends the literal. JScript then refuses the whole file and the disc opens to nothing. One bad name took the entire menu with it.

## What was already correct

Quoting. `"`, `\`, `<` and `>` were escaped properly (`He said \"hi\" \ \x3cscript\x3e`) and the HTA is written as ASCII, which closes the injection paths that matter. It was only the characters that end a line, in both writers.

`Remove-ControlChars` now runs in `New-AutorunInf`, `ConvertTo-JsString` and `ConvertTo-HtmlText` — and on project load, so the box cannot show one label while the disc carries another.

## Tests

**252 logic, 46 window** (from 246 / 46). Both proof-of-concepts re-run against the fix:

```
autorun.inf   contains an injected open= line?  False
JScript       {n:"foobar"}  - valid literal
```

One test-authoring note: my first version of the autorun assertion used a regex full of escaped backslashes, and a backslash was lost in transit — the pattern silently became invalid rather than wrong. It now compares whole lines instead, because a pattern that has to escape its own payload is a pattern that can be wrong in a way the test cannot see.