### PR TITLE
feat: pack several games onto a set of discs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,50 @@ between minor versions.
 
 ## [Unreleased]
 
+### Added
+
+- **A disc set, when the games do not fit on one disc.** Step 2 has a new
+  **Target disc** dropdown. Leave it on *Fit on one disc* and nothing changes:
+  DiscWright recommends a size and builds exactly one ISO, byte for byte as
+  before. Choose the disc you actually own — CD-R through BD-R XL — and it packs
+  the games onto as many discs as it takes.
+
+  Each disc in a set is a complete disc in its own right: its own icon, its own
+  menu, its own label. `WITCHER + HK D1`, `WITCHER + HK D2`, one ISO each. There
+  is no disc 2 that only makes sense with disc 1 in the drawer.
+
+  **The order on the form is the order on the discs.** A packer that reordered
+  games to save a disc would produce a set whose disc 2 holds the game you put
+  first, and the menu numbers follow the list. Saving one disc is worth less than
+  a set that matches what is on screen.
+
+  **A game and its add-ons always travel together.** An add-on knows which game it
+  belongs to by that game's position in the list, so a patch stranded on the next
+  disc would come out as a game of its own in the menu.
+
+  **The disc-wide manual and extras ride on disc 1 only.** Copying them onto every
+  disc would multiply gigabytes of bonus content by the size of the set. A game's
+  own manual and extras go wherever that game goes.
+
+  The volume id gets the disc number reserved before the name is truncated: at 16
+  characters, `THE WITCHER ENHANCED EDITION D2` would otherwise cut back to the
+  same id as disc 1, and Windows would show two discs with the same name.
+
+### Changed
+
+- **A payload too big for any single disc no longer just refuses.** It says to
+  pick the disc you are going to burn, because that is now an answer.
+- The project file is at schema 5, which records the target disc. Anything older
+  reads back as *Fit on one disc*, which is what those projects always were.
+
+### Still not handled
+
+- **One game bigger than one disc.** Spreading a single installer's `.bin` parts
+  across a set is a different problem: GOG's installer asks for the next part
+  itself, which makes a real "insert disc 2" possible, and that is worth doing
+  properly rather than bolting on. Until then, a set is refused with the name of
+  the game that will not fit.
+
 ## [0.4.1] — 2026-08-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,10 +38,28 @@ between minor versions.
   characters, `THE WITCHER ENHANCED EDITION D2` would otherwise cut back to the
   same id as disc 1, and Windows would show two discs with the same name.
 
+- **The menu names the game whose screen you are on.** A one-game disc used to go
+  straight to Play and Install with nothing anywhere saying which game they
+  belonged to — fine when there was one disc and the drive label told you, useless
+  across a set where every disc shares an icon and a background. The chooser had
+  the same gap: it lists the games, but the screen you land on after picking one
+  did not name it.
+
+  A disc that belongs to a set also says which one it is, under the game's name.
+  The caption is measured rather than assumed, so the existing shrink-to-fit rule
+  keeps a crowded screen inside the window.
+
 ### Changed
 
 - **A payload too big for any single disc no longer just refuses.** It says to
   pick the disc you are going to burn, because that is now an answer.
+- **A refusal says how big the offending game is.** *"Alan Wake alone is bigger
+  than a DVD5"* sat on a line beginning *"2 games (8.94 GB)"* and read as though
+  the 8.94 was the figure that would not fit. It now reads *"Alan Wake is 7.79 GB
+  on its own, too big for a DVD5 4.7 GB"*.
+- **The progress line says which disc of the set is being written.** A set runs
+  the bar from nothing to full once per disc, and with nothing naming the disc the
+  second pass read as the first one having started over.
 - The project file is at schema 5, which records the target disc. Anything older
   reads back as *Fit on one disc*, which is what those projects always were.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ between minor versions.
   characters, `THE WITCHER ENHANCED EDITION D2` would otherwise cut back to the
   same id as disc 1, and Windows would show two discs with the same name.
 
+- **"Also put the manual and extras on every disc of a set"**, under the extra
+  content list. Off by default, which keeps the disc-wide manual, Extras folder and
+  loose files on disc 1 alone: copying a 2 GB extras folder onto a five-disc set
+  costs ten. That is the right call for a making-of video and the wrong one for a
+  3 MB PDF, and no single rule covers both — so it is a choice rather than a
+  decision made for you. Greyed out when there is nothing disc-wide to carry.
+
+  A game's **own** manual and extras always travel with that game, on whichever
+  disc it lands, and are unaffected either way.
+
 - **Every row of the target-disc list says what it would cost.** *CD-R 700 MB - will
   not fit*, *DVD9 8.5 GB (dual layer) - 2 discs*, *BD-R 25 GB - 1 disc*. The list is
   where "which disc should I use" gets asked, so it is where the answer belongs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,13 @@ between minor versions.
   `DVD9 8.5 GB (dual layer)`), the label is 15px wider, and it ends a line it cannot
   fit with an ellipsis rather than a half-word, with the whole line on the tooltip.
   The dropdown keeps the full names — a row has the width to itself.
+- **The BUILD button knows about the whole set.** It asked whether `RETRO NIGHT.iso`
+  existed — a name a set never writes — so a folder holding the finished set still
+  read *BUILD ISO*, and the tooltip promised to write a file that would never appear.
+  It now reads *REBUILD ISO* when any disc of the set is already there, and says how
+  many: *"Rebuild the set - 2 of 2 already there"*. The button and the confirmation
+  dialog now work this out through one shared function, which is why they had drifted
+  apart in the first place.
 - **The progress line says which disc of the set is being written.** A set runs
   the bar from nothing to full once per disc, and with nothing naming the disc the
   second pass read as the first one having started over.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,13 @@ between minor versions.
   A game's **own** manual and extras always travel with that game, on whichever
   disc it lands, and are unaffected either way.
 
+  **The form says where they land**, since the option sits in step 5 and governs
+  step 4 as well. Once the build becomes a set, the two labels in step 4 read
+  *Manual file (disc 1)* and *Extras folder (disc 1)*, and step 5's heading reads
+  *copied to disc 1 of the set*. They go back to their plain wording on a single
+  disc, and when the option is ticked — the checkbox says so in words directly
+  underneath, and repeating it three times is noise.
+
 - **Every row of the target-disc list says what it would cost.** *CD-R 700 MB - will
   not fit*, *DVD9 8.5 GB (dual layer) - 2 discs*, *BD-R 25 GB - 1 disc*. The list is
   where "which disc should I use" gets asked, so it is where the answer belongs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,12 @@ between minor versions.
   than a DVD5"* sat on a line beginning *"2 games (8.94 GB)"* and read as though
   the 8.94 was the figure that would not fit. It now reads *"Alan Wake is 7.79 GB
   on its own, too big for a DVD5 4.7 GB"*.
+- **The advice line no longer runs off its own end.** A refusal naming a long game
+  measured 642px against a 640px label and lost its last word — *"too big for a DVD9
+  8.5 GB (dual"*. Prose now uses the short form of each medium (`DVD9 8.5 GB`, not
+  `DVD9 8.5 GB (dual layer)`), the label is 15px wider, and it ends a line it cannot
+  fit with an ellipsis rather than a half-word, with the whole line on the tooltip.
+  The dropdown keeps the full names — a row has the width to itself.
 - **The progress line says which disc of the set is being written.** A set runs
   the bar from nothing to full once per disc, and with nothing naming the disc the
   second pass read as the first one having started over.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,17 @@ between minor versions.
   characters, `THE WITCHER ENHANCED EDITION D2` would otherwise cut back to the
   same id as disc 1, and Windows would show two discs with the same name.
 
+- **Every row of the target-disc list says what it would cost.** *CD-R 700 MB - will
+  not fit*, *DVD9 8.5 GB (dual layer) - 2 discs*, *BD-R 25 GB - 1 disc*. The list is
+  where "which disc should I use" gets asked, so it is where the answer belongs.
+
+  Rows that cannot work are **not** greyed out, deliberately. The total on the form
+  is the wrong test — a set exists precisely so that twenty gigabytes can go on five
+  DVDs — and what actually rules a medium out is the largest single game plus its
+  add-ons. More to the point, a disabled row explains nothing, while selecting one
+  names the game that will not fit and how big it is. An empty form annotates
+  nothing, since there is no plan to report.
+
 - **The menu names the game whose screen you are on.** A one-game disc used to go
   straight to Play and Install with nothing anywhere saying which game they
   belonged to — fine when there was one disc and the drive label told you, useless

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -419,9 +419,12 @@ function Get-DiscPlan([array]$entries, [string]$mediaKey, [double]$overhead, [do
     if (-not $r.Ok) {
         # Name the game rather than the group index. "Group 2 is too big" is a
         # sentence about the packer; the user needs the sentence about the disc.
-        $nm = ''
-        if ($r.Reason -eq 'entry' -and $r.TooBig -ge 0) { $nm = [string]$entries[$groups[$r.TooBig][0]].GameName }
-        return @{ Ok=$false; Reason=$r.Reason; Discs=@(); Capacity=$cap; TooBigName=$nm; Room=$r.Room }
+        $nm = ''; $nb = [double]0
+        if ($r.Reason -eq 'entry' -and $r.TooBig -ge 0) {
+            $nm = [string]$entries[$groups[$r.TooBig][0]].GameName
+            $nb = [double]$sizes[$r.TooBig]
+        }
+        return @{ Ok=$false; Reason=$r.Reason; Discs=@(); Capacity=$cap; TooBigName=$nm; TooBigBytes=$nb; Room=$r.Room }
     }
 
     $discs = @()
@@ -430,7 +433,7 @@ function Get-DiscPlan([array]$entries, [string]$mediaKey, [double]$overhead, [do
         foreach ($gi in $d) { foreach ($e in $groups[$gi]) { $idx += $e } }
         $discs += ,@($idx)
     }
-    return @{ Ok=$true; Reason=''; Discs=$discs; Capacity=$cap; TooBigName=''; Room=$r.Room }
+    return @{ Ok=$true; Reason=''; Discs=$discs; Capacity=$cap; TooBigName=''; TooBigBytes=[double]0; Room=$r.Room }
 }
 
 # How the plan reads on the line under the installer list, and in the dialog that
@@ -440,7 +443,11 @@ function Get-DiscPlanText([hashtable]$plan, [string]$mediaKey) {
     $name = Get-MediaNameFromKey $mediaKey
     if (-not $plan.Ok) {
         switch ($plan.Reason) {
-            'entry'  { return ("$($plan.TooBigName) alone is bigger than a $name") }
+            # The game's OWN size, not the total on the form. "Alan Wake alone is
+            # bigger than a DVD5" sat on a line beginning "2 games (8.94 GB)", and
+            # read as though the 8.94 was what would not fit. Naming the figure
+            # that is actually too big settles it in the same breath.
+            'entry'  { return ("{0} is {1:N2} GB on its own, too big for a {2}" -f $plan.TooBigName, ([double]$plan.TooBigBytes/1GB), $name) }
             'extras' { return ("the extra content alone is bigger than a $name") }
             default  { return ("cannot be split onto $name") }
         }
@@ -953,6 +960,13 @@ function New-MenuHta([hashtable]$cfg,[string]$out) {
   #mute{position:absolute;right:44px;top:8px;width:28px;height:26px;line-height:26px;text-align:center;color:#e6ebef;
     font-family:'Segoe UI',Arial;font-size:15px;background:#0a1519;border:1px solid #16545a;cursor:pointer;display:none;}
   #mute:hover{color:#fff;border-color:#00bec8;}
+  /* The caption above the buttons: which game this screen is for, and which disc
+     of the set you are holding. Same nowrap+ellipsis rule as the buttons - game
+     names are user data and a long one must not push the panel around. */
+  #cap{width:250px;margin:0 0 10px 0;font-family:'Segoe UI',Arial;}
+  #cap .capn{display:block;font-size:17px;font-weight:600;letter-spacing:1px;text-transform:uppercase;
+    color:#dfe9ee;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+  #cap .capd{display:block;font-size:12px;letter-spacing:2px;color:#8fa5ad;margin-top:3px;}
   #status{position:absolute;left:%%PANELLEFT%%px;bottom:18px;width:250px;text-align:center;display:none;
     color:#9fb3ba;font-size:12px;line-height:17px;}
 </style>
@@ -964,6 +978,7 @@ function New-MenuHta([hashtable]$cfg,[string]$out) {
   var BTNS=%%BTNS%%;         // which of Play/Install/Manual/Extras/Exit the disc was built with
   var MANUAL="%%MANUAL%%"; var MUSIC="%%MUSIC%%";
   var PREVIEW=%%PREVIEW%%;   // true only for the app's Preview - see refreshButtons
+  var DISCNUM=%%DISCNUM%%, DISCOF=%%DISCOF%%;   // 1 and 1 unless this disc is part of a set
   // Which screen is showing: -1 is the game chooser, otherwise an index into GAMES.
   // A disc holding one game has nothing to choose, so it opens on that game and
   // never shows a Back button.
@@ -1079,14 +1094,27 @@ function New-MenuHta([hashtable]$cfg,[string]$out) {
   }
   // The panel is centred on however many buttons this screen happens to have, so
   // a three-game chooser and a six-button game screen both sit in the middle.
-  function setPanel(h){
+  // "Disc 2 of 3", or nothing at all on a disc that is not part of a set.
+  function discLine(){ return DISCOF>1 ? '<span class="capd">Disc '+DISCNUM+' of '+DISCOF+'</span>' : ''; }
+  // Game names arrive already escaped for a JS string literal, which turns "<"
+  // into < - so they cannot open a tag when they land in innerHTML here.
+  function capFor(name){
+    var d=discLine();
+    if(!name && !d) return "";
+    return (name ? '<span class="capn">'+name+'</span>' : '') + d;
+  }
+  function setPanel(h,cap){
     var p=document.getElementById("pan");
-    p.innerHTML=h;
+    p.innerHTML=(cap ? '<div id="cap">'+cap+'</div>' : '')+h;
+    var c=document.getElementById("cap");
+    // Measured rather than assumed: the caption is one line or two depending on
+    // whether this disc belongs to a set.
+    var capH=c ? c.offsetHeight+10 : 0;
     var a=p.getElementsByTagName("A"), n=a.length;
     // 46px buttons with 12px between them fill a 480px window at eight, and a
     // game with four add-ons already needs eight. Rather than let the ninth draw
     // off the bottom edge where nothing can reach it, the buttons shrink to fit.
-    var bh=46, gap=12, avail=440;
+    var bh=46, gap=12, avail=440-capH;
     if(n*bh+(n-1)*gap > avail){
       gap = 8;
       bh = Math.floor((avail-(n-1)*gap)/n);
@@ -1096,7 +1124,7 @@ function New-MenuHta([hashtable]$cfg,[string]$out) {
         a[i].style.height=bh+"px"; a[i].style.lineHeight=bh+"px"; a[i].style.marginBottom=gap+"px";
       }
     }
-    var block=n*bh+(n-1)*gap, t=Math.floor((480-block)/2);
+    var block=capH+n*bh+(n-1)*gap, t=Math.floor((480-block)/2);
     if(t<10) t=10;
     p.style.top=t+"px";
     setupHover();
@@ -1106,7 +1134,8 @@ function New-MenuHta([hashtable]$cfg,[string]$out) {
     var h="";
     for(var i=0;i<GAMES.length;i++){ h+=btnHtml("btn_game_"+i,"play",GAMES[i].n,"pick("+i+")",GAMES[i].n); }
     if(has("Exit")) h+=btnHtml("btn_Exit","exit","Exit","doExit()","");
-    setPanel(h);
+    // The chooser lists the games itself, so it needs only the disc line.
+    setPanel(h,capFor(""));
   }
   function renderGame(){
     var g=GAMES[cur], h="";
@@ -1123,7 +1152,7 @@ function New-MenuHta([hashtable]$cfg,[string]$out) {
     if(has("Extras"))  h+=btnHtml("btn_Extras","","Extras","doExtras()","");
     if(GAMES.length>1) h+=btnHtml("btn_Back","","Back","goBack()","Back to the game list");
     if(has("Exit"))    h+=btnHtml("btn_Exit","exit","Exit","doExit()","");
-    setPanel(h);
+    setPanel(h,capFor(g.n));
   }
   function show(){ if(tasks) renderTasks(); else if(cur<0) renderChooser(); else renderGame(); }
   function pick(i){ cur=i; show(); }
@@ -1285,7 +1314,7 @@ function New-MenuHta([hashtable]$cfg,[string]$out) {
     for(var i=0;i<tasks.length;i++){ h+=btnHtml("btn_task_"+i,"play",tasks[i].n,"playTask("+i+")",tasks[i].n); }
     h+=btnHtml("btn_TaskBack","","Back","tasksBack()","Back to "+GAMES[cur].n);
     if(has("Exit")) h+=btnHtml("btn_Exit","exit","Exit","doExit()","");
-    setPanel(h);
+    setPanel(h,capFor(GAMES[cur].n));
   }
   function playTask(i){ var t=tasks[i]; launchExe(t.p,t.a,t.w); }
   function tasksBack(){ tasks=null; show(); }
@@ -1335,6 +1364,8 @@ function New-MenuHta([hashtable]$cfg,[string]$out) {
                  Replace('%%BTNBORDER%%',$btnBorder).
                  Replace('%%TITLE%%',(ConvertTo-HtmlText $cfg.GameName)).
                  Replace('%%PANELLEFT%%',"$panelLeft").
+                 Replace('%%DISCNUM%%',"$([int]$(if($cfg.DiscNum){$cfg.DiscNum}else{1}))").
+                 Replace('%%DISCOF%%', "$([int]$(if($cfg.DiscOf){$cfg.DiscOf}else{1}))").
                  Replace('%%GAMES%%',$gamesJs).
                  Replace('%%BTNS%%',$btnsJs).
                  Replace('%%MANUAL%%',(ConvertTo-JsString $cfg.ManualFile)).
@@ -1555,6 +1586,9 @@ function Import-Project([string]$jsonPath) {
             WindowBorder=[bool]$j.WindowBorder
             ButtonStyle=$(if($j.ButtonStyle){$j.ButtonStyle}else{'Bordered'})
             MusicFile=$j.MusicFile; Buttons=@($j.Buttons); ManualPath=$j.ManualPath; ExtrasPath=$j.ExtrasPath
+            # Version 5. Absent in anything older, which is the automatic setting -
+            # and the automatic setting is what those projects always described.
+            MediaKey=$(if ($j.PSObject.Properties.Name -contains 'MediaKey') { [string]$j.MediaKey } else { '' })
             ExtraItems=@($j.ExtraItems); OutDir=$j.OutDir; Origin='project file'
         }
     } catch { return $null }
@@ -1821,7 +1855,8 @@ function Invoke-Build([hashtable]$s, [scriptblock]$log, [scriptblock]$progress=$
         }
         New-MenuHta @{ GameName=$s.Label; Games=$menuGames; Buttons=$s.Buttons;
                        MusicFile=$musicName; ManualFile=$manualName; PanelSide=$s.PanelSide; IconName=$icoName
-                       WindowBorder=[bool]$s.WindowBorder; ButtonStyle=$s.ButtonStyle } (Join-Path $stage 'AUTORUN\menu.hta')
+                       WindowBorder=[bool]$s.WindowBorder; ButtonStyle=$s.ButtonStyle
+                       DiscNum=$(if($s.DiscNum){[int]$s.DiscNum}else{1}); DiscOf=$(if($s.DiscOf){[int]$s.DiscOf}else{1}) } (Join-Path $stage 'AUTORUN\menu.hta')
     }
 
     # extra content - copied to the disc root, keeping its own name
@@ -1869,7 +1904,7 @@ function Invoke-Build([hashtable]$s, [scriptblock]$log, [scriptblock]$progress=$
 # Builds every disc the plan calls for, one after another, and returns the ISOs.
 # A plan of one disc goes straight through to Invoke-Build unchanged - a single
 # disc must come out byte for byte the way it always has, label and all.
-function Invoke-BuildSet([hashtable]$s, [scriptblock]$log, [scriptblock]$progress=$null) {
+function Invoke-BuildSet([hashtable]$s, [scriptblock]$log, [scriptblock]$progress=$null, [scriptblock]$onDisc=$null) {
     $plan = $s.Plan
     # Returned as a plain array, not the ",@()" wrapper used for values that get
     # assigned straight across: every caller here wraps the result in @(), and a
@@ -1883,6 +1918,7 @@ function Invoke-BuildSet([hashtable]$s, [scriptblock]$log, [scriptblock]$progres
     $isos = @()
     for ($d = 0; $d -lt $n; $d++) {
         $num = $d + 1
+        if ($onDisc) { & $onDisc $num $n }
         & $log ''
         & $log "===== Disc $num of $n ====="
         $ds = @{}
@@ -1891,6 +1927,8 @@ function Invoke-BuildSet([hashtable]$s, [scriptblock]$log, [scriptblock]$progres
         $ds.Label       = Get-DiscSetLabel $s.Label $num $n
         $ds.VolumeLabel = Get-VolumeLabel  $s.Label $num $n
         $ds.SkipProject = $true
+        $ds.DiscNum     = $num
+        $ds.DiscOf      = $n
         # The disc-wide manual, extras and loose files ride on disc 1 alone.
         # Copying them onto every disc would multiply gigabytes of bonus content
         # by the size of the set, which is nobody's idea of "extras on the disc".
@@ -2178,10 +2216,17 @@ $pbBuild=New-Object System.Windows.Forms.ProgressBar; $pbBuild.Location=New-Obje
 $lblElapsed=New-Object System.Windows.Forms.Label; $lblElapsed.Location=New-Object System.Drawing.Point(15,914); $lblElapsed.Size=New-Object System.Drawing.Size(160,20); $lblElapsed.ForeColor=[System.Drawing.Color]::DimGray; $form.Controls.Add($lblElapsed)
 
 $buildWatch = New-Object System.Diagnostics.Stopwatch
+# Prefixed onto the elapsed line while a set builds. A set runs the progress bar
+# from 0 to 100 once per disc, and with nothing saying which disc that was, the
+# second pass reads as the first one having restarted.
+$script:BuildDiscTag = ''
 
 $log = { param($m)
     $txtLog.AppendText($m + "`r`n")
-    if ($buildWatch.IsRunning) { $lblElapsed.Text = 'Elapsed  ' + (Format-Elapsed $buildWatch.Elapsed) }
+    if ($buildWatch.IsRunning) {
+        $lblElapsed.Text = $(if ($script:BuildDiscTag) { $script:BuildDiscTag + '  ' + (Format-Elapsed $buildWatch.Elapsed) }
+                             else                     { 'Elapsed  ' + (Format-Elapsed $buildWatch.Elapsed) })
+    }
     [System.Windows.Forms.Application]::DoEvents()
 }
 
@@ -2193,7 +2238,11 @@ $buildProgress = { param($done,$total)
     if ($total -gt 0) {
         $v = [int](1000.0 * $done / $total); if ($v -gt 1000) { $v = 1000 }
         $pbBuild.Value = $v
-        $lblElapsed.Text = 'ISO  {0}%   {1}' -f [int]($v/10), (Format-Elapsed $buildWatch.Elapsed)
+        # The label has 160px before it runs under the log box, so the disc tag
+        # replaces the word ISO rather than being added in front of it: a set
+        # shows "D1/2  45%  0:32" in the same width "ISO  45%   0:32" needed.
+        $lblElapsed.Text = $(if ($script:BuildDiscTag) { '{0}  {1}%   {2}' -f $script:BuildDiscTag, [int]($v/10), (Format-Elapsed $buildWatch.Elapsed) }
+                             else                     { 'ISO  {0}%   {1}'  -f [int]($v/10), (Format-Elapsed $buildWatch.Elapsed) })
     }
     [System.Windows.Forms.Application]::DoEvents()
 }
@@ -2998,8 +3047,12 @@ function Open-Project([string]$folder) {
     # A project written before target discs existed has no MediaKey, and a key
     # this build does not recognise is not worth guessing at either: both fall
     # back to the automatic setting rather than silently planning a set.
-    $mk = ''
-    if ($p.PSObject.Properties.Name -contains 'MediaKey') { $mk = [string]$p.MediaKey }
+    #
+    # ContainsKey, not PSObject.Properties: Import-Project hands back a HASHTABLE.
+    # A hashtable's keys are not PSObject properties, so the property test read
+    # false for every project ever saved and the target disc was silently dropped
+    # on reopen. Found by hand-testing the round trip, which no test covered.
+    $mk = $(if ($p.ContainsKey('MediaKey')) { [string]$p.MediaKey } else { '' })
     $cmbMedia.SelectedItem = $(if ($mk -and (Get-MediaCapacity $mk) -gt 0) { Get-MediaNameFromKey $mk } else { Get-MediaAutoText })
     if ($p.IconPath -and (Test-Path $p.IconPath)) { Set-IconFile $p.IconPath } else { & $log "  icon missing - pick one again." }
 
@@ -3272,9 +3325,8 @@ $btnBuild.Add_Click({
         # payload past the biggest disc there is, and it needs its own sentence.
         $mName = Get-MediaNameFromKey $mediaKey
         $why   = switch ($plan.Reason) {
-            'entry'  { ("{0} on its own is {1:N1} GB, and a {2} holds {3:N1} GB." -f $plan.TooBigName,
-                        (($(Get-Games) | Where-Object { $_.GameName -eq $plan.TooBigName } | Select-Object -First 1).TotalBytes/1GB),
-                        $mName, ($plan.Room/1GB)) +
+            'entry'  { ("{0} on its own is {1:N2} GB, and a {2} holds {3:N2} GB." -f $plan.TooBigName,
+                        ([double]$plan.TooBigBytes/1GB), $mName, ($plan.Room/1GB)) +
                        "`r`n`r`nSpreading one game's installer across several discs is not something DiscWright can do yet. Choose a larger disc in step 2, or leave that game off this set." }
             'extras' { "The extra content in step 5 is bigger than one $mName on its own, before any game is added.`r`n`r`nRemove some of it, or choose a larger disc." }
             default  { "This set cannot be planned for a $mName." }
@@ -3372,20 +3424,27 @@ $btnBuild.Add_Click({
          Buttons=$buttons; ManualPath=$(if($cbMan.Checked){$state.ManualPath}else{$null}); ExtrasPath=$(if($cbExtra.Checked){$state.ExtrasPath}else{$null});
          ExtraItems=@($lstExtra.Items); OutDir=$txtOut.Text.Trim(); MediaKey=$mediaKey; Plan=$plan }
     $btnBuild.Enabled=$false
+    $script:BuildDiscTag = ''
     $pbBuild.Value=0; $pbBuild.Visible=$true
     $buildWatch.Restart()
     $lblElapsed.Text='Starting...'
     try {
-        $isos = @(Invoke-BuildSet $s $log $buildProgress)
+        $onDisc = { param($num,$of)
+            $script:BuildDiscTag = "D$num/$of"
+            $pbBuild.Value = 0
+            [System.Windows.Forms.Application]::DoEvents()
+        }
+        $isos = @(Invoke-BuildSet $s $log $buildProgress $onDisc)
         $buildWatch.Stop()
         $took = Format-Elapsed $buildWatch.Elapsed
-        $lblElapsed.Text = "Done in $took"
+        $script:BuildDiscTag = ''
+        $lblElapsed.Text = $(if ($isos.Count -gt 1) { "$($isos.Count) discs in $took" } else { "Done in $took" })
         & $log "Total time: $took"
         $what = $(if ($isos.Count -gt 1) { "$($isos.Count) discs built in $took" } else { "Build complete in $took" })
         [System.Windows.Forms.MessageBox]::Show(($what + "`n`n" + ($isos -join "`n")),"DiscWright") | Out-Null
     }
     catch {
-        $buildWatch.Stop(); $lblElapsed.Text='Failed'
+        $buildWatch.Stop(); $script:BuildDiscTag = ''; $lblElapsed.Text='Failed'
         & $log ('ERROR: '+$_.Exception.Message); Show-Warn ("The build failed:`r`n`r`n" + $_.Exception.Message)
     }
     finally {

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -292,12 +292,12 @@ function Get-AddOnInfo([string]$exePath) {
 # on a DVD gets the whole premise wrong.
 function Get-MediaTiers {
     return @(
-        @{ Key='CD';   Gib=0.68; Name='CD-R 700 MB';                RecText='fits CD-R 700 MB' },
-        @{ Key='DVD5'; Gib=4.37; Name='DVD5 4.7 GB';                RecText='fits DVD5 4.7 GB (single layer)' },
-        @{ Key='DVD9'; Gib=7.95; Name='DVD9 8.5 GB (dual layer)';   RecText='needs DVD9 8.5 GB (dual layer)' },
-        @{ Key='BD25'; Gib=23.3; Name='BD-R 25 GB';                 RecText='too big for DVD - needs BD-R 25 GB' },
-        @{ Key='BD50'; Gib=46.6; Name='BD-R DL 50 GB (dual layer)'; RecText='needs BD-R DL 50 GB (dual layer)' },
-        @{ Key='BDXL'; Gib=93.0; Name='BD-R XL 100 GB';             RecText='needs BD-R XL 100 GB' }
+        @{ Key='CD';   Gib=0.68; Name='CD-R 700 MB';                Short='CD-R 700 MB';    RecText='fits CD-R 700 MB' },
+        @{ Key='DVD5'; Gib=4.37; Name='DVD5 4.7 GB';                Short='DVD5 4.7 GB';    RecText='fits DVD5 4.7 GB (single layer)' },
+        @{ Key='DVD9'; Gib=7.95; Name='DVD9 8.5 GB (dual layer)';   Short='DVD9 8.5 GB';    RecText='needs DVD9 8.5 GB (dual layer)' },
+        @{ Key='BD25'; Gib=23.3; Name='BD-R 25 GB';                 Short='BD-R 25 GB';     RecText='too big for DVD - needs BD-R 25 GB' },
+        @{ Key='BD50'; Gib=46.6; Name='BD-R DL 50 GB (dual layer)'; Short='BD-R DL 50 GB';  RecText='needs BD-R DL 50 GB (dual layer)' },
+        @{ Key='BDXL'; Gib=93.0; Name='BD-R XL 100 GB';             Short='BD-R XL 100 GB'; RecText='needs BD-R XL 100 GB' }
     )
 }
 
@@ -327,6 +327,13 @@ function Get-MediaKeyFromName([string]$name) {
 }
 function Get-MediaNameFromKey([string]$key) {
     foreach ($t in Get-MediaTiers) { if ($t.Key -ieq $key) { return $t.Name } }
+    return (Get-MediaAutoText)
+}
+# The same medium, minus the "(dual layer)" note. The dropdown has a row to
+# itself and can afford the full name; a sentence sharing one line with the
+# payload total and a game's title cannot.
+function Get-MediaShortFromKey([string]$key) {
+    foreach ($t in Get-MediaTiers) { if ($t.Key -ieq $key) { return $t.Short } }
     return (Get-MediaAutoText)
 }
 
@@ -455,15 +462,16 @@ function Get-DiscPlan([array]$entries, [string]$mediaKey, [double]$overhead, [do
 # refuses a build. One sentence, no jargon: the number of discs is the answer to
 # the only question being asked.
 function Get-DiscPlanText([hashtable]$plan, [string]$mediaKey) {
-    $name = Get-MediaNameFromKey $mediaKey
+    $name = Get-MediaShortFromKey $mediaKey
     if (-not $plan.Ok) {
         switch ($plan.Reason) {
             # The game's OWN size, not the total on the form. "Alan Wake alone is
             # bigger than a DVD5" sat on a line beginning "2 games (8.94 GB)", and
             # read as though the 8.94 was what would not fit. Naming the figure
             # that is actually too big settles it in the same breath.
-            'entry'  { return ("{0} is {1:N2} GB on its own, too big for a {2}" -f $plan.TooBigName, ([double]$plan.TooBigBytes/1GB), $name) }
+            'entry'  { return ("{0} is {1:N2} GB, too big for a {2}" -f $plan.TooBigName, ([double]$plan.TooBigBytes/1GB), $name) }
             'extras' { return ("the extra content alone is bigger than a $name") }
+            'media'  { return ("no such disc") }
             default  { return ("cannot be split onto $name") }
         }
     }
@@ -2142,7 +2150,11 @@ $btnFolder  =AddBtn 'Add game...' 545 68  110
 $btnAddOn   =AddBtn 'Add-on...'   545 96  110
 $btnGameEdit=AddBtn 'Change...'   545 124 110
 $btnGameDel =AddBtn 'Remove'      545 152 110
-$lblGame=AddLabel '' 15 180 640; $lblGame.ForeColor=[System.Drawing.Color]::DimGray
+$lblGame=AddLabel '' 15 180 655; $lblGame.ForeColor=[System.Drawing.Color]::DimGray
+# A game's title is user data and a refusal quotes it in full, so no width is
+# wide enough for every case. AutoEllipsis ends a line that will not fit with
+# "..." instead of cutting a word in half, and the tooltip carries the rest.
+$lblGame.AutoSize=$false; $lblGame.AutoEllipsis=$true
 
 AddLabel '2)  Disc label (shown in This PC):' 15 210 300 | Out-Null
 $txtLabel=AddText 15 232 300
@@ -2409,6 +2421,7 @@ function Update-MediaLabel {
         $lblGame.Text = "$txt   ->   Disc: $($m.Text)"
         $lblGame.ForeColor = if($m.Fit){[System.Drawing.Color]::Green}else{[System.Drawing.Color]::DarkOrange}
     }
+    Set-StatusTip $lblGame.Text
     # A missing installer part outranks the media advice - it is the thing that
     # makes the disc useless, so it takes the label and the colour.
     # With several games the label can only carry one warning, so take the first -
@@ -2420,7 +2433,15 @@ function Update-MediaLabel {
         $w = $warned[0]
         $lblGame.Text = if ($games.Count -eq 1) { $w.Warning } else { "$($w.GameName): $($w.Warning)" }
         $lblGame.ForeColor = if($w.MissingParts.Count -gt 0){[System.Drawing.Color]::Firebrick}else{[System.Drawing.Color]::DarkOrange}
+        Set-StatusTip $lblGame.Text
     }
+}
+
+# The advice line is clipped when it will not fit, so the whole of it has to be
+# reachable somewhere. Guarded because the logic tests exercise Update-MediaLabel
+# with stand-in controls and no tooltip provider.
+function Set-StatusTip([string]$text) {
+    if ($tips -and $lblGame -is [System.Windows.Forms.Control]) { $tips.SetToolTip($lblGame, $text) }
 }
 
 # The log box is for build progress. A click that cannot do its job needs an

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -1565,6 +1565,7 @@ function Save-Project([hashtable]$s,[string]$outDir) {
         ExtrasPath   = $s.ExtrasPath
         ExtraItems   = @($s.ExtraItems)
         MediaKey     = [string]$s.MediaKey
+        ExtrasEveryDisc = [bool]$s.ExtrasEveryDisc
         OutDir       = $outDir
     }
     $o | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath (Join-Path $outDir $PROJECT_FILE) -Encoding UTF8
@@ -1612,6 +1613,7 @@ function Import-Project([string]$jsonPath) {
             # Version 5. Absent in anything older, which is the automatic setting -
             # and the automatic setting is what those projects always described.
             MediaKey=$(if ($j.PSObject.Properties.Name -contains 'MediaKey') { [string]$j.MediaKey } else { '' })
+            ExtrasEveryDisc=$(if ($j.PSObject.Properties.Name -contains 'ExtrasEveryDisc') { [bool]$j.ExtrasEveryDisc } else { $false })
             ExtraItems=@($j.ExtraItems); OutDir=$j.OutDir; Origin='project file'
         }
     } catch { return $null }
@@ -1952,11 +1954,12 @@ function Invoke-BuildSet([hashtable]$s, [scriptblock]$log, [scriptblock]$progres
         $ds.SkipProject = $true
         $ds.DiscNum     = $num
         $ds.DiscOf      = $n
-        # The disc-wide manual, extras and loose files ride on disc 1 alone.
-        # Copying them onto every disc would multiply gigabytes of bonus content
-        # by the size of the set, which is nobody's idea of "extras on the disc".
-        # A game carries its own manual and extras with it, wherever it lands.
-        if ($num -ne 1) { $ds.ManualPath = $null; $ds.ExtrasPath = $null; $ds.ExtraItems = @() }
+        # The disc-wide manual, extras and loose files ride on disc 1 alone unless
+        # the form says otherwise: copying them onto every disc multiplies bonus
+        # content by the size of the set - the wrong default for a 2 GB making-of
+        # and the right one for a 3 MB manual, hence the choice.
+        # A game carries its OWN manual and extras with it, wherever it lands.
+        if ($num -ne 1 -and -not $s.ExtrasEveryDisc) { $ds.ManualPath = $null; $ds.ExtrasPath = $null; $ds.ExtraItems = @() }
         $isos += (Invoke-Build $ds $log $progress)
     }
 
@@ -2223,8 +2226,13 @@ $chkWinBorder=New-Object System.Windows.Forms.CheckBox; $chkWinBorder.Text='Wind
 $lblBtnStyle=New-Object System.Windows.Forms.Label; $lblBtnStyle.Text='Buttons:'; $lblBtnStyle.Location=New-Object System.Drawing.Point(380,250); $lblBtnStyle.Size=New-Object System.Drawing.Size(55,20); $grp.Controls.Add($lblBtnStyle)
 $cmbBtnStyle=New-Object System.Windows.Forms.ComboBox; $cmbBtnStyle.DropDownStyle='DropDownList'; $cmbBtnStyle.Location=New-Object System.Drawing.Point(438,247); $cmbBtnStyle.Size=New-Object System.Drawing.Size(130,24); [void]$cmbBtnStyle.Items.AddRange(@('Minimal','Bordered')); $cmbBtnStyle.SelectedIndex=0; $grp.Controls.Add($cmbBtnStyle)
 
-$grpX=New-Object System.Windows.Forms.GroupBox; $grpX.Text='5)  Extra content (copied to the disc root as-is)'; $grpX.Location=New-Object System.Drawing.Point(15,668); $grpX.Size=New-Object System.Drawing.Size(645,118); $form.Controls.Add($grpX)
-$lstExtra=New-Object System.Windows.Forms.ListBox; $lstExtra.Location=New-Object System.Drawing.Point(15,22); $lstExtra.Size=New-Object System.Drawing.Size(480,100); $lstExtra.SelectionMode='MultiExtended'; $lstExtra.HorizontalScrollbar=$true; $grpX.Controls.Add($lstExtra)
+$grpX=New-Object System.Windows.Forms.GroupBox; $grpX.Text='5)  Extra content (copied to the disc root as-is)'; $grpX.Location=New-Object System.Drawing.Point(15,668); $grpX.Size=New-Object System.Drawing.Size(645,124); $form.Controls.Add($grpX)
+$lstExtra=New-Object System.Windows.Forms.ListBox; $lstExtra.Location=New-Object System.Drawing.Point(15,22); $lstExtra.Size=New-Object System.Drawing.Size(480,72); $lstExtra.SelectionMode='MultiExtended'; $lstExtra.HorizontalScrollbar=$true; $grpX.Controls.Add($lstExtra)
+# The disc-wide manual, Extras folder and loose files ride on disc 1 of a set,
+# because copying a 2 GB extras folder onto five discs costs ten. That is the
+# right default and the wrong answer for a 3 MB PDF, so it is a choice. A game's
+# OWN manual and extras always travel with that game and are not affected.
+$chkXAll=New-Object System.Windows.Forms.CheckBox; $chkXAll.Text='Also put the manual and extras on every disc of a set'; $chkXAll.Location=New-Object System.Drawing.Point(15,98); $chkXAll.Size=New-Object System.Drawing.Size(400,22); $grpX.Controls.Add($chkXAll)
 $btnXFile=New-Object System.Windows.Forms.Button; $btnXFile.Text='Add files...'; $btnXFile.Location=New-Object System.Drawing.Point(505,22); $btnXFile.Size=New-Object System.Drawing.Size(120,24); $grpX.Controls.Add($btnXFile)
 $btnXDir =New-Object System.Windows.Forms.Button; $btnXDir.Text='Add folder...'; $btnXDir.Location=New-Object System.Drawing.Point(505,52); $btnXDir.Size=New-Object System.Drawing.Size(120,24); $grpX.Controls.Add($btnXDir)
 $btnXDel =New-Object System.Windows.Forms.Button; $btnXDel.Text='Remove'; $btnXDel.Location=New-Object System.Drawing.Point(505,82); $btnXDel.Size=New-Object System.Drawing.Size(120,24); $grpX.Controls.Add($btnXDel)
@@ -2312,6 +2320,9 @@ function Get-PlanInputs([hashtable]$payload=$null) {
     $p = $(if ($payload) { $payload } else { Get-PayloadBytes })
     $o = Get-DiscOverheadBytes @{ IconPath=$state.IconPath; BgPath=$state.BgPath
                                   MusicFile=$(if($chkMusic.Checked){$state.MusicFile}else{$null}) }
+    # On every disc they are overhead, like the menu. On disc 1 alone they are a
+    # one-off charge against the first disc's room. Same bytes, different bill.
+    if ($chkXAll.Checked) { return @{ Overhead=($o + $p.DiscExtra); FirstDiscExtra=[double]0; Payload=$p } }
     return @{ Overhead=$o; FirstDiscExtra=$p.DiscExtra; Payload=$p }
 }
 
@@ -2504,6 +2515,7 @@ function Test-FormDirty {
     if ($chkBgAsIs.Checked -or $chkTitle.Checked -or $chkMusic.Checked -or $chkDivider.Checked) { return $true }
     if ($cmbSide.SelectedIndex -ne 0 -or $cmbBtnStyle.SelectedIndex -ne 0) { return $true }
     if ($cmbMedia.SelectedIndex -ne 0) { return $true }
+    if ($chkXAll.Checked) { return $true }
     if (-not $cbPlay.Checked -or -not $cbInst.Checked -or -not $cbExit.Checked) { return $true }
     if ($cbMan.Checked -or $cbExtra.Checked) { return $true }
     return $false
@@ -2559,6 +2571,12 @@ function Update-ActionButtons {
     $tips.SetToolTip($txtTitle, $(if(-not $composites){$whyOff}
                                   elseif(-not $chkTitle.Checked){'Tick "Show title" first'}
                                   else{'Leave blank to use the disc label from step 2'}))
+
+    # Nothing disc-wide to carry means nothing for this to decide about.
+    $hasWide = ($cbMan.Checked -and $state.ManualPath) -or ($cbExtra.Checked -and $state.ExtrasPath) -or ($lstExtra.Items.Count -gt 0)
+    $chkXAll.Enabled = [bool]$hasWide
+    $tips.SetToolTip($chkXAll, $(if(-not $hasWide){'Add a manual, an Extras folder or some extra content first'}
+                                 else{'Off: they go on disc 1 of a set. On: every disc carries its own copy, which costs their size per disc. A game''s own manual and extras always travel with that game either way.'}))
 }
 
 # Renders the CURRENT settings into a temp folder so look changes can be checked
@@ -3042,6 +3060,7 @@ function Reset-Form {
     $null = Set-GameEntries @()
     $lblGame.Text = ''; $lblGame.ForeColor = [System.Drawing.Color]::DimGray
     $cmbMedia.SelectedIndex = 0
+    $chkXAll.Checked = $false
 
     # LastGameBrowse and LastFileBrowse are deliberately NOT reset - see where
     # $state is declared.
@@ -3177,6 +3196,7 @@ function Open-Project([string]$folder) {
     $out = $p.OutDir; if (-not $out -or -not (Test-Path $out)) { $out = Split-Path $disc -Parent }
     $txtOut.Text = $out
 
+    $chkXAll.Checked = $(if ($p.ContainsKey('ExtrasEveryDisc')) { [bool]$p.ExtrasEveryDisc } else { $false })
     # Last, not beside the label: the rows are annotated from the entries, so the
     # list this has to find its medium in does not exist until they are loaded.
     Update-MediaOptions
@@ -3516,7 +3536,8 @@ $btnBuild.Add_Click({
          WindowBorder=$chkWinBorder.Checked; ButtonStyle=[string]$cmbBtnStyle.SelectedItem;
          MusicFile=$(if($chkMusic.Checked){$state.MusicFile}else{$null});
          Buttons=$buttons; ManualPath=$(if($cbMan.Checked){$state.ManualPath}else{$null}); ExtrasPath=$(if($cbExtra.Checked){$state.ExtrasPath}else{$null});
-         ExtraItems=@($lstExtra.Items); OutDir=$txtOut.Text.Trim(); MediaKey=$mediaKey; Plan=$plan }
+         ExtraItems=@($lstExtra.Items); OutDir=$txtOut.Text.Trim(); MediaKey=$mediaKey; Plan=$plan
+         ExtrasEveryDisc=$chkXAll.Checked }
     $btnBuild.Enabled=$false
     $script:BuildDiscTag = ''
     $pbBuild.Value=0; $pbBuild.Visible=$true
@@ -3567,6 +3588,9 @@ foreach ($c in @($txtLabel,$txtIcon,$txtMusic,$txtMan,$txtEx,$txtTitle)) {
 foreach ($c in @($chkBgAsIs,$chkMusic,$chkDivider,$chkWinBorder,$cbPlay,$cbInst,$cbMan,$cbExtra,$cbExit)) {
     $c.Add_CheckedChanged({ Update-ActionButtons })
 }
+# This one moves bytes between "disc 1 only" and "every disc", so it changes the
+# plan as well as the buttons.
+$chkXAll.Add_CheckedChanged({ Update-MediaLabel; Update-ActionButtons })
 foreach ($c in @($cmbSide,$cmbBtnStyle)) {
     $c.Add_SelectedIndexChanged({ Update-ActionButtons })
 }

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -280,21 +280,54 @@ function Get-AddOnInfo([string]$exePath) {
     return $info
 }
 
-# Recommend the smallest media that fits the payload (usable capacities, GiB).
+# Every disc size DiscWright knows about, smallest first (usable capacities, GiB).
+# One table rather than a ladder of magic numbers, because two features now read
+# the same figures: the advice line under the installer list, and the splitter
+# that packs a set.
+#
+# An 80-minute CD-R is 360,000 sectors of 2048 bytes = 0.686 GiB; 0.68 leaves a
+# little room for the filesystem. Worth having as its own tier rather than
+# rounding up to DVD: the sub-700 MB back catalogue is exactly the audience for
+# a tool about authentic period discs, and telling someone to put a 1998 game
+# on a DVD gets the whole premise wrong.
+function Get-MediaTiers {
+    return @(
+        @{ Key='CD';   Gib=0.68; Name='CD-R 700 MB';                RecText='fits CD-R 700 MB' },
+        @{ Key='DVD5'; Gib=4.37; Name='DVD5 4.7 GB';                RecText='fits DVD5 4.7 GB (single layer)' },
+        @{ Key='DVD9'; Gib=7.95; Name='DVD9 8.5 GB (dual layer)';   RecText='needs DVD9 8.5 GB (dual layer)' },
+        @{ Key='BD25'; Gib=23.3; Name='BD-R 25 GB';                 RecText='too big for DVD - needs BD-R 25 GB' },
+        @{ Key='BD50'; Gib=46.6; Name='BD-R DL 50 GB (dual layer)'; RecText='needs BD-R DL 50 GB (dual layer)' },
+        @{ Key='BDXL'; Gib=93.0; Name='BD-R XL 100 GB';             RecText='needs BD-R XL 100 GB' }
+    )
+}
+
+# The first entry in the target-disc list: carry on doing what DiscWright has
+# always done, which is recommend a size and build exactly one disc.
+function Get-MediaAutoText { return 'Fit on one disc (recommended)' }
+
+# The dropdown shows names; everything else works in keys.
+function Get-MediaKeyFromName([string]$name) {
+    foreach ($t in Get-MediaTiers) { if ($t.Name -eq $name) { return $t.Key } }
+    return ''
+}
+function Get-MediaNameFromKey([string]$key) {
+    foreach ($t in Get-MediaTiers) { if ($t.Key -ieq $key) { return $t.Name } }
+    return (Get-MediaAutoText)
+}
+
+# Usable bytes for one disc of the named medium, or 0 for a key nothing recognises.
+function Get-MediaCapacity([string]$key) {
+    foreach ($t in Get-MediaTiers) { if ($t.Key -ieq $key) { return [double]$t.Gib * 1GB } }
+    return [double]0
+}
+
+# Recommend the smallest media that fits the payload.
 function Get-MediaRec([double]$bytes) {
     $gib = $bytes/1GB
-    # An 80-minute CD-R is 360,000 sectors of 2048 bytes = 0.686 GiB; 0.68 leaves a
-    # little room for the filesystem. Worth having as its own tier rather than
-    # rounding up to DVD: the sub-700 MB back catalogue is exactly the audience for
-    # a tool about authentic period discs, and telling someone to put a 1998 game
-    # on a DVD gets the whole premise wrong.
-    if     ($gib -le 0.68) { return @{ Fit=$true;  Text='fits CD-R 700 MB' } }
-    elseif ($gib -le 4.37) { return @{ Fit=$true;  Text='fits DVD5 4.7 GB (single layer)' } }
-    elseif ($gib -le 7.95) { return @{ Fit=$true;  Text='needs DVD9 8.5 GB (dual layer)' } }
-    elseif ($gib -le 23.3) { return @{ Fit=$true;  Text='too big for DVD - needs BD-R 25 GB' } }
-    elseif ($gib -le 46.6) { return @{ Fit=$true;  Text='needs BD-R DL 50 GB (dual layer)' } }
-    elseif ($gib -le 93.0) { return @{ Fit=$true;  Text='needs BD-R XL 100 GB' } }
-    else                   { return @{ Fit=$false; Text=("too big for one disc ({0:N1} GB) - multi-disc not supported" -f $gib) } }
+    foreach ($t in Get-MediaTiers) {
+        if ($gib -le $t.Gib) { return @{ Fit=$true; Key=$t.Key; Text=$t.RecText } }
+    }
+    return @{ Fit=$false; Key=''; Text=("too big for one disc ({0:N1} GB) - split it across a set" -f $gib) }
 }
 
 # Total bytes of a mixed list of files and folders.
@@ -308,6 +341,136 @@ function Get-ItemsSize($items) {
         } else { $sum += (Get-Item -LiteralPath $i).Length }
     }
     return $sum
+}
+
+# Packs a set in the order the entries already sit in on the form.
+#
+# Deliberately next-fit rather than any cleverer packing: the list on the form is
+# the order the user arranged, and the menu numbers follow it. A packer that
+# reordered games to save a disc would produce a set whose disc 2 holds the game
+# they put first. Saving one disc is worth less than a set that matches what is
+# on screen.
+#
+# $sizes is one figure per installer, in list order. $overhead is what every disc
+# carries no matter what else is on it - menu, icon, background, music.
+# $firstDiscExtra is the disc-wide manual and extras, which ride on disc 1 alone
+# rather than being copied onto every disc in the set.
+#
+# Refuses, rather than guessing, when a single installer is larger than a whole
+# disc. Spreading one game's parts across several discs is a different problem
+# with a different answer, and quietly producing a set that cannot install the
+# game would be worse than saying so.
+function Split-DiscSet([double[]]$sizes, [double]$capacity, [double]$overhead, [double]$firstDiscExtra) {
+    $usable = $capacity - $overhead
+    if ($usable -le 0) { return @{ Ok=$false; Reason='capacity'; TooBig=-1; Room=[double]0 } }
+    if ($firstDiscExtra -gt $usable) { return @{ Ok=$false; Reason='extras'; TooBig=-1; Room=$usable } }
+
+    $discs = @()
+    $cur   = @()
+    $used  = [double]0
+    $room  = $usable - $firstDiscExtra
+    for ($i = 0; $i -lt @($sizes).Count; $i++) {
+        $sz = [double]$sizes[$i]
+        if ($sz -gt $usable) { return @{ Ok=$false; Reason='entry'; TooBig=$i; Room=$usable } }
+        # Disc 1 gives up room to the disc-wide extras, so the first entry can be
+        # too big for disc 1 and still fit every disc after it. Let disc 1 carry
+        # the extras on their own rather than refuse a set that packs fine.
+        if ($cur.Count -eq 0 -and $sz -gt $room) { $discs += ,@(); $room = $usable }
+        if ($cur.Count -gt 0 -and ($used + $sz) -gt $room) {
+            $discs += ,@($cur)
+            $cur = @(); $used = [double]0; $room = $usable
+        }
+        $cur  += $i
+        $used += $sz
+    }
+    if ($cur.Count -gt 0 -or $discs.Count -eq 0) { $discs += ,@($cur) }
+    return @{ Ok=$true; Reason=''; TooBig=-1; Room=$usable; Discs=$discs }
+}
+
+# What every disc in a set carries no matter which games land on it: the icon at
+# the root and again inside AUTORUN, the composed background, the menu itself and
+# autorun.inf. Counted twice for the icon and the background because each ships
+# in two places, or is recomposed into a PNG that can come out larger than the
+# JPG it was made from. Erring high costs a little headroom; erring low produces
+# a disc that will not burn.
+function Get-DiscOverheadBytes([hashtable]$s) {
+    $b  = [double]2MB
+    $b += 2 * (Get-ItemsSize @($s.IconPath))
+    $b += 2 * (Get-ItemsSize @($s.BgPath))
+    $b += (Get-ItemsSize @($s.MusicFile))
+    return $b
+}
+
+# Works out how many discs the set needs and what goes on each, in entry indices.
+# Packs by group rather than by entry so a game and its add-ons stay together.
+function Get-DiscPlan([array]$entries, [string]$mediaKey, [double]$overhead, [double]$firstDiscExtra) {
+    $cap = Get-MediaCapacity $mediaKey
+    if ($cap -le 0) { return @{ Ok=$false; Reason='media'; Discs=@(); Capacity=[double]0; TooBigName=''; Room=[double]0 } }
+
+    $groups = Get-EntryGroups $entries
+    $sizes  = @()
+    foreach ($g in $groups) {
+        $t = [double]0
+        foreach ($i in $g) { $t += [double]$entries[$i].TotalBytes }
+        $sizes += $t
+    }
+
+    $r = Split-DiscSet ([double[]]$sizes) $cap $overhead $firstDiscExtra
+    if (-not $r.Ok) {
+        # Name the game rather than the group index. "Group 2 is too big" is a
+        # sentence about the packer; the user needs the sentence about the disc.
+        $nm = ''
+        if ($r.Reason -eq 'entry' -and $r.TooBig -ge 0) { $nm = [string]$entries[$groups[$r.TooBig][0]].GameName }
+        return @{ Ok=$false; Reason=$r.Reason; Discs=@(); Capacity=$cap; TooBigName=$nm; Room=$r.Room }
+    }
+
+    $discs = @()
+    foreach ($d in $r.Discs) {
+        $idx = @()
+        foreach ($gi in $d) { foreach ($e in $groups[$gi]) { $idx += $e } }
+        $discs += ,@($idx)
+    }
+    return @{ Ok=$true; Reason=''; Discs=$discs; Capacity=$cap; TooBigName=''; Room=$r.Room }
+}
+
+# How the plan reads on the line under the installer list, and in the dialog that
+# refuses a build. One sentence, no jargon: the number of discs is the answer to
+# the only question being asked.
+function Get-DiscPlanText([hashtable]$plan, [string]$mediaKey) {
+    $name = Get-MediaNameFromKey $mediaKey
+    if (-not $plan.Ok) {
+        switch ($plan.Reason) {
+            'entry'  { return ("$($plan.TooBigName) alone is bigger than a $name") }
+            'extras' { return ("the extra content alone is bigger than a $name") }
+            default  { return ("cannot be split onto $name") }
+        }
+    }
+    $n = @($plan.Discs).Count
+    if ($n -le 1) { return "1 disc, $name" }
+    return "$n discs of $name"
+}
+
+# What This PC calls each disc in a set. A set of one keeps the plain label:
+# a disc with no set around it should not announce itself as "D1".
+function Get-DiscSetLabel([string]$label, [int]$n, [int]$of) {
+    $base = "$label".Trim()
+    if ($of -le 1) { return $base }
+    return ("{0} D{1}" -f $base, $n)
+}
+
+# The ISO9660 volume identifier is 16 characters, and New-Iso folds anything that
+# is not alphanumeric to an underscore. Truncating the finished label at 16 would
+# cut the disc number off the end of a long name and hand every disc in the set
+# the same volume id, so the number is reserved first and the name takes what is
+# left over.
+function Get-VolumeLabel([string]$label, [int]$n, [int]$of) {
+    $sfx  = if ($of -le 1) { '' } else { "_D$n" }
+    $base = (("$label" -replace '[^A-Za-z0-9_]','_')).Trim('_')
+    $max  = 16 - $sfx.Length
+    if ($max -lt 1) { $max = 1 }
+    if ($base.Length -gt $max) { $base = $base.Substring(0, $max) }
+    if ([string]::IsNullOrEmpty($base)) { $base = 'DISC' }
+    return ($base + $sfx)
 }
 
 # Every disc used to ship its icon as "disc.ico". Explorer caches icon bitmaps
@@ -437,6 +600,51 @@ function Get-MenuGames([array]$entries) {
         $out += @{ Name=$e.GameName; MatchName=$e.GameName
                    Setup=(Get-DiscEntrySetup $entries $i); AddOns=@($addOns)
                    Manual=$man; Extras=$ext }
+    }
+    return ,@($out)
+}
+
+# A game and everything filed under it travel together when a set is packed.
+# Splitting them would strand an add-on on a disc whose ParentIndex points at a
+# game that is not on it, and the menu would show the patch as a game of its own.
+# Uses the same test for "is this really an add-on" as the menu does, so an
+# orphan - an add-on whose parent was removed - forms its own group, exactly as
+# it becomes its own entry in the menu.
+function Get-EntryGroups([array]$entries) {
+    $groups = @()
+    for ($i = 0; $i -lt $entries.Count; $i++) {
+        $e = $entries[$i]
+        $p = [int]$e.ParentIndex
+        $isAddOn = ($e.Kind -eq 'AddOn') -and $p -ge 0 -and $p -lt $entries.Count -and
+                   $p -ne $i -and $entries[$p].Kind -ne 'AddOn'
+        if ($isAddOn) { continue }
+        $g = @($i)
+        for ($j = 0; $j -lt $entries.Count; $j++) {
+            $a = $entries[$j]
+            if ($j -eq $i -or $a.Kind -ne 'AddOn') { continue }
+            if ([int]$a.ParentIndex -ne $i) { continue }
+            $g += $j
+        }
+        $groups += ,@($g)
+    }
+    return ,@($groups)
+}
+
+# One disc's slice of the list, renumbered so the disc stands on its own. Both
+# the folder names and the menu key off an entry's position, and ParentIndex has
+# to point inside the slice - left pointing at the full list it would either miss
+# or, worse, land on a different game.
+function Get-DiscEntries([array]$entries, [int[]]$indices) {
+    $map = @{}
+    for ($k = 0; $k -lt @($indices).Count; $k++) { $map[[int]$indices[$k]] = $k }
+    $out = @()
+    foreach ($i in @($indices)) {
+        $src  = $entries[[int]$i]
+        $copy = @{}
+        foreach ($key in $src.Keys) { $copy[$key] = $src[$key] }
+        $p = [int]$src.ParentIndex
+        $copy.ParentIndex = $(if ($map.ContainsKey($p)) { $map[$p] } else { -1 })
+        $out += $copy
     }
     return ,@($out)
 }
@@ -1258,7 +1466,10 @@ function Save-Project([hashtable]$s,[string]$outDir) {
         # wrote it - two different things, deliberately two different keys. This
         # merge is why: the schema went to 2 for the games list while the app was
         # independently at 0.2.0, and one field could not have said both.
-        Version      = 4
+        # Version 5 adds MediaKey - which disc the set was planned for. Absent in
+        # anything older, which reads back as the automatic setting and so builds
+        # the single disc those projects always described.
+        Version      = 5
         AppVersion   = $APP_VERSION
         SavedUtc     = (Get-Date).ToUniversalTime().ToString('s')
         # Version 1 knew about exactly one game and stored it here. Both keys are
@@ -1299,6 +1510,7 @@ function Save-Project([hashtable]$s,[string]$outDir) {
         ManualPath   = $s.ManualPath
         ExtrasPath   = $s.ExtrasPath
         ExtraItems   = @($s.ExtraItems)
+        MediaKey     = [string]$s.MediaKey
         OutDir       = $outDir
     }
     $o | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath (Join-Path $outDir $PROJECT_FILE) -Encoding UTF8
@@ -1638,13 +1850,59 @@ function Invoke-Build([hashtable]$s, [scriptblock]$log, [scriptblock]$progress=$
 
     & $log "Building ISO (UDF, this can take ~30-60s for a full game)..."
     $iso = Get-IsoPath $s.OutDir $s.Label
-    New-Iso $stage $iso $s.Label $progress
+    # A disc in a set gets its volume id worked out with the disc number reserved,
+    # so a long name cannot truncate away the one part that tells two discs apart.
+    $vol = $(if ($s.VolumeLabel) { [string]$s.VolumeLabel } else { Get-VolumeLabel $s.Label 1 1 })
+    New-Iso $stage $iso $vol $progress
     & $log ("DONE.  ISO: {0}  ({1:N2} GB)" -f $iso, ((Get-Item $iso).Length/1GB))
 
-    Save-Project $s $s.OutDir
-    & $log "Saved $PROJECT_FILE - use 'Open existing disc project' to edit and rebuild."
+    # One project file describes the whole set, so the caller saves it once after
+    # the last disc rather than each disc overwriting it with its own slice.
+    if (-not $s.SkipProject) {
+        Save-Project $s $s.OutDir
+        & $log "Saved $PROJECT_FILE - use 'Open existing disc project' to edit and rebuild."
+    }
     if ($tmpKeep -and (Test-Path $tmpKeep)) { Remove-Item $tmpKeep -Recurse -Force -EA SilentlyContinue }
     return $iso
+}
+
+# Builds every disc the plan calls for, one after another, and returns the ISOs.
+# A plan of one disc goes straight through to Invoke-Build unchanged - a single
+# disc must come out byte for byte the way it always has, label and all.
+function Invoke-BuildSet([hashtable]$s, [scriptblock]$log, [scriptblock]$progress=$null) {
+    $plan = $s.Plan
+    # Returned as a plain array, not the ",@()" wrapper used for values that get
+    # assigned straight across: every caller here wraps the result in @(), and a
+    # wrapper on top of that nests the list one level deeper than anyone reads.
+    if (-not $plan -or -not $plan.Ok -or @($plan.Discs).Count -le 1) {
+        return @(Invoke-Build $s $log $progress)
+    }
+
+    $all  = @($s.Games)
+    $n    = @($plan.Discs).Count
+    $isos = @()
+    for ($d = 0; $d -lt $n; $d++) {
+        $num = $d + 1
+        & $log ''
+        & $log "===== Disc $num of $n ====="
+        $ds = @{}
+        foreach ($k in $s.Keys) { $ds[$k] = $s[$k] }
+        $ds.Games       = Get-DiscEntries $all @($plan.Discs[$d])
+        $ds.Label       = Get-DiscSetLabel $s.Label $num $n
+        $ds.VolumeLabel = Get-VolumeLabel  $s.Label $num $n
+        $ds.SkipProject = $true
+        # The disc-wide manual, extras and loose files ride on disc 1 alone.
+        # Copying them onto every disc would multiply gigabytes of bonus content
+        # by the size of the set, which is nobody's idea of "extras on the disc".
+        # A game carries its own manual and extras with it, wherever it lands.
+        if ($num -ne 1) { $ds.ManualPath = $null; $ds.ExtrasPath = $null; $ds.ExtraItems = @() }
+        $isos += (Invoke-Build $ds $log $progress)
+    }
+
+    Save-Project $s $s.OutDir
+    & $log ''
+    & $log "Saved $PROJECT_FILE - use 'Open existing disc project' to edit and rebuild the set."
+    return @($isos)
 }
 
 # =================== UI ===================
@@ -1833,8 +2091,22 @@ $btnGameEdit=AddBtn 'Change...'   545 124 110
 $btnGameDel =AddBtn 'Remove'      545 152 110
 $lblGame=AddLabel '' 15 180 640; $lblGame.ForeColor=[System.Drawing.Color]::DimGray
 
-AddLabel '2)  Disc label (shown in This PC):' 15 210 520 | Out-Null
+AddLabel '2)  Disc label (shown in This PC):' 15 210 300 | Out-Null
 $txtLabel=AddText 15 232 300
+
+# Which disc you are actually going to burn. Until now DiscWright only ever
+# recommended a size; a payload past the biggest disc was simply refused. Saying
+# which medium you own turns that into a set: the games are packed onto as many
+# discs as it takes, in the order they sit in the list.
+AddLabel 'Target disc:' 330 210 200 | Out-Null
+$cmbMedia=New-Object System.Windows.Forms.ComboBox
+$cmbMedia.DropDownStyle='DropDownList'
+$cmbMedia.Location=New-Object System.Drawing.Point(330,232)
+$cmbMedia.Size=New-Object System.Drawing.Size(240,24)
+[void]$cmbMedia.Items.Add((Get-MediaAutoText))
+foreach ($t in Get-MediaTiers) { [void]$cmbMedia.Items.Add($t.Name) }
+$cmbMedia.SelectedIndex=0
+$form.Controls.Add($cmbMedia)
 
 AddLabel '3)  Disc icon (.ico, or .png/.jpg to auto-convert):' 15 268 520 | Out-Null
 $txtIcon=AddText 15 290 520
@@ -1941,13 +2213,41 @@ function Get-PayloadBytes {
     # not go through that path.
     $installer = [double]0
     foreach ($g in $games) { $installer += [double]$g.TotalBytes }
+    # Split out rather than summed in one go: the music rides on every disc of a
+    # set because every disc has its own menu, while the manual, the extras and
+    # the loose files ride on disc 1 alone. Adding them together would charge the
+    # wrong disc for one of them.
     $side = @()
     $side += @($state.ExtraItems)
     if ($cbMan.Checked   -and $state.ManualPath) { $side += $state.ManualPath }
     if ($cbExtra.Checked -and $state.ExtrasPath) { $side += $state.ExtrasPath }
-    if ($chkMusic.Checked -and $state.MusicFile) { $side += $state.MusicFile }
-    $extra = [double](Get-ItemsSize $side)
-    return @{ Installer=$installer; Extra=$extra; Total=($installer + $extra) }
+    $discExtra = [double](Get-ItemsSize $side)
+    $music     = [double]0
+    if ($chkMusic.Checked -and $state.MusicFile) { $music = [double](Get-ItemsSize @($state.MusicFile)) }
+    return @{ Installer=$installer; Extra=($discExtra + $music); DiscExtra=$discExtra; Music=$music
+              Total=($installer + $discExtra + $music) }
+}
+
+# The overhead figure and the disc-1 figure the planner needs, read off the form.
+# Takes an already-measured payload when the caller has one: Get-PayloadBytes
+# walks the extras folder, and the advice line runs on every keystroke in the
+# disc label. Measuring the same folder twice per character is not free.
+function Get-PlanInputs([hashtable]$payload=$null) {
+    $p = $(if ($payload) { $payload } else { Get-PayloadBytes })
+    $o = Get-DiscOverheadBytes @{ IconPath=$state.IconPath; BgPath=$state.BgPath
+                                  MusicFile=$(if($chkMusic.Checked){$state.MusicFile}else{$null}) }
+    return @{ Overhead=$o; FirstDiscExtra=$p.DiscExtra; Payload=$p }
+}
+
+# The medium the form is currently pointed at, '' for the automatic setting.
+function Get-SelectedMediaKey { return (Get-MediaKeyFromName ([string]$cmbMedia.SelectedItem)) }
+
+# The plan for what is on the form right now, or $null when no target is chosen.
+function Get-CurrentPlan([hashtable]$payload=$null) {
+    $key = Get-SelectedMediaKey
+    if (-not $key) { return $null }
+    $pi = Get-PlanInputs $payload
+    return (Get-DiscPlan (Get-Games) $key $pi.Overhead $pi.FirstDiscExtra)
 }
 
 function Update-MediaLabel {
@@ -1980,8 +2280,19 @@ function Update-MediaLabel {
                "$part ($(Format-Size $p.Installer))"
            }
     if ($p.Extra -gt 0) { $txt += " + $(Format-Size $p.Extra) extra" }
-    $lblGame.Text = "$txt   ->   Disc: $($m.Text)"
-    $lblGame.ForeColor = if($m.Fit){[System.Drawing.Color]::Green}else{[System.Drawing.Color]::DarkOrange}
+    $key  = Get-SelectedMediaKey
+    if ($key) {
+        # A target disc turns the advice line into a plan: how many discs, of
+        # what. The recommendation is no longer the interesting number once the
+        # user has told DiscWright which discs are actually in the drawer.
+        $pi   = Get-PlanInputs $p
+        $plan = Get-DiscPlan $games $key $pi.Overhead $pi.FirstDiscExtra
+        $lblGame.Text = "$txt   ->   $(Get-DiscPlanText $plan $key)"
+        $lblGame.ForeColor = if($plan.Ok){[System.Drawing.Color]::Green}else{[System.Drawing.Color]::DarkOrange}
+    } else {
+        $lblGame.Text = "$txt   ->   Disc: $($m.Text)"
+        $lblGame.ForeColor = if($m.Fit){[System.Drawing.Color]::Green}else{[System.Drawing.Color]::DarkOrange}
+    }
     # A missing installer part outranks the media advice - it is the thing that
     # makes the disc useless, so it takes the label and the colour.
     # With several games the label can only carry one warning, so take the first -
@@ -2055,6 +2366,7 @@ function Test-FormDirty {
     if (-not $chkMenu.Checked -or -not $chkWinBorder.Checked) { return $true }
     if ($chkBgAsIs.Checked -or $chkTitle.Checked -or $chkMusic.Checked -or $chkDivider.Checked) { return $true }
     if ($cmbSide.SelectedIndex -ne 0 -or $cmbBtnStyle.SelectedIndex -ne 0) { return $true }
+    if ($cmbMedia.SelectedIndex -ne 0) { return $true }
     if (-not $cbPlay.Checked -or -not $cbInst.Checked -or -not $cbExit.Checked) { return $true }
     if ($cbMan.Checked -or $cbExtra.Checked) { return $true }
     return $false
@@ -2592,6 +2904,7 @@ function Reset-Form {
 
     $null = Set-GameEntries @()
     $lblGame.Text = ''; $lblGame.ForeColor = [System.Drawing.Color]::DimGray
+    $cmbMedia.SelectedIndex = 0
 
     # LastGameBrowse and LastFileBrowse are deliberately NOT reset - see where
     # $state is declared.
@@ -2682,6 +2995,12 @@ function Open-Project([string]$folder) {
     # doing it here too means a poisoned project file cannot present one thing in
     # the window and put another on the disc.
     $txtLabel.Text = Remove-ControlChars $p.Label; $state.LabelSeededFrom = $null
+    # A project written before target discs existed has no MediaKey, and a key
+    # this build does not recognise is not worth guessing at either: both fall
+    # back to the automatic setting rather than silently planning a set.
+    $mk = ''
+    if ($p.PSObject.Properties.Name -contains 'MediaKey') { $mk = [string]$p.MediaKey }
+    $cmbMedia.SelectedItem = $(if ($mk -and (Get-MediaCapacity $mk) -gt 0) { Get-MediaNameFromKey $mk } else { Get-MediaAutoText })
     if ($p.IconPath -and (Test-Path $p.IconPath)) { Set-IconFile $p.IconPath } else { & $log "  icon missing - pick one again." }
 
     $chkMenu.Checked = $p.Menu
@@ -2944,12 +3263,32 @@ $btnBuild.Add_Click({
     # The media label has always worked out that a payload is too big for any disc,
     # but nothing acted on it - the build ran to completion and handed back an ISO
     # that could never be burned.
+    $mediaKey  = Get-SelectedMediaKey
+    $plan      = Get-CurrentPlan $pay
+    $discCount = $(if ($plan -and $plan.Ok) { @($plan.Discs).Count } else { 1 })
+
+    if ($plan -and -not $plan.Ok) {
+        # A chosen medium that cannot hold the set is a different failure from a
+        # payload past the biggest disc there is, and it needs its own sentence.
+        $mName = Get-MediaNameFromKey $mediaKey
+        $why   = switch ($plan.Reason) {
+            'entry'  { ("{0} on its own is {1:N1} GB, and a {2} holds {3:N1} GB." -f $plan.TooBigName,
+                        (($(Get-Games) | Where-Object { $_.GameName -eq $plan.TooBigName } | Select-Object -First 1).TotalBytes/1GB),
+                        $mName, ($plan.Room/1GB)) +
+                       "`r`n`r`nSpreading one game's installer across several discs is not something DiscWright can do yet. Choose a larger disc in step 2, or leave that game off this set." }
+            'extras' { "The extra content in step 5 is bigger than one $mName on its own, before any game is added.`r`n`r`nRemove some of it, or choose a larger disc." }
+            default  { "This set cannot be planned for a $mName." }
+        }
+        Deny-Build ("cannot plan a set of $mName - $($plan.Reason).") $why
+        return
+    }
+
     $rec = Get-MediaRec $pay.Total
-    if (-not $rec.Fit) {
+    if (-not $plan -and -not $rec.Fit) {
         Deny-Build ("payload is {0:N1} GB - too big for any single disc." -f ($pay.Total/1GB)) (
             ("This disc would be {0:N1} GB, which is bigger than any single disc DiscWright can write." -f ($pay.Total/1GB)) +
             "`r`n`r`nThe largest supported medium is BD-R XL at 100 GB." +
-            "`r`n`r`nRemove some extra content in step 5, or split the game across several discs by hand.")
+            "`r`n`r`nPick the disc you are going to burn in step 2 and DiscWright will split the games across a set.")
         return
     }
 
@@ -2987,8 +3326,13 @@ $btnBuild.Add_Click({
 
     # A rebuild replaces work that already exists - say exactly what goes.
     $stage      = Join-Path $outDir 'disc'
-    $isoPath    = Get-IsoPath $outDir $txtLabel.Text.Trim()
-    $isoExists  = Test-AlreadyBuilt $outDir $txtLabel.Text.Trim()
+    # Every ISO this build is about to write, so the confirmation can name them
+    # rather than describe "the ISO" and then quietly replace three files.
+    $setLabels  = @(1..$discCount | ForEach-Object { Get-DiscSetLabel $txtLabel.Text.Trim() $_ $discCount })
+    $setIsos    = @($setLabels | ForEach-Object { Get-IsoPath $outDir $_ })
+    $isoPath    = $setIsos[0]
+    $existing   = @($setLabels | Where-Object { Test-AlreadyBuilt $outDir $_ })
+    $isoExists  = ($existing.Count -gt 0)
     $stageExists = Test-Path $stage
     # Ask before destroying anything - but only about what actually goes. The ISO
     # named by THIS label, and the staging folder. A differently named ISO sitting
@@ -2999,7 +3343,12 @@ $btnBuild.Add_Click({
         $bGames  = Get-Games
         $inPlace = ($bGames.Count -eq 1) -and (Test-SamePath $bGames[0].Folder $stage)
         $isoName = if ($isoPath) { Split-Path $isoPath -Leaf } else { 'the ISO' }
-        if ($isoExists) {
+        $isoList = ($setIsos | ForEach-Object { '  ' + (Split-Path $_ -Leaf) }) -join "`r`n"
+        if ($discCount -gt 1) {
+            $msg = "Build a set of $discCount discs in:`r`n$outDir`r`n`r`nThese will be written:`r`n$isoList"
+            if ($isoExists) { $msg += "`r`n`r`n$($existing.Count) of them already exist and will be replaced." }
+            $msg += "`r`n`r`nAny other ISO already in this folder is left alone."
+        } elseif ($isoExists) {
             $msg = "Rebuild the disc in:`r`n$outDir`r`n`r`n$isoName already exists and will be replaced."
         } else {
             $msg = "Build the disc in:`r`n$outDir`r`n`r`n$isoName will be written. Any other ISO already in this folder is left alone."
@@ -3021,18 +3370,19 @@ $btnBuild.Add_Click({
          WindowBorder=$chkWinBorder.Checked; ButtonStyle=[string]$cmbBtnStyle.SelectedItem;
          MusicFile=$(if($chkMusic.Checked){$state.MusicFile}else{$null});
          Buttons=$buttons; ManualPath=$(if($cbMan.Checked){$state.ManualPath}else{$null}); ExtrasPath=$(if($cbExtra.Checked){$state.ExtrasPath}else{$null});
-         ExtraItems=@($lstExtra.Items); OutDir=$txtOut.Text.Trim() }
+         ExtraItems=@($lstExtra.Items); OutDir=$txtOut.Text.Trim(); MediaKey=$mediaKey; Plan=$plan }
     $btnBuild.Enabled=$false
     $pbBuild.Value=0; $pbBuild.Visible=$true
     $buildWatch.Restart()
     $lblElapsed.Text='Starting...'
     try {
-        $iso=Invoke-Build $s $log $buildProgress
+        $isos = @(Invoke-BuildSet $s $log $buildProgress)
         $buildWatch.Stop()
         $took = Format-Elapsed $buildWatch.Elapsed
         $lblElapsed.Text = "Done in $took"
         & $log "Total time: $took"
-        [System.Windows.Forms.MessageBox]::Show("Build complete in $took`n`n$iso","DiscWright") | Out-Null
+        $what = $(if ($isos.Count -gt 1) { "$($isos.Count) discs built in $took" } else { "Build complete in $took" })
+        [System.Windows.Forms.MessageBox]::Show(($what + "`n`n" + ($isos -join "`n")),"DiscWright") | Out-Null
     }
     catch {
         $buildWatch.Stop(); $lblElapsed.Text='Failed'
@@ -3067,6 +3417,8 @@ foreach ($c in @($chkBgAsIs,$chkMusic,$chkDivider,$chkWinBorder,$cbPlay,$cbInst,
 foreach ($c in @($cmbSide,$cmbBtnStyle)) {
     $c.Add_SelectedIndexChanged({ Update-ActionButtons })
 }
+# The target disc changes the answer on the advice line, not only the buttons.
+$cmbMedia.Add_SelectedIndexChanged({ Update-MediaLabel; Update-ActionButtons })
 
 Update-ActionButtons   # start greyed out - nothing to open yet
 Update-GameList        # and the same for Change.../Remove, with an empty list

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -480,6 +480,25 @@ function Get-DiscPlanText([hashtable]$plan, [string]$mediaKey) {
     return "$n discs of $name"
 }
 
+# Every label a build of $discs discs will use, in order. One disc gives one
+# plain label, which is what a single-disc build has always written.
+function Get-SetLabels([string]$label, [int]$discs) {
+    $n = $(if ($discs -lt 1) { 1 } else { $discs })
+    return ,@(1..$n | ForEach-Object { Get-DiscSetLabel $label $_ $n })
+}
+
+# What a build is about to write, and how much of it is already there. The BUILD
+# button and the confirmation dialog both ask this - separately, they drifted: the
+# dialog listed "RETRO NIGHT D1.iso" and "D2.iso" while the button was still
+# asking whether "RETRO NIGHT.iso" existed, a name a set never writes, so it read
+# BUILD ISO over a folder holding the whole set.
+function Get-BuildTargets([string]$outDir, [string]$label, [int]$discs) {
+    $labels = Get-SetLabels $label $discs
+    $isos   = @($labels | ForEach-Object { Get-IsoPath $outDir $_ })
+    $have   = @($labels | Where-Object { Test-AlreadyBuilt $outDir $_ })
+    return @{ Labels=@($labels); Isos=$isos; Existing=$have.Count; Count=@($labels).Count }
+}
+
 # What This PC calls each disc in a set. A set of one keeps the plain label:
 # a disc with no set around it should not announce itself as "D1".
 function Get-DiscSetLabel([string]$label, [int]$n, [int]$of) {
@@ -2408,8 +2427,14 @@ function Update-DiscWideLabels($plan) {
     if ($script:grpX.Text   -ne $cap) { $script:grpX.Text   = $cap }
 }
 
+# How many discs the current form comes to. Cached by Update-MediaLabel rather than
+# recomputed by Update-ActionButtons: planning walks the extras folder, and the
+# buttons refresh on every keystroke in the disc label.
+$script:PlannedDiscs = 1
+
 function Update-MediaLabel {
     $games = Get-Games
+    $script:PlannedDiscs = 1
     Update-MediaOptions
     if ($games.Count -eq 0) {
         # Removing the last entry has to clear this line, not leave it alone.
@@ -2447,6 +2472,7 @@ function Update-MediaLabel {
         # user has told DiscWright which discs are actually in the drawer.
         $pi   = Get-PlanInputs $p
         $plan = Get-DiscPlan $games $key $pi.Overhead $pi.FirstDiscExtra
+        if ($plan.Ok) { $script:PlannedDiscs = @($plan.Discs).Count }
         $lblGame.Text = "$txt   ->   $(Get-DiscPlanText $plan $key)"
         $lblGame.ForeColor = if($plan.Ok){[System.Drawing.Color]::Green}else{[System.Drawing.Color]::DarkOrange}
         Update-DiscWideLabels $plan
@@ -2563,13 +2589,18 @@ function Update-ActionButtons {
     # The button names the file it is about to write, so REBUILD always means "this
     # exact file is going to be overwritten" rather than "there is something in that
     # folder somewhere".
-    $isoNow = Get-IsoPath $t $txtLabel.Text.Trim()
-    if (Test-AlreadyBuilt $t $txtLabel.Text.Trim()) {
+    $bt     = Get-BuildTargets $t $txtLabel.Text.Trim() $script:PlannedDiscs
+    $isoNow = $(if (@($bt.Isos).Count) { $bt.Isos[0] } else { '' })
+    $names  = ($bt.Isos | Where-Object { $_ } | ForEach-Object { Split-Path $_ -Leaf }) -join ', '
+    if ($bt.Existing -gt 0) {
         $btnBuild.Text = 'REBUILD ISO'
-        $tips.SetToolTip($btnBuild, "Replace $(Split-Path $isoNow -Leaf) and rebuild the disc folder")
+        $tips.SetToolTip($btnBuild, $(if ($bt.Count -gt 1) { "Rebuild the set - $($bt.Existing) of $($bt.Count) already there: $names" }
+                                      else { "Replace $names and rebuild the disc folder" }))
     } else {
         $btnBuild.Text = 'BUILD ISO'
-        $tips.SetToolTip($btnBuild, $(if($isoNow){"Write $(Split-Path $isoNow -Leaf) and the disc folder"}else{'Build the disc folder and ISO'}))
+        $tips.SetToolTip($btnBuild, $(if (-not $names) { 'Build the disc folder and ISO' }
+                                      elseif ($bt.Count -gt 1) { "Write $($bt.Count) ISOs and the disc folder: $names" }
+                                      else { "Write $names and the disc folder" }))
     }
 
     # Divider and panel side are painted into bg.png by New-Background, which is
@@ -3526,11 +3557,10 @@ $btnBuild.Add_Click({
     $stage      = Join-Path $outDir 'disc'
     # Every ISO this build is about to write, so the confirmation can name them
     # rather than describe "the ISO" and then quietly replace three files.
-    $setLabels  = @(1..$discCount | ForEach-Object { Get-DiscSetLabel $txtLabel.Text.Trim() $_ $discCount })
-    $setIsos    = @($setLabels | ForEach-Object { Get-IsoPath $outDir $_ })
+    $bt         = Get-BuildTargets $outDir $txtLabel.Text.Trim() $discCount
+    $setIsos    = @($bt.Isos)
     $isoPath    = $setIsos[0]
-    $existing   = @($setLabels | Where-Object { Test-AlreadyBuilt $outDir $_ })
-    $isoExists  = ($existing.Count -gt 0)
+    $isoExists  = ($bt.Existing -gt 0)
     $stageExists = Test-Path $stage
     # Ask before destroying anything - but only about what actually goes. The ISO
     # named by THIS label, and the staging folder. A differently named ISO sitting
@@ -3544,7 +3574,7 @@ $btnBuild.Add_Click({
         $isoList = ($setIsos | ForEach-Object { '  ' + (Split-Path $_ -Leaf) }) -join "`r`n"
         if ($discCount -gt 1) {
             $msg = "Build a set of $discCount discs in:`r`n$outDir`r`n`r`nThese will be written:`r`n$isoList"
-            if ($isoExists) { $msg += "`r`n`r`n$($existing.Count) of them already exist and will be replaced." }
+            if ($isoExists) { $msg += "`r`n`r`n$($bt.Existing) of them already exist and will be replaced." }
             $msg += "`r`n`r`nAny other ISO already in this folder is left alone."
         } elseif ($isoExists) {
             $msg = "Rebuild the disc in:`r`n$outDir`r`n`r`n$isoName already exists and will be replaced."

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -2388,6 +2388,26 @@ function Get-CurrentPlan([hashtable]$payload=$null) {
     return (Get-DiscPlan (Get-Games) $key $pi.Overhead $pi.FirstDiscExtra)
 }
 
+# When a set is planned, say on the form where the disc-wide content lands. Only
+# the surprising case is annotated: unticked means disc 1 alone and nothing else
+# on the form says so, while ticked is spelled out on the checkbox itself.
+#
+# $script: on every control, deliberately. The entry dialog declares its own
+# $lblMan for "Its own manual:", and PowerShell's dynamic scoping would hand
+# that one to this function whenever it is reached from inside that dialog.
+function Update-DiscWideLabels($plan) {
+    if (-not $script:lblMan -or -not $script:lblEx -or -not $script:grpX) { return }
+    $isSet = ($plan -and $plan.Ok -and @($plan.Discs).Count -gt 1)
+    $note  = ($isSet -and -not $script:chkXAll.Checked)
+    $man  = $(if ($note) { 'Manual file (disc 1):' }   else { 'Manual file:' })
+    $ext  = $(if ($note) { 'Extras folder (disc 1):' } else { 'Extras folder:' })
+    $cap  = $(if ($note) { '5)  Extra content (copied to disc 1 of the set)' }
+             else        { '5)  Extra content (copied to the disc root as-is)' })
+    if ($script:lblMan.Text -ne $man) { $script:lblMan.Text = $man }
+    if ($script:lblEx.Text  -ne $ext) { $script:lblEx.Text  = $ext }
+    if ($script:grpX.Text   -ne $cap) { $script:grpX.Text   = $cap }
+}
+
 function Update-MediaLabel {
     $games = Get-Games
     Update-MediaOptions
@@ -2398,6 +2418,7 @@ function Update-MediaLabel {
         # the form accounted for any more.
         $lblGame.Text = ''
         $lblGame.ForeColor = [System.Drawing.Color]::DimGray
+        Update-DiscWideLabels $null
         return
     }
     $g = $games[0]
@@ -2428,9 +2449,11 @@ function Update-MediaLabel {
         $plan = Get-DiscPlan $games $key $pi.Overhead $pi.FirstDiscExtra
         $lblGame.Text = "$txt   ->   $(Get-DiscPlanText $plan $key)"
         $lblGame.ForeColor = if($plan.Ok){[System.Drawing.Color]::Green}else{[System.Drawing.Color]::DarkOrange}
+        Update-DiscWideLabels $plan
     } else {
         $lblGame.Text = "$txt   ->   Disc: $($m.Text)"
         $lblGame.ForeColor = if($m.Fit){[System.Drawing.Color]::Green}else{[System.Drawing.Color]::DarkOrange}
+        Update-DiscWideLabels $null
     }
     Set-StatusTip $lblGame.Text
     # A missing installer part outranks the media advice - it is the thing that

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -305,9 +305,24 @@ function Get-MediaTiers {
 # always done, which is recommend a size and build exactly one disc.
 function Get-MediaAutoText { return 'Fit on one disc (recommended)' }
 
-# The dropdown shows names; everything else works in keys.
+# What one row of the dropdown reads, given what the planner made of that tier.
+# The list is where the question "which disc should I use" gets asked, so it is
+# where the answer belongs. No games on the form means no plan and no annotation.
+function Get-MediaOptionText([hashtable]$tier, $plan) {
+    if (-not $plan) { return [string]$tier.Name }
+    if (-not $plan.Ok) { return ("{0}  -  will not fit" -f $tier.Name) }
+    $n = @($plan.Discs).Count
+    return ("{0}  -  {1} disc{2}" -f $tier.Name, $n, $(if ($n -eq 1) { '' } else { 's' }))
+}
+
+# The dropdown shows names; everything else works in keys. Rows carry an
+# annotation once there is something to plan, so a row is matched on the tier
+# name it starts with rather than on the whole string.
 function Get-MediaKeyFromName([string]$name) {
-    foreach ($t in Get-MediaTiers) { if ($t.Name -eq $name) { return $t.Key } }
+    $n = "$name".Trim()
+    foreach ($t in Get-MediaTiers) {
+        if ($n -eq $t.Name -or $n.StartsWith($t.Name + '  ')) { return $t.Key }
+    }
     return ''
 }
 function Get-MediaNameFromKey([string]$key) {
@@ -2291,6 +2306,57 @@ function Get-PlanInputs([hashtable]$payload=$null) {
 # The medium the form is currently pointed at, '' for the automatic setting.
 function Get-SelectedMediaKey { return (Get-MediaKeyFromName ([string]$cmbMedia.SelectedItem)) }
 
+# Rebuilding the rows re-enters through SelectedIndexChanged, and the handler
+# calls straight back here. One flag rather than unhooking the event: unhooking
+# and rehooking a WinForms handler around every list refresh is the kind of thing
+# that eventually leaves it unhooked.
+$script:MediaRowsBusy = $false
+
+# Re-annotate the dropdown for what is on the form now. Selection is restored by
+# KEY, because the text it was selected by has just changed underneath it.
+function Update-MediaOptions {
+    if ($script:MediaRowsBusy) { return }
+    $games = Get-Games
+    $pi    = $(if ($games.Count) { Get-PlanInputs } else { $null })
+    $rows  = @((Get-MediaAutoText))
+    foreach ($t in Get-MediaTiers) {
+        $plan = $null
+        if ($games.Count) { $plan = Get-DiscPlan $games $t.Key $pi.Overhead $pi.FirstDiscExtra }
+        $rows += (Get-MediaOptionText $t $plan)
+    }
+    # Only touch the control when something actually changed. Rewriting the list
+    # on every keystroke would close the dropdown under a user reading it.
+    $now = @($cmbMedia.Items | ForEach-Object { [string]$_ })
+    if (($now -join '|') -eq ($rows -join '|')) { return }
+
+    $key = Get-SelectedMediaKey
+    $script:MediaRowsBusy = $true
+    try {
+        $cmbMedia.BeginUpdate()
+        $cmbMedia.Items.Clear()
+        [void]$cmbMedia.Items.AddRange([object[]]$rows)
+        $idx = 0
+        if ($key) {
+            for ($i = 1; $i -lt $rows.Count; $i++) {
+                if ((Get-MediaKeyFromName $rows[$i]) -eq $key) { $idx = $i; break }
+            }
+        }
+        $cmbMedia.SelectedIndex = $idx
+    } finally {
+        $cmbMedia.EndUpdate()
+        $script:MediaRowsBusy = $false
+    }
+}
+
+# Point the dropdown at a medium by key. Used when a project is reopened: the row
+# text depends on what is on the form, so the key is the only stable handle.
+function Select-MediaKey([string]$key) {
+    for ($i = 0; $i -lt $cmbMedia.Items.Count; $i++) {
+        if ((Get-MediaKeyFromName ([string]$cmbMedia.Items[$i])) -eq $key) { $cmbMedia.SelectedIndex = $i; return }
+    }
+    $cmbMedia.SelectedIndex = 0
+}
+
 # The plan for what is on the form right now, or $null when no target is chosen.
 function Get-CurrentPlan([hashtable]$payload=$null) {
     $key = Get-SelectedMediaKey
@@ -2301,6 +2367,7 @@ function Get-CurrentPlan([hashtable]$payload=$null) {
 
 function Update-MediaLabel {
     $games = Get-Games
+    Update-MediaOptions
     if ($games.Count -eq 0) {
         # Removing the last entry has to clear this line, not leave it alone.
         # Returning early left the previous disc's summary sitting under an empty
@@ -3053,7 +3120,7 @@ function Open-Project([string]$folder) {
     # false for every project ever saved and the target disc was silently dropped
     # on reopen. Found by hand-testing the round trip, which no test covered.
     $mk = $(if ($p.ContainsKey('MediaKey')) { [string]$p.MediaKey } else { '' })
-    $cmbMedia.SelectedItem = $(if ($mk -and (Get-MediaCapacity $mk) -gt 0) { Get-MediaNameFromKey $mk } else { Get-MediaAutoText })
+    if ((Get-MediaCapacity $mk) -le 0) { $mk = '' }
     if ($p.IconPath -and (Test-Path $p.IconPath)) { Set-IconFile $p.IconPath } else { & $log "  icon missing - pick one again." }
 
     $chkMenu.Checked = $p.Menu
@@ -3088,6 +3155,12 @@ function Open-Project([string]$folder) {
 
     $out = $p.OutDir; if (-not $out -or -not (Test-Path $out)) { $out = Split-Path $disc -Parent }
     $txtOut.Text = $out
+
+    # Last, not beside the label: the rows are annotated from the entries, so the
+    # list this has to find its medium in does not exist until they are loaded.
+    Update-MediaOptions
+    Select-MediaKey $mk
+    Update-MediaLabel
 
     $state.Loading = $false
     Update-ActionButtons

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -3354,14 +3354,23 @@ $btnBg.Add_Click({ $d=New-FileDialog 'Pick the menu background' 'Images|*.png;*.
 $btnMusic.Add_Click({ $d=New-FileDialog 'Pick the background music' 'Audio|*.mp3;*.wav;*.wma' $txtMusic.Text; if($d.ShowDialog() -eq 'OK'){ Set-LastFileBrowse $d.FileName; $txtMusic.Text=$d.FileName; $state.MusicFile=$d.FileName } })
 # Manuals are usually PDF but plenty ship as text or HTML, and the menu just
 # shell-executes whatever it is - nothing in the pipeline needs it to be a PDF.
-$btnMan.Add_Click({ $d=New-FileDialog 'Pick the manual for this disc' 'Manuals|*.pdf;*.txt;*.htm;*.html;*.rtf;*.doc;*.docx|All files|*.*' $txtMan.Text; if($d.ShowDialog() -eq 'OK'){ Set-LastFileBrowse $d.FileName; $txtMan.Text=$d.FileName; $state.ManualPath=$d.FileName; Update-MediaLabel } })
+# Both of these refresh the BUTTONS as well as the advice line. What they set -
+# the disc-wide manual and extras - is what decides whether "put them on every
+# disc" has anything to govern, and that rule lives in Update-ActionButtons.
+# Without this the checkbox sat greyed out with a folder chosen right above it.
+# Add-ExtraItem has said the same thing for the step 5 list since 0.3.0.
+$btnMan.Add_Click({ $d=New-FileDialog 'Pick the manual for this disc' 'Manuals|*.pdf;*.txt;*.htm;*.html;*.rtf;*.doc;*.docx|All files|*.*' $txtMan.Text; if($d.ShowDialog() -eq 'OK'){ Set-LastFileBrowse $d.FileName; $state.ManualPath=$d.FileName; $txtMan.Text=$d.FileName; Update-MediaLabel; Update-ActionButtons } })
 $btnEx.Add_Click({
     # Folder pickers READ the shared fallback but never write it. Only a file pick
     # updates it, so choosing an extras folder cannot quietly move where the icon
     # picker opens next.
     $start = $txtEx.Text.Trim(); if (-not $start) { $start = Get-MediaBrowseFallback }
     $d=New-FolderDialog 'Pick a folder of extras to put on the disc' $start
-    if($d.ShowDialog() -eq 'OK'){ $txtEx.Text=$d.SelectedPath; $state.ExtrasPath=$d.SelectedPath; Update-MediaLabel } })
+    # $state first, box second. Assigning .Text raises TextChanged synchronously,
+    # and that handler runs Update-ActionButtons, which reads $state.ExtrasPath to
+    # decide whether the every-disc option has anything to govern. Written the
+    # other way round it read the value one statement before it was set.
+    if($d.ShowDialog() -eq 'OK'){ $state.ExtrasPath=$d.SelectedPath; $txtEx.Text=$d.SelectedPath; Update-MediaLabel; Update-ActionButtons } })
 $btnOut.Add_Click({ $d=New-FolderDialog 'Pick where the disc folder and the ISO get written' $txtOut.Text.Trim(); if($d.ShowDialog() -eq 'OK'){ $txtOut.Text=$d.SelectedPath } })
 $btnXFile.Add_Click({
     $d=New-FileDialog 'Pick any files to put on the disc' 'All files|*.*' ''

--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ produces a set that looks fine and behaves badly:
   position in the list, so one left on the next disc would show up as a game of its own.
 - **The disc-wide manual and extras go on disc 1 only.** Otherwise a 2 GB extras folder
   costs 2 GB on every disc in the set. Anything you attached to a *particular* game
-  travels with that game.
+  travels with that game. Tick **Also put the manual and extras on every disc of a set**
+  in step 5 if you would rather pay that — worth it for a small manual, not for a
+  making-of video.
 
 **A single game bigger than the disc is still refused**, by name, rather than split. That
 one needs the game's own installer to ask for the next disc, which is the next thing on

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ The launchers run the script with `-ExecutionPolicy Bypass`, the flag Windows re
 1. **Add the games** — each one a GOG folder holding `setup_*.exe` and any `.bin` parts. DiscWright reads the game's name out of the installer and tells you which disc size the lot of them needs. Add as many as fit.
 
    **Add-ons** — DLC, expansions, GOG patches, mods — are added the same way, except you pick the **installer file** rather than a folder, and it can be **any `.exe`**: the `setup_*.exe` rule is how a GOG *game* folder is recognised, and GOG ships patches as `patch_*.exe` while a mod installer is named whatever its author chose. You say which game each one belongs to. Names come from the filename and can be edited, because every GOG patch reports the game's own name as its product name — all four Hollow Knight patches call themselves "Hollow Knight".
-2. **Set the disc label** — what This PC will call the drive.
+2. **Set the disc label** — what This PC will call the drive. **Target disc** next
+   to it is where you say which discs you actually own; leave it on *Fit on one
+   disc* and DiscWright recommends a size and builds one ISO, as it always has.
 3. **Choose an icon** — a `.ico`, or any PNG/JPG and it builds a proper multi-size icon for you.
 4. **Set up the menu** — background artwork, which side the buttons sit on, which buttons you want, optional music, optional title text over the artwork.
 5. **Add extra content** — a manual, an Extras folder, or any loose files and folders to drop at the disc root. Each game can also have a manual and an Extras folder **of its own**, set when you add it; a game with none of its own falls back to the disc-wide ones.
@@ -80,6 +82,30 @@ Every build writes a `discproject.json` next to the ISO. **Open existing disc...
 Two games and two Hollow Knight patches, ending on the menu the disc will show.
 
 The patches sit on Hollow Knight's own screen rather than in the chooser, and they stay **greyed until that game is installed** — applying a patch to nothing produces an error from GOG's installer several clicks later, which is a poor place to learn the rule.
+
+### When it does not fit on one disc
+
+Pick the disc you are going to burn from **Target disc** in step 2 and the line under
+the installer list stops recommending a size and starts telling you how many discs it
+will take: *3 discs of DVD5 4.7 GB*.
+
+Each disc in the set is a whole disc. Own icon, own menu, own label — `BOXED SET D1`,
+`BOXED SET D2` — and its own ISO. There is no disc 2 that is useless without disc 1.
+
+Three rules decide what lands where, and all three exist because the alternative
+produces a set that looks fine and behaves badly:
+
+- **The order on the form is the order on the discs.** Repacking to save a disc would
+  put the game you listed first on disc 2.
+- **A game and its add-ons stay together.** A patch knows its game by that game's
+  position in the list, so one left on the next disc would show up as a game of its own.
+- **The disc-wide manual and extras go on disc 1 only.** Otherwise a 2 GB extras folder
+  costs 2 GB on every disc in the set. Anything you attached to a *particular* game
+  travels with that game.
+
+**A single game bigger than the disc is still refused**, by name, rather than split. That
+one needs the game's own installer to ask for the next disc, which is the next thing on
+the roadmap.
 
 ### Where to get artwork
 
@@ -144,10 +170,12 @@ Stated up front rather than discovered later.
 - **AutoPlay has to be allowed.** If you have previously told Windows to "Take no action" for this drive, the menu will not launch on insert. Double-clicking the drive still opens it.
 - **Paths longer than 260 characters** will fail during the copy. PowerShell 5.1 limitation.
 - **One music track** per disc, by design. Manuals are per game.
-- **No multi-disc splitting.** Anything larger than a 100 GB BD-R XL is out of scope.
+- **One game bigger than one disc cannot be split.** Several games are packed across a
+  set happily, but a single installer larger than the disc you picked is refused by
+  name. Spreading one game's `.bin` parts across a set is next on the [roadmap](ROADMAP.md).
 - **Disc labels are limited to what Windows can encode.** AutoRun reads `autorun.inf` in the system ANSI codepage and has no Unicode mode at all, so accented Latin characters are fine but Cyrillic, Greek and CJK are not. DiscWright shows you exactly what This PC will display and asks before building one it cannot represent.
 
-Not all of these are permanent — multi-disc splitting in particular is on the [roadmap](ROADMAP.md). [Issues](../../issues) is the place to ask for something, and [CHANGELOG.md](CHANGELOG.md) records what has changed between releases.
+Not all of these are permanent — splitting one game across a set in particular is on the [roadmap](ROADMAP.md). [Issues](../../issues) is the place to ask for something, and [CHANGELOG.md](CHANGELOG.md) records what has changed between releases.
 
 ## Media sizes
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,6 +31,26 @@ on the continuation discs, and a check that the default path really does resolve
 swap. That last one is testable by mounting two ISOs to the same drive letter in turn, no
 burning required.
 
+**What it will not be able to promise.** DiscWright can only move whole files, and GOG
+slices its installers at about 4 GB — measured across four real downloads:
+
+```
+Alan Wake      4.00 GB + 3.79 GB
+The Witcher    4.00 GB + 4.00 GB + 1.48 GB
+Dead Space     3.91 GB + 3.91 GB + 0.29 GB
+Hollow Knight  1.16 GB, one file, nothing to split
+```
+
+So one slice is the floor. **No game with `.bin` parts can go on CDs**, however many you
+have, and re-slicing is not a way out: the installer asks for the exact filenames GOG
+produced, and half of one is not a file it recognises. A 100 GB game is roughly 25
+slices — about 25 DVDs, 5 BD-Rs, or 2 BD-R XLs.
+
+Whether a disc takes one slice or two depends on the exact slice size rather than the
+tier: two of Dead Space's 3.91 GB parts fit a DVD9's 7.95 GB, two 4.00 GB parts do not.
+CDs keep the role they already have here, the sub-700 MB back catalogue, where the whole
+game is a single `.exe` and none of this arises.
+
 ## Delivered
 
 **Several games across a disc set** — the first half of multi-disc splitting, requested

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,13 +15,28 @@ feature only creates pressure to cram things in to justify it.
 
 ## Next
 
-**Multi-disc splitting.** The largest thing still outstanding, and the one most likely to
-be asked for next: anything bigger than a single disc is a known limitation today. It was
-requested twice, independently, within hours of the first release. Needs a splitting
-strategy, a volume label convention, and a menu that can ask for disc 2 — which is,
-admittedly, most of what made the original experience feel like the original experience.
+**Splitting one game across a set.** Half of multi-disc splitting shipped: several games
+are now packed onto as many discs as they need. What is left is the harder and better
+half — a single installer larger than one disc.
+
+This turns out to be more promising than expected. GOG's installers are Inno Setup with
+disk spanning switched on: run one without a `.bin` part beside it and it raises
+*"Installer needs the next part (.BIN) file"* with a path box, rather than failing. It
+also runs from a temp copy of itself, so ejecting disc 1 mid-install is safe, and it
+defaults the path to the installer's own folder — so a set that keeps the same layout on
+every disc may need nothing more than a disc swap and OK.
+
+Needs: parts distributed across the set, a menu that explains the swap, Install disabled
+on the continuation discs, and a check that the default path really does resolve after a
+swap. That last one is testable by mounting two ISOs to the same drive letter in turn, no
+burning required.
 
 ## Delivered
+
+**Several games across a disc set** — the first half of multi-disc splitting, requested
+twice within hours of the first release. Say which disc you own and the games are packed
+onto as many as it takes, in the order they sit on the form, with each game's add-ons
+kept alongside it and every disc standing on its own.
 
 **More than one installer on a disc** — shipped in 0.3.0, and it was the most-asked-for
 thing on this page. Several games on one disc with a chooser in the menu; DLC, expansions,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -82,6 +82,26 @@ finding a `setup_*.exe` — see *Installers that are not from GOG* under Conside
 
 ## Later
 
+**Say which blank each disc in a set actually needs.** A set is planned against one
+medium, so every disc is assumed to be the same size — and the last disc of a set is
+usually nowhere near full. Building Hollow Knight and Alan Wake for DVD9 today gives a
+1.8 GB disc and a 7.8 GB one, and the first of those wastes most of an expensive blank
+for no reason.
+
+DiscWright already knows each disc's payload, so it can simply say: *disc 1, 1.8 GB, a
+DVD5 will do; disc 2, 7.8 GB, needs a DVD9*. Nothing about the packing changes. It is a
+line of advice, and it costs one pass over a plan that has already been computed.
+
+The bigger version of this — telling DiscWright how many blanks of each size you own and
+letting it pack accordingly — is deliberately **not** the plan. It turns a simple problem
+into bin packing with heterogeneous bins, it needs a real inventory in the interface, and
+on the cases tried it changes which disc things land on without changing how many discs
+or which blanks get used. Advice gets nearly all of the benefit for almost none of it.
+
+Worth doing after splitting one game across a set, not before: a single game sliced at
+4 GB is where the waste becomes routine. One 4.00 GB slice on a DVD9 leaves 3.95 GB
+unused on every disc in the set, and a DVD5 would have been the right blank throughout.
+
 **Artwork without the detour through an image editor.** Two requests that meet in the
 middle. One: fetch the game's icon and cover art automatically rather than making you hunt
 for a PNG. Two: build printable case inserts as well as the disc face — cover on the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,25 +31,38 @@ on the continuation discs, and a check that the default path really does resolve
 swap. That last one is testable by mounting two ISOs to the same drive letter in turn, no
 burning required.
 
-**What it will not be able to promise.** DiscWright can only move whole files, and GOG
-slices its installers at about 4 GB — measured across four real downloads:
+**What this depends on, and it is worth stating plainly.** DiscWright would not cut
+anything up — GOG already ships a large game as numbered `.bin` parts, and all this
+feature does is put different existing parts on different discs. Nothing is sliced,
+joined or modified. So the whole idea rests on GOG continuing to split its installers
+the way it does today. Were they ever to switch to a single enormous file per game,
+there would be nothing left to distribute and the feature would stop applying to new
+downloads.
+
+That looks safe rather than lucky. Measured across six games from four publishers,
+1 GB to 137 GB, every one slices at about 4 GB:
 
 ```
-Alan Wake      4.00 GB + 3.79 GB
-The Witcher    4.00 GB + 4.00 GB + 1.48 GB
-Dead Space     3.91 GB + 3.91 GB + 0.29 GB
-Hollow Knight  1.16 GB, one file, nothing to split
+Baldur's Gate 3   137.0 GB   33 parts   4.15 GB each
+Cyberpunk 2077    113.1 GB   28 parts   4.04 GB each
+The Witcher         9.48 GB   3 parts   4.00 / 4.00 / 1.48
+Dead Space          8.13 GB   3 parts   3.91 / 3.91 / 0.29
+Alan Wake           7.79 GB   2 parts   4.00 / 3.79
+Hollow Knight       1.16 GB   1 file    nothing to split
 ```
 
-So one slice is the floor. **No game with `.bin` parts can go on CDs**, however many you
-have, and re-slicing is not a way out: the installer asks for the exact filenames GOG
-produced, and half of one is not a file it recognises. A 100 GB game is roughly 25
-slices — about 25 DVDs, 5 BD-Rs, or 2 BD-R XLs.
+There is a reason it holds. 4 GiB is the largest file FAT32 can store, Inno Setup has
+`DiskSliceSize` precisely for that, and GOG sets it just under the line. It is a
+deliberate constraint rather than a habit, which makes it unlikely to change quietly.
 
-Whether a disc takes one slice or two depends on the exact slice size rather than the
-tier: two of Dead Space's 3.91 GB parts fit a DVD9's 7.95 GB, two 4.00 GB parts do not.
-CDs keep the role they already have here, the sub-700 MB back catalogue, where the whole
-game is a single `.exe` and none of this arises.
+The practical consequence is that **one slice is the smallest thing that can move**.
+A 100 GB game is roughly 25 pieces, so two BD-R XLs or six BD-Rs. Whether a disc takes
+one piece or two depends on the exact slice size rather than the tier: two of Dead
+Space's 3.91 GB parts fit a DVD9's 7.95 GB, two 4.00 GB parts do not.
+
+If a game ever did arrive as one indivisible file, nothing breaks - the planner treats a
+slice as an atom, so it would refuse by name exactly as it refuses The Witcher on a DVD5
+today.
 
 ## Delivered
 

--- a/docs/MANUAL-TEST-multi-disc.md
+++ b/docs/MANUAL-TEST-multi-disc.md
@@ -1,0 +1,304 @@
+# Manual test - disc sets (PR #24)
+
+Branch `feat/multi-disc-splitting`. Launch with:
+
+```
+powershell -ExecutionPolicy Bypass -File C:\Users\lazar\DiscWright\DiscWright.ps1
+```
+
+Every expected string here was produced by running the current code against the real
+games in `F:\DWdemo`. They are exact, spacing included. A difference is a finding,
+not a rounding error.
+
+| Game | Detected name | Size |
+|---|---|---|
+| Hollow Knight | `Hollow Knight` | 1.16 GB |
+| Alan Wake | `Alan Wake` | 7.79 GB |
+| Dead Space | `Dead Space` | 8.13 GB |
+| The Witcher | `The Witcher - Enhanced Edition` | 9.48 GB |
+
+**Make `C:\dwtest` first and use it as the output folder.** The demo folders are
+junctions to `C:`, so an output folder on `C:` lets DiscWright hardlink the installers
+instead of copying them across volumes - about a minute for the two-disc build instead
+of about three.
+
+Around fifteen minutes end to end, most of it test 6.
+
+---
+
+## 1. Untouched, nothing has changed
+
+The feature has to be invisible until asked for.
+
+1. **Add game...** -> `F:\DWdemo\Hollow Knight`
+2. Target disc reads **`Fit on one disc (recommended)`**
+3. The line under the list reads exactly:
+
+```
+Detected: Hollow Knight  (1 file, 1.16 GB)   ->   Disc: fits DVD5 4.7 GB (single layer)
+```
+
+That is 0.4.1's wording. Anything mentioning *discs of* here means the automatic
+setting has stopped behaving the way it used to.
+
+Step 4 should read plain **`Manual file:`** and **`Extras folder:`**, and step 5
+**`5)  Extra content (copied to the disc root as-is)`**.
+
+---
+
+## 2. The dropdown answers the question
+
+Open **Target disc** with Hollow Knight still the only game. Every row carries its own
+answer:
+
+```
+Fit on one disc (recommended)
+CD-R 700 MB  -  will not fit
+DVD5 4.7 GB  -  1 disc
+DVD9 8.5 GB (dual layer)  -  1 disc
+BD-R 25 GB  -  1 disc
+BD-R DL 50 GB (dual layer)  -  1 disc
+BD-R XL 100 GB  -  1 disc
+```
+
+Rows that cannot work are **selectable on purpose**, not greyed. Pick `CD-R 700 MB`:
+
+```
+Detected: Hollow Knight  (1 file, 1.16 GB)   ->   Hollow Knight is 1.16 GB, too big for a CD-R 700 MB
+```
+
+That sentence is the reason for not greying the row - a disabled row could name
+neither the game nor its size. Then `DVD5 4.7 GB`:
+
+```
+Detected: Hollow Knight  (1 file, 1.16 GB)   ->   1 disc, DVD5 4.7 GB
+```
+
+**A single disc is never called a set** - `1 disc,` and not `1 discs of`.
+
+Back to `Fit on one disc (recommended)` and the old wording returns.
+
+---
+
+## 3. Two games, and the disc decides
+
+**Add game...** -> `F:\DWdemo\Alan Wake`.
+
+| Choose | Line reads |
+|---|---|
+| `DVD9 8.5 GB (dual layer)` | `2 games (8.94 GB)   ->   2 discs of DVD9 8.5 GB` |
+| `BD-R 25 GB` | `2 games (8.94 GB)   ->   1 disc, BD-R 25 GB` |
+| `DVD5 4.7 GB` | `2 games (8.94 GB)   ->   Alan Wake is 7.79 GB, too big for a DVD5 4.7 GB` |
+
+The rows follow along - on `DVD9` the list now reads `2 discs`, and CD-R and DVD5
+`will not fit`.
+
+**The refusal names the game and its own size.** The line begins with 8.94 GB, so
+without `is 7.79 GB` it would read as though the total were the problem.
+
+---
+
+## 4. The case that is deliberately refused
+
+Select Alan Wake, **Remove**. **Add game...** -> `F:\DWdemo\The Witcher`.
+
+| Choose | Line reads |
+|---|---|
+| `DVD9 8.5 GB (dual layer)` | `2 games (10.64 GB)   ->   The Witcher - Enhanced Edition is 9.48 GB, too big for a DVD9 8.5 GB` |
+| `BD-R 25 GB` | `2 games (10.64 GB)   ->   1 disc, BD-R 25 GB` |
+
+That first line is the longest one these games can produce. **It must not be cut off
+mid-word.** Ending in `...` is acceptable if hovering shows the whole line in a
+tooltip; a hard cut is a bug.
+
+Splitting one game across discs is the next change, not this one. What matters here is
+that it refuses by name instead of building something unburnable.
+
+---
+
+## 5. A game and its patches stay together
+
+1. **New disc**, answer **Yes**
+2. **Add game...** -> `F:\DWdemo\Hollow Knight`
+3. **Add-on...** -> `F:\DWdemo\Hollow Knight\patch_hollow_knight_1.5.78.11833a_(85515)_to_1.5.12459_(88294).exe`,
+   belongs to **Hollow Knight**, name `Update 1.5.12459 (88294)`
+4. **Add game...** -> `F:\DWdemo\Alan Wake`
+5. Target disc: `DVD9 8.5 GB (dual layer)`
+
+Three entries, and the line reads:
+
+```
+2 games + 1 add-on (8.95 GB)   ->   2 discs of DVD9 8.5 GB
+```
+
+**Two discs, not three.** Three would mean a group was split and the patch stranded
+away from its game.
+
+---
+
+## 6. Build the set and look at it
+
+Keep the form from test 5 and fill in the rest.
+
+1. Disc label: **`RETRO NIGHT`**
+2. Step 3 icon: `F:\DWdemo\artwork\alanwake-icon.ico`
+3. Step 4 background: `F:\DWdemo\artwork\alanwake-background.jpg`
+4. Step 4, tick **Extras** first (Browse stays disabled until you do), then
+   **Extras folder: Browse...** -> `F:\DWdemo\media\DiscExtras`. The
+   **Also put the manual and extras on every disc of a set** box in step 5 must stop
+   being greyed the moment the folder is chosen
+5. Output folder: `C:\dwtest`
+
+The line now reads:
+
+```
+2 games + 1 add-on (8.95 GB) + 5 MB extra   ->   2 discs of DVD9 8.5 GB
+```
+
+### 6a. The form says where the extras go
+
+**Look at the labels, not the boxes** - this is easy to walk straight past. With the
+target on `DVD9` and two discs planned, step 4 and step 5 read:
+
+- **`Manual file (disc 1):`**
+- **`Extras folder (disc 1):`**
+- **`5)  Extra content (copied to disc 1 of the set)`**
+
+Flip the target back to `Fit on one disc` and all three lose the note; flip to `DVD9`
+and it returns. If they never show the note at all, that is a bug - it was verified
+working, so a failure here means something regressed. This is the disclosure that the every-disc option, which lives down in
+step 5, governs step 4 as well.
+
+### 6b. Build
+
+**BUILD ISO.** The confirmation names both files rather than saying "the ISO":
+
+```
+Build a set of 2 discs in:
+C:\dwtest
+
+These will be written:
+  RETRO NIGHT D1.iso
+  RETRO NIGHT D2.iso
+```
+
+While it runs the elapsed line reads **`D1/2  45%  0:32`** and later **`D2/2 ...`**.
+The bar fills twice; without the tag the second pass reads as the first restarting.
+
+Afterwards `C:\dwtest` holds exactly:
+
+```
+RETRO NIGHT D1.iso        about 1.2 GB
+RETRO NIGHT D2.iso        about 7.8 GB
+discproject.json          ONE file, describing the whole set
+disc\                     staging, holding disc 2
+```
+
+**One project file.** Two ISOs and a project describing only Alan Wake would mean the
+last disc overwrote it.
+
+### 6c. Mount both
+
+Right-click each ISO -> **Mount**.
+
+| | Disc 1 | Disc 2 |
+|---|---|---|
+| Name in This PC | `RETRO NIGHT D1` | `RETRO NIGHT D2` |
+| Icon | the Alan Wake icon | the same icon |
+| Menu caption | `HOLLOW KNIGHT` above `Disc 1 of 2` | `ALAN WAKE` above `Disc 2 of 2` |
+| Chooser | none - one game | none - one game |
+| Install buttons | Install, plus one for the patch | Install only |
+| `Extras\` at the root | **present** | **absent** |
+| Extras button in the menu | works | **greyed** |
+
+The four that matter most:
+
+- **The two names in This PC differ.** The same name on both would mean the volume id
+  truncated past the disc number.
+- **The menu says which game and which disc.** Without it the two discs are
+  indistinguishable - same icon, same artwork.
+- **The patch is on disc 1, with Hollow Knight.** Not on disc 2, and not as a game of
+  its own in a chooser.
+- **`Extras\` is on disc 1 only**, and disc 2 greys the button rather than offering a
+  broken one.
+
+---
+
+## 7. Extras on every disc
+
+1. Back in the app, tick **Also put the manual and extras on every disc of a set**
+2. The three labels from 6a lose their `(disc 1)` note - the checkbox now says it in
+   words, so repeating it would be noise
+3. **BUILD ISO** again, **Yes** to replacing both
+4. Mount `RETRO NIGHT D2.iso`: `Extras\` is now **present** and the Extras button works
+
+Untick it, rebuild, and disc 2 goes back to having no `Extras\`.
+
+With these extras at 5 MB the disc count does not change, which is correct - the
+option moves 5 MB onto each disc, nowhere near enough to need another. It would matter
+for a 2 GB folder.
+
+**Then start a new disc with nothing on the form: the checkbox is greyed out**, because
+with no manual, no Extras folder and no extra content it governs nothing.
+
+---
+
+## 8. Reopening remembers the disc
+
+1. **New disc**, **Yes**
+2. Output folder -> `C:\dwtest`
+3. **Open existing disc...**, accept `C:\dwtest`
+
+The dropdown must come back on **`DVD9 8.5 GB (dual layer)  -  2 discs`** and the line
+on `2 discs of DVD9 8.5 GB`, with all three entries and the patch still filed under
+Hollow Knight. The every-disc tick comes back the way you left it.
+
+This is the one that was broken: the project file was written correctly and the read
+path dropped it, so every reopen silently fell back to `Fit on one disc`.
+
+---
+
+## 9. A project from before this change
+
+`F:\DWdemo\out\discproject.json` was written by 0.4.1 and has no target disc in it.
+
+1. **New disc**, **Yes**
+2. Output folder -> `F:\DWdemo\out`
+3. **Open existing disc...**
+
+It must open on **`Fit on one disc (recommended)`** with the old `Disc: ` wording, and
+the every-disc box unticked. Older projects described a single disc and have to keep
+describing one.
+
+---
+
+## 10. New disc puts everything back
+
+1. Choose any medium, tick the every-disc box
+2. **New disc**, **Yes**
+3. Dropdown reads `Fit on one disc (recommended)`, box unticked, labels plain
+
+Also: on a completely fresh form **New disc is greyed out**. Choosing a medium and
+nothing else should wake it, since that is now a change worth discarding.
+
+---
+
+## What counts as a bug
+
+- Any disc in a set missing its menu or icon
+- Two discs with the same name in This PC
+- A menu that does not say which game or which disc it is
+- `Extras\` on disc 2 with the box unticked, or missing from disc 2 with it ticked
+- A patch on a different disc from its game, or showing as a game of its own
+- A chooser on a disc holding one game
+- The plan promising a number of discs and the build writing a different number
+- A status line cut off mid-word with no tooltip behind it
+- Anything at all different while `Fit on one disc` is selected
+
+## Tidying up
+
+Eject both mounted discs, then:
+
+```
+Remove-Item C:\dwtest -Recurse -Force
+```

--- a/docs/MANUAL-TEST-multi-disc.md
+++ b/docs/MANUAL-TEST-multi-disc.md
@@ -244,8 +244,10 @@ The four that matter most:
 1. Back in the app, tick **Also put the manual and extras on every disc of a set**
 2. The three labels from 6a lose their `(disc 1)` note - the checkbox now says it in
    words, so repeating it would be noise
-3. **BUILD ISO** again, **Yes** to replacing both
-4. Mount `RETRO NIGHT D2.iso`: `Extras\` is now **present** and the Extras button works
+3. The button should now read **REBUILD ISO** - the set is on disk. Hover it: *Rebuild
+   the set - 2 of 2 already there*
+4. **REBUILD ISO**, **Yes** to replacing both
+5. Mount `RETRO NIGHT D2.iso`: `Extras\` is now **present** and the Extras button works
 
 Untick it, rebuild, and disc 2 goes back to having no `Extras\`.
 
@@ -308,6 +310,7 @@ nothing else should wake it, since that is now a change worth discarding.
 - A chooser on a disc holding one game
 - The plan promising a number of discs and the build writing a different number
 - A status line cut off mid-word with no tooltip behind it
+- The button reading BUILD ISO over a folder that already holds the set
 - Anything at all different while `Fit on one disc` is selected
 
 ## Tidying up

--- a/docs/MANUAL-TEST-multi-disc.md
+++ b/docs/MANUAL-TEST-multi-disc.md
@@ -128,11 +128,24 @@ that it refuses by name instead of building something unburnable.
 Three entries, and the line reads:
 
 ```
-2 games + 1 add-on (8.95 GB)   ->   2 discs of DVD9 8.5 GB
+2 games + 1 add-on (9.55 GB)   ->   2 discs of DVD9 8.5 GB
 ```
 
 **Two discs, not three.** Three would mean a group was split and the patch stranded
 away from its game.
+
+What ends up where, for reference:
+
+| Disc | Payload | Contents |
+|---|---|---|
+| 1 | 1.76 GB | Hollow Knight 1.16 GB + its patch 0.61 GB |
+| 2 | 7.79 GB | Alan Wake |
+
+**You do not need to burn anything to run this test** - mounting the ISOs shows
+everything. If you do burn: disc 2 needs a DVD9 (7.79 GB against 7.95 GB usable, so
+0.16 GB spare), but disc 1 is only 1.8 GB and a DVD5 holds it comfortably. DiscWright
+plans the set for one medium; nothing stops you putting a small disc on a smaller
+blank.
 
 ---
 
@@ -152,7 +165,7 @@ Keep the form from test 5 and fill in the rest.
 The line now reads:
 
 ```
-2 games + 1 add-on (8.95 GB) + 5 MB extra   ->   2 discs of DVD9 8.5 GB
+2 games + 1 add-on (9.55 GB) + 5 MB extra   ->   2 discs of DVD9 8.5 GB
 ```
 
 ### 6a. The form says where the extras go
@@ -190,8 +203,8 @@ The bar fills twice; without the tag the second pass reads as the first restarti
 Afterwards `C:\dwtest` holds exactly:
 
 ```
-RETRO NIGHT D1.iso        about 1.2 GB
-RETRO NIGHT D2.iso        about 7.8 GB
+RETRO NIGHT D1.iso        about 1.8 GB   Hollow Knight + its patch
+RETRO NIGHT D2.iso        about 7.8 GB   Alan Wake
 discproject.json          ONE file, describing the whole set
 disc\                     staging, holding disc 2
 ```

--- a/docs/MANUAL-TEST-multi-disc.md
+++ b/docs/MANUAL-TEST-multi-disc.md
@@ -164,10 +164,12 @@ target on `DVD9` and two discs planned, step 4 and step 5 read:
 - **`Extras folder (disc 1):`**
 - **`5)  Extra content (copied to disc 1 of the set)`**
 
+This is the disclosure that the every-disc option, which lives down in step 5,
+governs step 4 as well.
+
 Flip the target back to `Fit on one disc` and all three lose the note; flip to `DVD9`
-and it returns. If they never show the note at all, that is a bug - it was verified
-working, so a failure here means something regressed. This is the disclosure that the every-disc option, which lives down in
-step 5, governs step 4 as well.
+and it returns. If the note never appears at all, that is a regression - it was
+verified working on this branch.
 
 ### 6b. Build
 

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -511,8 +511,26 @@ Describe 'Project file' -Tag 'Unit' {
 
     Context 'writing' {
 
-        It 'declares schema version 4' {
-            $script:PJson.Version | Should -Be 4
+        It 'declares schema version 5' {
+            $script:PJson.Version | Should -Be 5
+        }
+
+        It 'records which disc the set was planned for' {
+            # Version 5. A project saved with the automatic setting stores an
+            # empty key, which is what reopens as "fit on one disc" - the same
+            # thing a version 4 file with no key at all reopens as.
+            $script:PJson.PSObject.Properties.Name | Should -Contain 'MediaKey'
+            $script:PJson.MediaKey | Should -Be ''
+        }
+
+        It 'keeps the chosen medium when there is one' {
+            $out = Join-Path $script:POut 'withmedia'
+            New-Item -ItemType Directory -Force -Path $out | Out-Null
+            $s = New-BuildSettings -Games $script:PGames -Label 'Trilogy' -OutDir $out
+            $s.MediaKey = 'DVD5'
+            Save-Project $s $out
+            $j = Get-Content -Raw (Join-Path $out 'discproject.json') | ConvertFrom-Json
+            $j.MediaKey | Should -Be 'DVD5'
         }
 
         It 'records a Kind and a Parent for every entry' {
@@ -1941,5 +1959,464 @@ Describe 'Control characters cannot escape into what a disc carries' -Tag 'Unit'
         # The stripping is additive - it must not have loosened anything.
         ConvertTo-JsString 'He said "hi" \ <script>' | Should -Be 'He said \"hi\" \\ \x3cscript\x3e'
         ConvertTo-HtmlText '<b>&"'                   | Should -Be '&lt;b&gt;&amp;&quot;'
+    }
+}
+
+Describe 'Which disc sizes DiscWright knows about' {
+
+    It 'hands back a capacity for every tier it lists' {
+        foreach ($t in Get-MediaTiers) {
+            (Get-MediaCapacity $t.Key) | Should -Be ([double]$t.Gib * 1GB) -Because "$($t.Key) is in the table"
+        }
+    }
+
+    It 'lists the tiers smallest first, so the recommendation stops at the first fit' {
+        $gib = @(Get-MediaTiers | ForEach-Object { $_.Gib })
+        $sorted = @($gib | Sort-Object)
+        ($gib -join ',') | Should -Be ($sorted -join ',')
+    }
+
+    It 'returns nothing for a medium it has never heard of' {
+        Get-MediaCapacity 'LASERDISC' | Should -Be 0
+        Get-MediaCapacity ''          | Should -Be 0
+    }
+
+    It 'still recommends what it always did, and now says which tier that was' {
+        $cd = Get-MediaRec (0.5 * 1GB)
+        $cd.Text | Should -Be 'fits CD-R 700 MB'
+        $cd.Key  | Should -Be 'CD'
+
+        (Get-MediaRec (5 * 1GB)).Text  | Should -Be 'needs DVD9 8.5 GB (dual layer)'
+        (Get-MediaRec (10 * 1GB)).Text | Should -Be 'too big for DVD - needs BD-R 25 GB'
+    }
+
+    It 'admits when a payload is past the largest disc there is' {
+        $r = Get-MediaRec (200 * 1GB)
+        $r.Fit | Should -BeFalse
+        $r.Key | Should -Be ''
+    }
+}
+
+Describe 'Packing a set onto the discs you actually have' {
+
+    BeforeAll {
+        $script:DVD5 = Get-MediaCapacity 'DVD5'
+        $script:OVER = 10MB
+    }
+
+    It 'leaves everything on one disc when everything fits' {
+        $r = Split-DiscSet @(1GB, 1GB) $script:DVD5 $script:OVER 0
+        $r.Ok            | Should -BeTrue
+        $r.Discs.Count   | Should -Be 1
+        ($r.Discs[0] -join ',') | Should -Be '0,1'
+    }
+
+    It 'starts a second disc when the next game will not fit on the first' {
+        $r = Split-DiscSet @(2GB, 2GB, 2GB) $script:DVD5 $script:OVER 0
+        $r.Ok          | Should -BeTrue
+        $r.Discs.Count | Should -Be 2
+        ($r.Discs[0] -join ',') | Should -Be '0,1'
+        ($r.Discs[1] -join ',') | Should -Be '2'
+    }
+
+    It 'keeps the order on the form rather than repacking to save a disc' {
+        # 3 + 1 + 3 fits two discs either way, but a best-fit packer would put
+        # the two 3s together and move the 1. The list on screen is the order
+        # the menu numbers follow, so the set has to match it.
+        $r = Split-DiscSet @(3GB, 1GB, 3GB) $script:DVD5 $script:OVER 0
+        $r.Ok | Should -BeTrue
+        ($r.Discs[0] -join ',') | Should -Be '0,1'
+        ($r.Discs[1] -join ',') | Should -Be '2'
+    }
+
+    It 'gives every entry a disc, exactly once, in order' {
+        $r = Split-DiscSet @(2GB, 2GB, 2GB, 2GB, 2GB) $script:DVD5 $script:OVER 0
+        $flat = @($r.Discs | ForEach-Object { $_ })
+        ($flat -join ',') | Should -Be '0,1,2,3,4'
+    }
+
+    It 'refuses a single installer bigger than a whole disc, and says which one' {
+        # This is the case a later release handles by spreading one game's parts
+        # across the set. Producing a disc set that cannot install the game would
+        # be worse than refusing to produce one.
+        $r = Split-DiscSet @(1GB, 6GB, 1GB) $script:DVD5 $script:OVER 0
+        $r.Ok     | Should -BeFalse
+        $r.Reason | Should -Be 'entry'
+        $r.TooBig | Should -Be 1
+    }
+
+    It 'charges the disc-wide extras to disc 1 only' {
+        # 3 GB of extras plus a 1 GB game fits disc 1; the second 1 GB game does
+        # not, and lands on disc 2 - which pays nothing for the extras.
+        $r = Split-DiscSet @(1GB, 1GB) $script:DVD5 $script:OVER (3GB)
+        $r.Ok          | Should -BeTrue
+        $r.Discs.Count | Should -Be 2
+        ($r.Discs[0] -join ',') | Should -Be '0'
+        ($r.Discs[1] -join ',') | Should -Be '1'
+    }
+
+    It 'lets disc 1 carry nothing but the extras rather than refusing the set' {
+        # 4 GB of extras leaves no room on disc 1 for a 1 GB game, but every disc
+        # after it has the room. A set is still the right answer here.
+        $r = Split-DiscSet @(1GB, 1GB) $script:DVD5 $script:OVER (4GB)
+        $r.Ok            | Should -BeTrue
+        $r.Discs.Count   | Should -Be 2
+        $r.Discs[0].Count | Should -Be 0
+        ($r.Discs[1] -join ',') | Should -Be '0,1'
+    }
+
+    It 'refuses when the disc-wide extras alone are bigger than a disc' {
+        $r = Split-DiscSet @(1GB) $script:DVD5 $script:OVER (5GB)
+        $r.Ok     | Should -BeFalse
+        $r.Reason | Should -Be 'extras'
+    }
+
+    It 'refuses when the menu overhead alone would fill the medium' {
+        $r = Split-DiscSet @(1GB) (5MB) (10MB) 0
+        $r.Ok     | Should -BeFalse
+        $r.Reason | Should -Be 'capacity'
+    }
+
+    It 'returns one empty disc for an empty list rather than no discs at all' {
+        $r = Split-DiscSet @() $script:DVD5 $script:OVER 0
+        $r.Ok          | Should -BeTrue
+        $r.Discs.Count | Should -Be 1
+    }
+
+    It 'counts the overhead against every disc in the set' {
+        # Two games of exactly half a disc each fit together only if the menu is
+        # free, which it is not.
+        $half = $script:DVD5 / 2
+        $r = Split-DiscSet @($half, $half) $script:DVD5 $script:OVER 0
+        $r.Discs.Count | Should -Be 2
+    }
+}
+
+Describe 'Naming the discs in a set' {
+
+    It 'leaves a lone disc alone' {
+        Get-DiscSetLabel 'ALAN WAKE' 1 1 | Should -Be 'ALAN WAKE'
+        Get-VolumeLabel  'ALAN WAKE' 1 1 | Should -Be 'ALAN_WAKE'
+    }
+
+    It 'numbers the discs when there is more than one' {
+        Get-DiscSetLabel 'ALAN WAKE' 1 3 | Should -Be 'ALAN WAKE D1'
+        Get-DiscSetLabel 'ALAN WAKE' 3 3 | Should -Be 'ALAN WAKE D3'
+    }
+
+    It 'keeps the disc number even when the name is too long to fit beside it' {
+        # The volume id is 16 characters. Truncating the finished label would cut
+        # the number off the end and give every disc in the set the same id.
+        $v = Get-VolumeLabel 'THE WITCHER ENHANCED EDITION' 2 3
+        $v.Length     | Should -BeLessOrEqual 16
+        $v            | Should -BeLike '*_D2'
+    }
+
+    It 'gives every disc in a long-named set its own volume id' {
+        $ids = 1..4 | ForEach-Object { Get-VolumeLabel 'THE WITCHER ENHANCED EDITION' $_ 4 }
+        (@($ids | Sort-Object -Unique)).Count | Should -Be 4
+    }
+
+    It 'folds a label the volume id cannot carry, and never comes back empty' {
+        Get-VolumeLabel 'Hollow Knight!' 1 1 | Should -Be 'Hollow_Knight'
+        Get-VolumeLabel '***'            1 1 | Should -Be 'DISC'
+        Get-VolumeLabel ''               2 2 | Should -Be 'DISC_D2'
+    }
+}
+
+Describe 'Keeping a game and its add-ons on the same disc' {
+
+    BeforeAll {
+        # Two games, with two patches filed under the second - the shape the
+        # multi-game GIF records, and the one most likely to straddle a disc.
+        $script:Entries = @(
+            @{ GameName='The Witcher';  Kind='Game';  ParentIndex=-1; TotalBytes=9.48GB }
+            @{ GameName='Hollow Knight';Kind='Game';  ParentIndex=-1; TotalBytes=1.16GB }
+            @{ GameName='Update 1.5';   Kind='AddOn'; ParentIndex=1;  TotalBytes=0.20GB }
+            @{ GameName='Update 1.6';   Kind='AddOn'; ParentIndex=1;  TotalBytes=0.20GB }
+        )
+    }
+
+    It 'gathers each game with the add-ons filed under it' {
+        $g = Get-EntryGroups $script:Entries
+        $g.Count | Should -Be 2
+        ($g[0] -join ',') | Should -Be '0'
+        ($g[1] -join ',') | Should -Be '1,2,3'
+    }
+
+    It 'treats an add-on whose game is gone as an entry in its own right' {
+        # Same rule the menu uses. An orphan still has to be built and still has
+        # to land on some disc, so it cannot simply vanish from the grouping.
+        $orphan = @(
+            @{ GameName='Hollow Knight'; Kind='Game';  ParentIndex=-1; TotalBytes=1GB }
+            @{ GameName='Stray patch';   Kind='AddOn'; ParentIndex=7;  TotalBytes=1GB }
+        )
+        $g = Get-EntryGroups $orphan
+        $g.Count | Should -Be 2
+        ($g[1] -join ',') | Should -Be '1'
+    }
+
+    It 'accounts for every entry exactly once' {
+        # Assign before flattening: piping the function's output straight into
+        # ForEach-Object leaves the wrapper that the ,@() return idiom exists to
+        # keep, and you get the groups back rather than the indices inside them.
+        $groups = Get-EntryGroups $script:Entries
+        $flat = @(); foreach ($g in $groups) { $flat += $g }
+        (@($flat | Sort-Object) -join ',') | Should -Be '0,1,2,3'
+    }
+}
+
+Describe 'Cutting the list down to one disc of it' {
+
+    BeforeAll {
+        $script:Entries = @(
+            @{ GameName='The Witcher';   Kind='Game';  ParentIndex=-1 }
+            @{ GameName='Hollow Knight'; Kind='Game';  ParentIndex=-1 }
+            @{ GameName='Update 1.5';    Kind='AddOn'; ParentIndex=1  }
+        )
+    }
+
+    It 'renumbers the parent so the add-on still points at its own game' {
+        # Hollow Knight is entry 1 of the full list but entry 0 of this disc.
+        # Left alone, ParentIndex=1 would point at the patch itself.
+        $d = Get-DiscEntries $script:Entries @(1,2)
+        $d.Count               | Should -Be 2
+        $d[0].GameName         | Should -Be 'Hollow Knight'
+        [int]$d[1].ParentIndex | Should -Be 0
+    }
+
+    It 'produces a slice the menu reads the same way the whole list reads' {
+        $d  = Get-DiscEntries $script:Entries @(1,2)
+        $mg = Get-MenuGames $d
+        $mg.Count            | Should -Be 1
+        $mg[0].Name          | Should -Be 'Hollow Knight'
+        $mg[0].AddOns.Count  | Should -Be 1
+    }
+
+    It 'cuts the parent loose when it did not come along' {
+        # Not a case the packer creates - groups travel whole - but a slice that
+        # silently kept a stale index would be a menu pointing at the wrong game.
+        $d = Get-DiscEntries $script:Entries @(2)
+        [int]$d[0].ParentIndex | Should -Be -1
+    }
+
+    It 'does not disturb the list it was given' {
+        $before = [int]$script:Entries[2].ParentIndex
+        Get-DiscEntries $script:Entries @(1,2) | Out-Null
+        [int]$script:Entries[2].ParentIndex | Should -Be $before
+    }
+}
+
+Describe 'Planning a set for the disc you are going to burn' {
+
+    BeforeAll {
+        $script:Two = @(
+            @{ GameName='Big';   Kind='Game';  ParentIndex=-1; TotalBytes=3GB    }
+            @{ GameName='Small'; Kind='Game';  ParentIndex=-1; TotalBytes=1.16GB }
+            @{ GameName='P1';    Kind='AddOn'; ParentIndex=1;  TotalBytes=0.2GB  }
+            @{ GameName='P2';    Kind='AddOn'; ParentIndex=1;  TotalBytes=0.2GB  }
+        )
+    }
+
+    It 'keeps a game and its patches on the same disc even when that costs a disc' {
+        # Big is 3 GB; Small plus its two patches is 1.56 GB. Both together are
+        # 4.56 GB, past a DVD5, so the group moves whole rather than leaving a
+        # patch behind on disc 1 pointing at a game that is not there.
+        $plan = Get-DiscPlan $script:Two 'DVD5' 10MB 0
+        $plan.Ok        | Should -BeTrue
+        $plan.Discs.Count | Should -Be 2
+        ($plan.Discs[0] -join ',') | Should -Be '0'
+        ($plan.Discs[1] -join ',') | Should -Be '1,2,3'
+    }
+
+    It 'puts the lot on one disc when the medium is big enough' {
+        $plan = Get-DiscPlan $script:Two 'BD25' 10MB 0
+        $plan.Ok          | Should -BeTrue
+        $plan.Discs.Count | Should -Be 1
+        ($plan.Discs[0] -join ',') | Should -Be '0,1,2,3'
+    }
+
+    It 'names the game that will not fit rather than the group that held it' {
+        $huge = @(@{ GameName='The Witcher'; Kind='Game'; ParentIndex=-1; TotalBytes=9.48GB })
+        $plan = Get-DiscPlan $huge 'DVD9' 10MB 0
+        $plan.Ok         | Should -BeFalse
+        $plan.Reason     | Should -Be 'entry'
+        $plan.TooBigName | Should -Be 'The Witcher'
+    }
+
+    It 'refuses a medium it does not have a capacity for' {
+        $plan = Get-DiscPlan $script:Two 'LASERDISC' 10MB 0
+        $plan.Ok     | Should -BeFalse
+        $plan.Reason | Should -Be 'media'
+    }
+
+    It 'hands the slicer indices it can build a working disc from' {
+        # The end-to-end shape: plan, slice, and the menu on disc 2 has to show
+        # one game carrying two add-ons - not three separate games.
+        $plan = Get-DiscPlan $script:Two 'DVD5' 10MB 0
+        $d2   = Get-DiscEntries $script:Two @($plan.Discs[1])
+        $mg   = Get-MenuGames $d2
+        $mg.Count           | Should -Be 1
+        $mg[0].Name         | Should -Be 'Small'
+        $mg[0].AddOns.Count | Should -Be 2
+    }
+}
+
+Describe 'Telling you what the plan came to' {
+
+    # @() flattens a SINGLE argument, so a one-disc @(@(0,1)) collapses into a
+    # two-element array and reads back as a two-disc set. Several arguments are
+    # left alone. The planner sidesteps both by appending with ",@()".
+    It 'counts the discs and names the medium' {
+        $plan = @{ Ok=$true; Discs=@(@(0), @(1), @(2)) }
+        Get-DiscPlanText $plan 'DVD5' | Should -Be '3 discs of DVD5 4.7 GB'
+    }
+
+    It 'does not call a single disc a set' {
+        $plan = @{ Ok=$true; Discs=@(,@(0,1)) }
+        Get-DiscPlanText $plan 'BD25' | Should -Be '1 disc, BD-R 25 GB'
+    }
+
+    It 'says which game is the problem, in the words on the dropdown' {
+        $plan = @{ Ok=$false; Reason='entry'; TooBigName='The Witcher'; Discs=@() }
+        Get-DiscPlanText $plan 'DVD5' | Should -Be 'The Witcher alone is bigger than a DVD5 4.7 GB'
+    }
+
+    It 'separates extras that will not fit from a game that will not fit' {
+        $plan = @{ Ok=$false; Reason='extras'; TooBigName=''; Discs=@() }
+        Get-DiscPlanText $plan 'CD' | Should -Be 'the extra content alone is bigger than a CD-R 700 MB'
+    }
+}
+
+Describe 'Turning what the dropdown says into what the planner needs' {
+
+    It 'round-trips every tier through its name' {
+        foreach ($t in Get-MediaTiers) {
+            Get-MediaKeyFromName $t.Name | Should -Be $t.Key
+            Get-MediaNameFromKey $t.Key  | Should -Be $t.Name
+        }
+    }
+
+    It 'reads the automatic setting as no medium at all' {
+        # This is what keeps a single disc building exactly as it always has.
+        Get-MediaKeyFromName (Get-MediaAutoText) | Should -Be ''
+        Get-MediaKeyFromName 'something else'    | Should -Be ''
+    }
+
+    It 'falls back to the automatic setting for a key it cannot place' {
+        Get-MediaNameFromKey 'LASERDISC' | Should -Be (Get-MediaAutoText)
+        Get-MediaNameFromKey ''          | Should -Be (Get-MediaAutoText)
+    }
+}
+
+Describe 'Building a set of discs' -Tag 'Build' -Skip:(-not $script:CanBuildIso) {
+
+    BeforeAll {
+        $script:SetGames = @(
+            (Get-GameInfo (New-FixtureGame -Slug 'set_alpha' -ExeMb 2)),
+            (Get-GameInfo (New-FixtureGame -Slug 'set_beta'  -ExeMb 2)),
+            (Get-GameInfo (New-FixtureGame -Slug 'set_gamma' -ExeMb 2))
+        )
+        $script:SetOut = Join-Path $script:Sandbox 'build-set'
+        New-Item -ItemType Directory -Force -Path $script:SetOut | Out-Null
+
+        # A disc-wide Extras folder, so the test can show which disc it lands on.
+        $script:SetExtras = Join-Path $script:Sandbox 'set-extras'
+        New-Item -ItemType Directory -Force -Path $script:SetExtras | Out-Null
+        Set-Content -LiteralPath (Join-Path $script:SetExtras 'bonus.txt') -Value 'bonus' -Encoding ASCII
+
+        $s = New-BuildSettings -Games $script:SetGames -Label 'Boxed Set' -OutDir $script:SetOut
+        $s.ExtrasPath = $script:SetExtras
+        # The disc-wide Extras only ship when the Extras button is switched on -
+        # the folder alone is not enough, and the default fixture buttons omit it.
+        $s.Buttons    = @('Play','Install','Extras','Exit')
+        $s.MediaKey   = 'CD'
+        # The plan is handed in rather than worked out from real sizes. How the
+        # games get divided is Get-DiscPlan's job and has its own tests; a fixture
+        # big enough to actually fill a CD would add most of a gigabyte of writing
+        # to every run to prove something already proven.
+        # @(@(0), @(1,2)) is two elements because @() only flattens a SINGLE
+        # argument - which is why a one-disc plan has to be written @(,@(0,1)).
+        $s.Plan = @{ Ok=$true; Reason=''; Discs=@(@(0), @(1,2))
+                     Capacity=(Get-MediaCapacity 'CD'); TooBigName=''; Room=[double]0 }
+
+        $script:SetIsos  = @(Invoke-BuildSet $s $script:LogSink)
+        $script:SetStage = Join-Path $script:SetOut 'disc'
+    }
+
+    It 'writes one ISO per disc' {
+        $script:SetIsos.Count | Should -Be 2
+        foreach ($i in $script:SetIsos) { Test-Path $i | Should -BeTrue }
+    }
+
+    It 'numbers the ISOs so a set does not overwrite itself' {
+        # The bug this pins: every disc named from the same label would write the
+        # same file, and a three-disc set would leave one ISO behind.
+        (Split-Path $script:SetIsos[0] -Leaf) | Should -Be 'Boxed Set D1.iso'
+        (Split-Path $script:SetIsos[1] -Leaf) | Should -Be 'Boxed Set D2.iso'
+    }
+
+    It 'saves one project file, describing the whole set rather than the last disc' {
+        $j = Get-Content -Raw (Join-Path $script:SetOut 'discproject.json') | ConvertFrom-Json
+        @($j.Games).Count | Should -Be 3
+        $j.Label          | Should -Be 'Boxed Set'
+        $j.MediaKey       | Should -Be 'CD'
+    }
+
+    It 'stages the last disc of the set, not the first' {
+        # One staging folder is reused disc by disc, so what survives is disc 2 -
+        # two games, which always live in Games\.
+        Test-Path (Join-Path $script:SetStage 'Games') | Should -BeTrue
+        @(Get-ChildItem (Join-Path $script:SetStage 'Games') -Directory).Count | Should -Be 2
+    }
+
+    It 'renumbers each disc from 01 rather than carrying on from the last one' {
+        # Disc 2 holds entries 1 and 2 of the list. On the disc they are 01 and 02:
+        # the folder numbers are the menu order for THAT disc.
+        $names = @(Get-ChildItem (Join-Path $script:SetStage 'Games') -Directory | ForEach-Object { $_.Name } | Sort-Object)
+        $names[0] | Should -BeLike '01 - *'
+        $names[1] | Should -BeLike '02 - *'
+    }
+
+    Context 'what actually ended up on each disc' -Skip:(-not $script:SevenZip) {
+
+        BeforeAll {
+            $script:D1 = Get-IsoEntries -IsoPath $script:SetIsos[0] -SevenZip $script:SevenZip
+            $script:D2 = Get-IsoEntries -IsoPath $script:SetIsos[1] -SevenZip $script:SevenZip
+        }
+
+        It 'gives every disc its own volume id' {
+            $v1 = Get-IsoVolumeId -IsoPath $script:SetIsos[0] -SevenZip $script:SevenZip
+            $v2 = Get-IsoVolumeId -IsoPath $script:SetIsos[1] -SevenZip $script:SevenZip
+            $v1 | Should -Be 'Boxed_Set_D1'
+            $v2 | Should -Be 'Boxed_Set_D2'
+        }
+
+        It 'gives every disc a menu of its own' {
+            $script:D1 | Should -Contain 'AUTORUN\menu.hta'
+            $script:D2 | Should -Contain 'AUTORUN\menu.hta'
+            $script:D1 | Should -Contain 'autorun.inf'
+            $script:D2 | Should -Contain 'autorun.inf'
+        }
+
+        It 'leaves the one game on disc 1 at the root, as a one-game disc always is' {
+            @($script:D1 | Where-Object { $_ -like 'Games\*' }).Count | Should -Be 0
+            @($script:D1 | Where-Object { $_ -like 'setup_set_alpha*' }).Count | Should -BeGreaterThan 0
+        }
+
+        It 'carries the disc-wide extras on disc 1 only' {
+            # Copying them onto every disc would multiply bonus content by the
+            # size of the set - the reason they are charged to disc 1 in the plan.
+            $script:D1 | Should -Contain 'Extras\bonus.txt'
+            @($script:D2 | Where-Object { $_ -like 'Extras\*' }).Count | Should -Be 0
+        }
+
+        It 'puts each game on exactly one disc in the set' {
+            $onD1 = @($script:D1 | Where-Object { $_ -match 'setup_set_(alpha|beta|gamma)' })
+            $onD2 = @($script:D2 | Where-Object { $_ -match 'setup_set_(alpha|beta|gamma)' })
+            ($onD1 | Where-Object { $_ -match 'beta|gamma' }).Count | Should -Be 0
+            ($onD2 | Where-Object { $_ -match 'alpha' }).Count      | Should -Be 0
+            $onD2.Count | Should -BeGreaterThan 1
+        }
     }
 }

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -523,6 +523,33 @@ Describe 'Project file' -Tag 'Unit' {
             $script:PJson.MediaKey | Should -Be ''
         }
 
+        It 'hands the chosen medium back when the project is read again' {
+            # The bug this pins: Save-Project wrote MediaKey correctly and
+            # Import-Project never copied it into what it returns, so reopening
+            # any project silently dropped the target disc. Writing the file was
+            # tested; reading it back was not.
+            $out = Join-Path $script:POut 'roundtrip'
+            New-Item -ItemType Directory -Force -Path $out | Out-Null
+            $s = New-BuildSettings -Games $script:PGames -Label 'Trilogy' -OutDir $out
+            $s.MediaKey = 'BD25'
+            Save-Project $s $out
+            $back = Import-Project (Join-Path $out 'discproject.json')
+            $back.MediaKey | Should -Be 'BD25'
+        }
+
+        It 'reads a project from before target discs existed as no medium at all' {
+            $out = Join-Path $script:POut 'v4'
+            New-Item -ItemType Directory -Force -Path $out | Out-Null
+            $s = New-BuildSettings -Games $script:PGames -Label 'Trilogy' -OutDir $out
+            Save-Project $s $out
+            $f = Join-Path $out 'discproject.json'
+            # Strip the key back out, which is what a 0.4.1 file looks like.
+            $j = Get-Content -Raw $f | ConvertFrom-Json
+            $j.PSObject.Properties.Remove('MediaKey')
+            $j | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $f -Encoding UTF8
+            (Import-Project $f).MediaKey | Should -Be ''
+        }
+
         It 'keeps the chosen medium when there is one' {
             $out = Join-Path $script:POut 'withmedia'
             New-Item -ItemType Directory -Force -Path $out | Out-Null
@@ -2242,6 +2269,20 @@ Describe 'Planning a set for the disc you are going to burn' {
         $plan.Ok         | Should -BeFalse
         $plan.Reason     | Should -Be 'entry'
         $plan.TooBigName | Should -Be 'The Witcher'
+        $plan.TooBigBytes | Should -Be 9.48GB
+    }
+
+    It 'reports the whole group size when a game plus its add-ons is what overflows' {
+        # The figure has to describe what the packer actually refused, which is
+        # the group - naming the game's size alone would not add up.
+        $grp = @(
+            @{ GameName='Hollow Knight'; Kind='Game';  ParentIndex=-1; TotalBytes=4GB }
+            @{ GameName='Big patch';     Kind='AddOn'; ParentIndex=0;  TotalBytes=1GB }
+        )
+        $plan = Get-DiscPlan $grp 'DVD5' 10MB 0
+        $plan.Ok          | Should -BeFalse
+        $plan.TooBigName  | Should -Be 'Hollow Knight'
+        $plan.TooBigBytes | Should -Be 5GB
     }
 
     It 'refuses a medium it does not have a capacity for' {
@@ -2277,9 +2318,12 @@ Describe 'Telling you what the plan came to' {
         Get-DiscPlanText $plan 'BD25' | Should -Be '1 disc, BD-R 25 GB'
     }
 
-    It 'says which game is the problem, in the words on the dropdown' {
-        $plan = @{ Ok=$false; Reason='entry'; TooBigName='The Witcher'; Discs=@() }
-        Get-DiscPlanText $plan 'DVD5' | Should -Be 'The Witcher alone is bigger than a DVD5 4.7 GB'
+    It 'says which game is the problem, how big it is, and against what' {
+        # The line this sits on begins with the total on the form - "2 games
+        # (8.94 GB)". Without the game's OWN size beside its name, the refusal
+        # reads as though the 8.94 was the figure that would not fit.
+        $plan = @{ Ok=$false; Reason='entry'; TooBigName='The Witcher'; TooBigBytes=9.48GB; Discs=@() }
+        Get-DiscPlanText $plan 'DVD5' | Should -Be 'The Witcher is 9.48 GB on its own, too big for a DVD5 4.7 GB'
     }
 
     It 'separates extras that will not fit from a game that will not fit' {
@@ -2370,6 +2414,13 @@ Describe 'Building a set of discs' -Tag 'Build' -Skip:(-not $script:CanBuildIso)
         @(Get-ChildItem (Join-Path $script:SetStage 'Games') -Directory).Count | Should -Be 2
     }
 
+    It 'tells each disc which one of the set it is' {
+        # Read out of the staged disc rather than the ISO: what matters is
+        # that the number is per disc and not the same on every one.
+        $hta = Get-Content -Raw (Join-Path $script:SetStage (Join-Path 'AUTORUN' 'menu.hta'))
+        $hta.Contains('var DISCNUM=2, DISCOF=2;') | Should -BeTrue
+    }
+
     It 'renumbers each disc from 01 rather than carrying on from the last one' {
         # Disc 2 holds entries 1 and 2 of the list. On the disc they are 01 and 02:
         # the folder numbers are the menu order for THAT disc.
@@ -2418,5 +2469,68 @@ Describe 'Building a set of discs' -Tag 'Build' -Skip:(-not $script:CanBuildIso)
             ($onD2 | Where-Object { $_ -match 'alpha' }).Count      | Should -Be 0
             $onD2.Count | Should -BeGreaterThan 1
         }
+    }
+}
+
+Describe 'What the menu says about the disc it is on' {
+
+    BeforeAll {
+        $script:CapDir = Join-Path $script:Sandbox 'caption'
+        New-Item -ItemType Directory -Force -Path $script:CapDir | Out-Null
+
+        function New-Menu([hashtable]$extra) {
+            $cfg = @{ GameName='Boxed Set'; Buttons=@('Play','Install','Exit'); MusicFile=''
+                      ManualFile=''; PanelSide='Right'; IconName='disc.ico'
+                      WindowBorder=$true; ButtonStyle='Minimal'
+                      Games=@(@{ Name='Hollow Knight'; MatchName='Hollow Knight'
+                                 Setup='setup.exe'; AddOns=@(); Manual=''; Extras='' }) }
+            foreach ($k in $extra.Keys) { $cfg[$k] = $extra[$k] }
+            $out = Join-Path $script:CapDir ('menu_' + [Guid]::NewGuid().ToString('N').Substring(0,6) + '.hta')
+            New-MenuHta $cfg $out
+            return (Get-Content -Raw $out)
+        }
+    }
+
+    It 'says it is one of one when nothing said otherwise' {
+        # Every disc built before sets existed, and every single disc built now.
+        $h = New-Menu @{}
+        $h.Contains('var DISCNUM=1, DISCOF=1;') | Should -BeTrue
+    }
+
+    It 'carries its place in the set' {
+        $h = New-Menu @{ DiscNum=2; DiscOf=3 }
+        $h.Contains('var DISCNUM=2, DISCOF=3;') | Should -BeTrue
+    }
+
+    It 'shows the disc line only when there is a set to be part of' {
+        # discLine is what decides it, and it reads DISCOF at run time - so the
+        # single-disc menu carries the same code and simply renders nothing.
+        $h = New-Menu @{}
+        $h.Contains('DISCOF>1') | Should -BeTrue
+    }
+
+    It 'names the game on its own screen' {
+        # The gap this closes: a one-game disc went straight to Play/Install with
+        # nothing anywhere saying which game they belonged to. On a set of discs
+        # that all share an icon and a background, that is the only difference
+        # between them.
+        $h = New-Menu @{}
+        $h.Contains('setPanel(h,capFor(g.n));') | Should -BeTrue
+    }
+
+    It 'leaves the chooser to name the games itself' {
+        # The chooser is a list of game names, so a caption naming one of them
+        # would be both redundant and wrong.
+        $h = New-Menu @{}
+        $h.Contains('setPanel(h,capFor(""));') | Should -BeTrue
+    }
+
+    It 'measures the caption instead of assuming how tall it is' {
+        # The panel is centred on its contents and the buttons shrink to fit. A
+        # hard-coded caption height would push a crowded screen off the bottom
+        # the moment the disc line appeared.
+        $h = New-Menu @{ DiscNum=1; DiscOf=2 }
+        $h.Contains('var capH=c ? c.offsetHeight+10 : 0;') | Should -BeTrue
+        $h.Contains('avail=440-capH')                      | Should -BeTrue
     }
 }

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -307,6 +307,9 @@ Describe 'Recovering from a bad folder choice' -Tag 'Unit' {
         # the fake works.
         $script:cmbMedia  = New-Object System.Windows.Forms.ComboBox
         $script:chkXAll   = [pscustomobject]@{ Checked = $false }
+        $script:lblMan    = [pscustomobject]@{ Text = 'Manual file:' }
+        $script:lblEx     = [pscustomobject]@{ Text = 'Extras folder:' }
+        $script:grpX      = [pscustomobject]@{ Text = '5)  Extra content (copied to the disc root as-is)' }
         $script:lblGame   = [pscustomobject]@{ Text = ''; ForeColor = $null }
         $script:cbMan     = [pscustomobject]@{ Checked = $false }
         $script:cbExtra   = [pscustomobject]@{ Checked = $false }
@@ -1088,6 +1091,9 @@ Describe 'Adding and removing entries in the list' {
         $script:btnGameEdit = New-Object System.Windows.Forms.Button
         $script:cmbMedia = New-Object System.Windows.Forms.ComboBox
         $script:chkXAll  = [pscustomobject]@{ Checked=$false }
+        $script:lblMan   = [pscustomobject]@{ Text='Manual file:' }
+        $script:lblEx    = [pscustomobject]@{ Text='Extras folder:' }
+        $script:grpX     = [pscustomobject]@{ Text='5)  Extra content (copied to the disc root as-is)' }
         $script:lblGame  = [pscustomobject]@{ Text=''; ForeColor=$null }
         $script:cbMan    = [pscustomobject]@{ Checked=$false }
         $script:cbExtra  = [pscustomobject]@{ Checked=$false }
@@ -2638,5 +2644,57 @@ Describe 'A set told to carry its extras on every disc' -Tag 'Build' -Skip:(-not
         $j.PSObject.Properties.Remove('ExtrasEveryDisc')
         $j | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $f -Encoding UTF8
         (Import-Project $f).ExtrasEveryDisc | Should -BeFalse
+    }
+}
+
+Describe 'Saying on the form where the disc-wide content lands' {
+
+    BeforeAll {
+        $script:lblMan  = [pscustomobject]@{ Text = 'Manual file:' }
+        $script:lblEx   = [pscustomobject]@{ Text = 'Extras folder:' }
+        $script:grpX    = [pscustomobject]@{ Text = '5)  Extra content (copied to the disc root as-is)' }
+        $script:chkXAll = [pscustomobject]@{ Checked = $false }
+        $script:SetPlan = @{ Ok=$true; Discs=@(@(0), @(1)) }
+        $script:OnePlan = @{ Ok=$true; Discs=@(,@(0,1)) }
+    }
+
+    It 'says nothing at all when the build is a single disc' {
+        # The overwhelmingly common case, and there is nothing to disclose.
+        Update-DiscWideLabels $script:OnePlan
+        $script:lblEx.Text  | Should -Be 'Extras folder:'
+        $script:lblMan.Text | Should -Be 'Manual file:'
+        $script:grpX.Text   | Should -Be '5)  Extra content (copied to the disc root as-is)'
+    }
+
+    It 'says nothing when there is no plan yet' {
+        Update-DiscWideLabels $null
+        $script:lblEx.Text | Should -Be 'Extras folder:'
+    }
+
+    It 'names the disc once the build becomes a set' {
+        # The gap this closes: the option lives under the extra-content list in
+        # step 5, so nothing beside the Extras folder in step 4 said that it also
+        # goes on disc 1 alone.
+        Update-DiscWideLabels $script:SetPlan
+        $script:lblEx.Text  | Should -Be 'Extras folder (disc 1):'
+        $script:lblMan.Text | Should -Be 'Manual file (disc 1):'
+        $script:grpX.Text   | Should -Be '5)  Extra content (copied to disc 1 of the set)'
+    }
+
+    It 'stops naming a disc once they go on all of them' {
+        # Ticked, the checkbox says so in words directly underneath, so repeating
+        # it on three labels would be noise.
+        $script:chkXAll.Checked = $true
+        try {
+            Update-DiscWideLabels $script:SetPlan
+            $script:lblEx.Text  | Should -Be 'Extras folder:'
+            $script:lblMan.Text | Should -Be 'Manual file:'
+            $script:grpX.Text   | Should -Be '5)  Extra content (copied to the disc root as-is)'
+        } finally { $script:chkXAll.Checked = $false }
+    }
+
+    It 'says nothing when the set could not be planned at all' {
+        Update-DiscWideLabels @{ Ok=$false; Discs=@() }
+        $script:lblEx.Text | Should -Be 'Extras folder:'
     }
 }

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -302,6 +302,10 @@ Describe 'Recovering from a bad folder choice' -Tag 'Unit' {
         $script:btnGameEdit = New-Object System.Windows.Forms.Button
 
         # Stand-ins for the plain labels Set-GameEntries and Update-MediaLabel write to.
+        # The dropdown is a real ComboBox rather than a stub object: Update-MediaOptions
+        # rebuilds its Items and moves its selection, so a fake would only prove
+        # the fake works.
+        $script:cmbMedia  = New-Object System.Windows.Forms.ComboBox
         $script:lblGame   = [pscustomobject]@{ Text = ''; ForeColor = $null }
         $script:cbMan     = [pscustomobject]@{ Checked = $false }
         $script:cbExtra   = [pscustomobject]@{ Checked = $false }
@@ -1081,6 +1085,7 @@ Describe 'Adding and removing entries in the list' {
         $script:btnGameDel  = New-Object System.Windows.Forms.Button
         $script:btnAddOn    = New-Object System.Windows.Forms.Button
         $script:btnGameEdit = New-Object System.Windows.Forms.Button
+        $script:cmbMedia = New-Object System.Windows.Forms.ComboBox
         $script:lblGame  = [pscustomobject]@{ Text=''; ForeColor=$null }
         $script:cbMan    = [pscustomobject]@{ Checked=$false }
         $script:cbExtra  = [pscustomobject]@{ Checked=$false }
@@ -2339,6 +2344,28 @@ Describe 'Turning what the dropdown says into what the planner needs' {
             Get-MediaKeyFromName $t.Name | Should -Be $t.Key
             Get-MediaNameFromKey $t.Key  | Should -Be $t.Name
         }
+    }
+
+    It 'annotates a row with the number of discs that medium would take' {
+        $tier = @(Get-MediaTiers | Where-Object { $_.Key -eq 'DVD5' })[0]
+        Get-MediaOptionText $tier @{ Ok=$true; Discs=@(@(0),@(1),@(2)) } | Should -Be 'DVD5 4.7 GB  -  3 discs'
+        Get-MediaOptionText $tier @{ Ok=$true; Discs=@(,@(0,1)) }        | Should -Be 'DVD5 4.7 GB  -  1 disc'
+        Get-MediaOptionText $tier @{ Ok=$false; Discs=@() }              | Should -Be 'DVD5 4.7 GB  -  will not fit'
+    }
+
+    It 'leaves a row bare when there is nothing to plan' {
+        # An empty form has no answer to give, so the list says only what the
+        # media are - which is what it said before any of this existed.
+        $tier = @(Get-MediaTiers | Where-Object { $_.Key -eq 'DVD5' })[0]
+        Get-MediaOptionText $tier $null | Should -Be 'DVD5 4.7 GB'
+    }
+
+    It 'still reads an annotated row back as the medium it names' {
+        # The row text changes with the form; the key it stands for must not.
+        Get-MediaKeyFromName 'DVD5 4.7 GB  -  3 discs'      | Should -Be 'DVD5'
+        Get-MediaKeyFromName 'BD-R 25 GB  -  will not fit'  | Should -Be 'BD25'
+        Get-MediaKeyFromName 'BD-R DL 50 GB (dual layer)  -  1 disc' | Should -Be 'BD50'
+        Get-MediaKeyFromName 'DVD5 4.7 GB'                  | Should -Be 'DVD5'
     }
 
     It 'reads the automatic setting as no medium at all' {

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -2313,6 +2313,24 @@ Describe 'Telling you what the plan came to' {
     # @() flattens a SINGLE argument, so a one-disc @(@(0,1)) collapses into a
     # two-element array and reads back as a two-disc set. Several arguments are
     # left alone. The planner sidesteps both by appending with ",@()".
+    It 'uses the short form of the medium, because the line is shared' {
+        # The advice line already carries the payload total and can carry a game
+        # title too. "(dual layer)" is thirteen characters of nothing useful, and
+        # the line was being cut off mid-word without them.
+        $plan = @{ Ok=$false; Reason='entry'; TooBigName='The Witcher - Enhanced Edition'
+                   TooBigBytes=9.48GB; Discs=@() }
+        Get-DiscPlanText $plan 'DVD9' | Should -Be 'The Witcher - Enhanced Edition is 9.48 GB, too big for a DVD9 8.5 GB'
+        Get-DiscPlanText @{ Ok=$true; Discs=@(@(0),@(1)) } 'BD50' | Should -Be '2 discs of BD-R DL 50 GB'
+    }
+
+    It 'has a short form for every tier it lists' {
+        foreach ($t in Get-MediaTiers) {
+            $t.Short | Should -Not -BeNullOrEmpty
+            (Get-MediaShortFromKey $t.Key) | Should -Be $t.Short
+            $t.Short.Length | Should -BeLessOrEqual $t.Name.Length
+        }
+    }
+
     It 'counts the discs and names the medium' {
         $plan = @{ Ok=$true; Discs=@(@(0), @(1), @(2)) }
         Get-DiscPlanText $plan 'DVD5' | Should -Be '3 discs of DVD5 4.7 GB'
@@ -2328,7 +2346,7 @@ Describe 'Telling you what the plan came to' {
         # (8.94 GB)". Without the game's OWN size beside its name, the refusal
         # reads as though the 8.94 was the figure that would not fit.
         $plan = @{ Ok=$false; Reason='entry'; TooBigName='The Witcher'; TooBigBytes=9.48GB; Discs=@() }
-        Get-DiscPlanText $plan 'DVD5' | Should -Be 'The Witcher is 9.48 GB on its own, too big for a DVD5 4.7 GB'
+        Get-DiscPlanText $plan 'DVD5' | Should -Be 'The Witcher is 9.48 GB, too big for a DVD5 4.7 GB'
     }
 
     It 'separates extras that will not fit from a game that will not fit' {

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -306,6 +306,7 @@ Describe 'Recovering from a bad folder choice' -Tag 'Unit' {
         # rebuilds its Items and moves its selection, so a fake would only prove
         # the fake works.
         $script:cmbMedia  = New-Object System.Windows.Forms.ComboBox
+        $script:chkXAll   = [pscustomobject]@{ Checked = $false }
         $script:lblGame   = [pscustomobject]@{ Text = ''; ForeColor = $null }
         $script:cbMan     = [pscustomobject]@{ Checked = $false }
         $script:cbExtra   = [pscustomobject]@{ Checked = $false }
@@ -1086,6 +1087,7 @@ Describe 'Adding and removing entries in the list' {
         $script:btnAddOn    = New-Object System.Windows.Forms.Button
         $script:btnGameEdit = New-Object System.Windows.Forms.Button
         $script:cmbMedia = New-Object System.Windows.Forms.ComboBox
+        $script:chkXAll  = [pscustomobject]@{ Checked=$false }
         $script:lblGame  = [pscustomobject]@{ Text=''; ForeColor=$null }
         $script:cbMan    = [pscustomobject]@{ Checked=$false }
         $script:cbExtra  = [pscustomobject]@{ Checked=$false }
@@ -2577,5 +2579,64 @@ Describe 'What the menu says about the disc it is on' {
         $h = New-Menu @{ DiscNum=1; DiscOf=2 }
         $h.Contains('var capH=c ? c.offsetHeight+10 : 0;') | Should -BeTrue
         $h.Contains('avail=440-capH')                      | Should -BeTrue
+    }
+}
+
+Describe 'A set told to carry its extras on every disc' -Tag 'Build' -Skip:(-not $script:CanBuildIso) {
+
+    BeforeAll {
+        $script:EvGames = @(
+            (Get-GameInfo (New-FixtureGame -Slug 'ev_one' -ExeMb 2)),
+            (Get-GameInfo (New-FixtureGame -Slug 'ev_two' -ExeMb 2))
+        )
+        $script:EvOut = Join-Path $script:Sandbox 'build-ev'
+        New-Item -ItemType Directory -Force -Path $script:EvOut | Out-Null
+        $script:EvExtras = Join-Path $script:Sandbox 'ev-extras'
+        New-Item -ItemType Directory -Force -Path $script:EvExtras | Out-Null
+        Set-Content -LiteralPath (Join-Path $script:EvExtras 'manual.txt') -Value 'read me' -Encoding ASCII
+
+        $s = New-BuildSettings -Games $script:EvGames -Label 'Every Disc' -OutDir $script:EvOut
+        $s.ExtrasPath      = $script:EvExtras
+        $s.Buttons         = @('Play','Install','Extras','Exit')
+        $s.MediaKey        = 'CD'
+        $s.ExtrasEveryDisc = $true
+        $s.Plan = @{ Ok=$true; Reason=''; Discs=@(@(0), @(1))
+                     Capacity=(Get-MediaCapacity 'CD'); TooBigName=''; Room=[double]0 }
+        $script:EvIsos = @(Invoke-BuildSet $s $script:LogSink)
+    }
+
+    It 'still writes one ISO per disc' {
+        $script:EvIsos.Count | Should -Be 2
+    }
+
+    Context 'on the discs themselves' -Skip:(-not $script:SevenZip) {
+
+        It 'puts the extras on the later discs too, not just the first' {
+            # The opposite of the default, and the whole point of the option: a
+            # small manual is worth its size on every disc of the set.
+            $d1 = Get-IsoEntries -IsoPath $script:EvIsos[0] -SevenZip $script:SevenZip
+            $d2 = Get-IsoEntries -IsoPath $script:EvIsos[1] -SevenZip $script:SevenZip
+            $d1 | Should -Contain 'Extras\manual.txt'
+            $d2 | Should -Contain 'Extras\manual.txt'
+        }
+    }
+
+    It 'records the choice so a reopened project rebuilds the same set' {
+        $j = Get-Content -Raw (Join-Path $script:EvOut 'discproject.json') | ConvertFrom-Json
+        $j.ExtrasEveryDisc | Should -BeTrue
+        (Import-Project (Join-Path $script:EvOut 'discproject.json')).ExtrasEveryDisc | Should -BeTrue
+    }
+
+    It 'reads a project that predates the option as disc 1 only' {
+        # Every project written before this existed described the old behaviour,
+        # and has to keep describing it.
+        $out = Join-Path $script:Sandbox 'ev-old'
+        New-Item -ItemType Directory -Force -Path $out | Out-Null
+        Save-Project (New-BuildSettings -Games $script:EvGames -Label 'Old' -OutDir $out) $out
+        $f = Join-Path $out 'discproject.json'
+        $j = Get-Content -Raw $f | ConvertFrom-Json
+        $j.PSObject.Properties.Remove('ExtrasEveryDisc')
+        $j | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $f -Encoding UTF8
+        (Import-Project $f).ExtrasEveryDisc | Should -BeFalse
     }
 }

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -2698,3 +2698,63 @@ Describe 'Saying on the form where the disc-wide content lands' {
         $script:lblEx.Text | Should -Be 'Extras folder:'
     }
 }
+
+Describe 'Knowing what a build is about to overwrite' {
+
+    BeforeAll {
+        $script:BtDir = Join-Path $script:Sandbox 'buildtargets'
+        New-Item -ItemType Directory -Force -Path $script:BtDir | Out-Null
+        function New-EmptyIso([string]$name) {
+            $fs = [IO.File]::Create((Join-Path $script:BtDir $name)); $fs.SetLength(1024); $fs.Close()
+        }
+    }
+
+    It 'names one file for a single disc, keeping the plain label' {
+        $l = Get-SetLabels 'RETRO NIGHT' 1
+        @($l).Count | Should -Be 1
+        $l[0]       | Should -Be 'RETRO NIGHT'
+    }
+
+    It 'numbers every label of a set' {
+        (Get-SetLabels 'RETRO NIGHT' 3) -join '|' | Should -Be 'RETRO NIGHT D1|RETRO NIGHT D2|RETRO NIGHT D3'
+    }
+
+    It 'treats a nonsense disc count as one disc rather than none' {
+        @(Get-SetLabels 'X' 0).Count  | Should -Be 1
+        @(Get-SetLabels 'X' -4).Count | Should -Be 1
+    }
+
+    It 'counts nothing as built in an empty folder' {
+        $bt = Get-BuildTargets $script:BtDir 'SET A' 2
+        $bt.Count    | Should -Be 2
+        $bt.Existing | Should -Be 0
+        ($bt.Isos | ForEach-Object { Split-Path $_ -Leaf }) -join '|' | Should -Be 'SET A D1.iso|SET A D2.iso'
+    }
+
+    It 'notices a set that is only half built' {
+        New-EmptyIso 'SET B D1.iso'
+        $bt = Get-BuildTargets $script:BtDir 'SET B' 2
+        $bt.Existing | Should -Be 1
+        $bt.Count    | Should -Be 2
+    }
+
+    It 'notices a set that is entirely there' {
+        New-EmptyIso 'SET C D1.iso'
+        New-EmptyIso 'SET C D2.iso'
+        (Get-BuildTargets $script:BtDir 'SET C' 2).Existing | Should -Be 2
+    }
+
+    It 'does not mistake a single-disc build for a set that was already made' {
+        # The bug: the button asked whether "SET C.iso" existed. A set never writes
+        # that name, so a folder holding the whole set still read BUILD ISO.
+        New-EmptyIso 'SET D.iso'
+        (Get-BuildTargets $script:BtDir 'SET D' 1).Existing | Should -Be 1
+        (Get-BuildTargets $script:BtDir 'SET D' 2).Existing | Should -Be 0
+        (Get-BuildTargets $script:BtDir 'SET C' 1).Existing | Should -Be 0
+    }
+
+    It 'ignores an ISO belonging to a different disc in the same folder' {
+        New-EmptyIso 'SOMETHING ELSE.iso'
+        (Get-BuildTargets $script:BtDir 'SET E' 1).Existing | Should -Be 0
+    }
+}

--- a/tests/ui/DiscWright.UI.Tests.ps1
+++ b/tests/ui/DiscWright.UI.Tests.ps1
@@ -129,6 +129,20 @@ BeforeAll {
         ExtraItems=@(); MediaKey='CD'; OutDir=$script:BigOutSet
     } $script:BigOutSet
 
+    # Extras button on, no folder chosen yet: the state you are in the moment
+    # before browsing for one, which is where the greying bug lived.
+    $script:BigOutEx = Join-Path $script:Sandbox 'bigproj-ex'
+    New-Item -ItemType Directory -Force -Path $script:BigOutEx | Out-Null
+    Save-Project @{
+        Games=@((Get-GameInfo $script:BigA),(Get-GameInfo $script:BigB)); Label='Needs Extras'
+        IconPath=$script:Art; IconIsIco=$false
+        Menu=$true; BgPath=$script:Art; BgAsIs=$false; PanelSide='Right'
+        Divider=$false; ShowTitle=$false; TitleText=''
+        WindowBorder=$true; ButtonStyle='Minimal'; MusicFile=$null
+        Buttons=@('Play','Install','Extras','Exit'); ManualPath=$null; ExtrasPath=$null
+        ExtraItems=@(); MediaKey='CD'; ExtrasEveryDisc=$false; OutDir=$script:BigOutEx
+    } $script:BigOutEx
+
     $script:App = $null
 }
 
@@ -725,5 +739,37 @@ Describe 'Reopening a project that was planned as a set' -Tag 'UI' -Skip:(-not $
         Start-Sleep -Seconds 2
         Get-MediaTargetText $script:Win | Should -BeLike 'Fit on one disc*'
         Get-StatusText $script:Win | Should -Match 'Disc: '
+    }
+}
+
+Describe 'Choosing an extras folder wakes the every-disc option' -Tag 'UI' -Skip:(-not $script:HaveDesktop) {
+
+    # The bug: the Browse handlers for the disc-wide manual and Extras folder
+    # refreshed the advice line but not the buttons, and the rule deciding whether
+    # "put them on every disc" has anything to govern lives with the buttons. So
+    # the checkbox stayed greyed out with a folder chosen directly above it.
+    # Add-ExtraItem had called both since 0.3.0; these two never did.
+
+    BeforeAll {
+        $script:App = Start-DiscWright -AppPath $script:AppPath
+        $script:Win = $script:App.Window
+        Set-CtlText -Ctl (Get-BoxAfter $script:Win '6)  Output folder*') -Text $script:BigOutEx
+        Invoke-CtlNamed $script:Win 'Open existing disc*' | Out-Null
+        Complete-FolderDialog -Win $script:Win | Out-Null
+        Start-Sleep -Seconds 2
+    }
+    AfterAll { Stop-DiscWright $script:App; $script:App = $null }
+
+    It 'starts greyed, because there is no disc-wide content yet' {
+        Test-CtlEnabled $script:Win 'Also put the manual*' | Should -BeFalse
+    }
+
+    It 'wakes as soon as a folder is chosen, without touching anything else' {
+        $b = Find-RowButton -Win $script:Win -LabelLike 'Extras folder*'
+        $b | Should -Not -BeNullOrEmpty
+        Invoke-Ctl -Ctl $b -SettleMs 700
+        Complete-FolderDialog -Win $script:Win | Out-Null
+        Start-Sleep -Seconds 1
+        Test-CtlEnabled $script:Win 'Also put the manual*' | Should -BeTrue
     }
 }

--- a/tests/ui/DiscWright.UI.Tests.ps1
+++ b/tests/ui/DiscWright.UI.Tests.ps1
@@ -128,6 +128,11 @@ BeforeAll {
         Buttons=@('Play','Install','Exit'); ManualPath=$null; ExtrasPath=$null
         ExtraItems=@(); MediaKey='CD'; OutDir=$script:BigOutSet
     } $script:BigOutSet
+    # Stand-ins for a set that has already been built into this folder. Sparse, so
+    # two "ISOs" cost nothing - only their names matter to the button.
+    foreach ($n in 'Big Set D1.iso','Big Set D2.iso') {
+        $fs = [IO.File]::Create((Join-Path $script:BigOutSet $n)); $fs.SetLength(1024); $fs.Close()
+    }
 
     # Extras button on, no folder chosen yet: the state you are in the moment
     # before browsing for one, which is where the greying bug lived.
@@ -728,6 +733,13 @@ Describe 'Reopening a project that was planned as a set' -Tag 'UI' -Skip:(-not $
 
     It 'plans the set again straight away, without touching the dropdown' {
         Get-StatusText $script:Win | Should -Match 'discs of CD-R 700 MB'
+    }
+
+    It 'offers to REBUILD, having noticed the set is already there' {
+        # The button used to ask whether "Big Set.iso" existed - a name a set never
+        # writes - so a folder holding the whole set still read BUILD ISO.
+        Find-Ctl $script:Win 'REBUILD ISO' -TimeoutSec 4 | Should -Not -BeNullOrEmpty
+        Find-Ctl $script:Win 'BUILD ISO'   -TimeoutSec 1 | Should -BeNullOrEmpty
     }
 
     It 'still reopens an older project as no target at all' {

--- a/tests/ui/DiscWright.UI.Tests.ps1
+++ b/tests/ui/DiscWright.UI.Tests.ps1
@@ -115,6 +115,20 @@ BeforeAll {
         ExtraItems=@(); MediaKey=''; OutDir=$script:BigOut
     } $script:BigOut
 
+    # The same project again, but saved with a target disc on it. Reopening this
+    # one has to bring the dropdown back with it.
+    $script:BigOutSet = Join-Path $script:Sandbox 'bigproj-set'
+    New-Item -ItemType Directory -Force -Path $script:BigOutSet | Out-Null
+    Save-Project @{
+        Games=@((Get-GameInfo $script:BigA),(Get-GameInfo $script:BigB)); Label='Big Set'
+        IconPath=$script:Art; IconIsIco=$false
+        Menu=$true; BgPath=$script:Art; BgAsIs=$false; PanelSide='Right'
+        Divider=$false; ShowTitle=$false; TitleText=''
+        WindowBorder=$true; ButtonStyle='Minimal'; MusicFile=$null
+        Buttons=@('Play','Install','Exit'); ManualPath=$null; ExtrasPath=$null
+        ExtraItems=@(); MediaKey='CD'; OutDir=$script:BigOutSet
+    } $script:BigOutSet
+
     $script:App = $null
 }
 
@@ -658,5 +672,42 @@ Describe 'Choosing the disc you are going to burn' -Tag 'UI' -Skip:(-not $script
         Read-MessageBox -Win $script:Win -TitleLike 'New disc' -Button 'Yes' | Out-Null
         Start-Sleep -Seconds 1
         Get-MediaTargetText $script:Win | Should -BeLike 'Fit on one disc*'
+    }
+}
+
+Describe 'Reopening a project that was planned as a set' -Tag 'UI' -Skip:(-not $script:HaveDesktop) {
+
+    # The bug this block exists for: Save-Project wrote the target disc correctly
+    # and Import-Project never copied it into what it hands back, so every reopen
+    # silently fell back to "Fit on one disc". Writing the file had a test.
+    # Reading it back did not, and the round trip only shows up from the window.
+
+    BeforeAll {
+        $script:App = Start-DiscWright -AppPath $script:AppPath
+        $script:Win = $script:App.Window
+        Set-CtlText -Ctl (Get-BoxAfter $script:Win '6)  Output folder*') -Text $script:BigOutSet
+        Invoke-CtlNamed $script:Win 'Open existing disc*' | Out-Null
+        Complete-FolderDialog -Win $script:Win | Out-Null
+        Start-Sleep -Seconds 2
+    }
+    AfterAll { Stop-DiscWright $script:App; $script:App = $null }
+
+    It 'comes back on the disc it was planned for' {
+        Get-MediaTargetText $script:Win | Should -Be 'CD-R 700 MB'
+    }
+
+    It 'plans the set again straight away, without touching the dropdown' {
+        Get-StatusText $script:Win | Should -Match 'discs of CD-R 700 MB'
+    }
+
+    It 'still reopens an older project as no target at all' {
+        # $script:BigOut was saved with an empty MediaKey, which is what every
+        # project written before 0.5 looks like.
+        Set-CtlText -Ctl (Get-BoxAfter $script:Win '6)  Output folder*') -Text $script:BigOut
+        Invoke-CtlNamed $script:Win 'Open existing disc*' | Out-Null
+        Complete-FolderDialog -Win $script:Win | Out-Null
+        Start-Sleep -Seconds 2
+        Get-MediaTargetText $script:Win | Should -BeLike 'Fit on one disc*'
+        Get-StatusText $script:Win | Should -Match 'Disc: '
     }
 }

--- a/tests/ui/DiscWright.UI.Tests.ps1
+++ b/tests/ui/DiscWright.UI.Tests.ps1
@@ -652,6 +652,12 @@ Describe 'Choosing the disc you are going to burn' -Tag 'UI' -Skip:(-not $script
         $s | Should -Not -Match 'Disc: '
     }
 
+    It 'greys the every-disc option until there is something to put on every disc' {
+        # This project has no manual, no Extras folder and no loose files, so the
+        # option governs nothing and must not look as though it does.
+        Test-CtlEnabled $script:Win 'Also put the manual*' | Should -BeFalse
+    }
+
     It 'says on the row itself how many discs that disc would take' {
         # The dropdown is where "which disc should I use" gets asked, so the
         # count belongs in the list rather than only on the line underneath.

--- a/tests/ui/DiscWright.UI.Tests.ps1
+++ b/tests/ui/DiscWright.UI.Tests.ps1
@@ -645,17 +645,27 @@ Describe 'Choosing the disc you are going to burn' -Tag 'UI' -Skip:(-not $script
         # Index 1 is CD-R, the first real medium. A gigabyte of games does not
         # fit one, so this is a genuine set and not a relabelled single disc.
         Set-MediaTarget -Win $script:Win -Index 1
-        Get-MediaTargetText $script:Win | Should -Be 'CD-R 700 MB'
+        # The row carries its own answer now, so match the tier it names.
+        Get-MediaTargetText $script:Win | Should -BeLike 'CD-R 700 MB*'
         $s = Get-StatusText $script:Win
         $s | Should -Match 'discs of CD-R 700 MB'
         $s | Should -Not -Match 'Disc: '
+    }
+
+    It 'says on the row itself how many discs that disc would take' {
+        # The dropdown is where "which disc should I use" gets asked, so the
+        # count belongs in the list rather than only on the line underneath.
+        Set-MediaTarget -Win $script:Win -Index 1
+        Get-MediaTargetText $script:Win | Should -Be 'CD-R 700 MB  -  2 discs'
+        Set-MediaTarget -Win $script:Win -Index 2
+        Get-MediaTargetText $script:Win | Should -Be 'DVD5 4.7 GB  -  1 disc'
     }
 
     It 'needs fewer discs when a bigger one is chosen' {
         # Index 2 is DVD5. The same games now fit on one, and a single disc is
         # not called a set.
         Set-MediaTarget -Win $script:Win -Index 2
-        Get-MediaTargetText $script:Win | Should -Be 'DVD5 4.7 GB'
+        Get-MediaTargetText $script:Win | Should -BeLike 'DVD5 4.7 GB*'
         Get-StatusText $script:Win | Should -Match '1 disc, DVD5 4\.7 GB'
     }
 
@@ -667,7 +677,7 @@ Describe 'Choosing the disc you are going to burn' -Tag 'UI' -Skip:(-not $script
 
     It 'is put back to the automatic setting by New disc' {
         Set-MediaTarget -Win $script:Win -Index 3
-        Get-MediaTargetText $script:Win | Should -Be 'DVD9 8.5 GB (dual layer)'
+        Get-MediaTargetText $script:Win | Should -BeLike 'DVD9 8.5 GB (dual layer)*'
         Invoke-CtlNamed $script:Win 'New disc' | Out-Null
         Read-MessageBox -Win $script:Win -TitleLike 'New disc' -Button 'Yes' | Out-Null
         Start-Sleep -Seconds 1
@@ -693,7 +703,7 @@ Describe 'Reopening a project that was planned as a set' -Tag 'UI' -Skip:(-not $
     AfterAll { Stop-DiscWright $script:App; $script:App = $null }
 
     It 'comes back on the disc it was planned for' {
-        Get-MediaTargetText $script:Win | Should -Be 'CD-R 700 MB'
+        Get-MediaTargetText $script:Win | Should -BeLike 'CD-R 700 MB*'
     }
 
     It 'plans the set again straight away, without touching the dropdown' {

--- a/tests/ui/DiscWright.UI.Tests.ps1
+++ b/tests/ui/DiscWright.UI.Tests.ps1
@@ -95,6 +95,26 @@ BeforeAll {
         ExtraItems=@(); OutDir=$script:ProjOut
     } { param($m) $null = $m }
 
+    # A second project, sized so that one CD-R cannot hold it. Sparse again, so a
+    # gigabyte of "game" costs nothing and takes no time. Saved as a project file
+    # rather than built: Open existing disc reads the JSON, and writing a real
+    # 1 GB ISO to prove a dropdown is wired would be a poor trade.
+    $script:BigA = Join-Path $script:SrcRoot 'ccc_big_one'
+    $script:BigB = Join-Path $script:SrcRoot 'ddd_big_two'
+    $null = New-Installer $script:BigA 'setup_big_one_1.0.exe' 500
+    $null = New-Installer $script:BigB 'setup_big_two_1.0.exe' 500
+    $script:BigOut = Join-Path $script:Sandbox 'bigproj'
+    New-Item -ItemType Directory -Force -Path $script:BigOut | Out-Null
+    Save-Project @{
+        Games=@((Get-GameInfo $script:BigA),(Get-GameInfo $script:BigB)); Label='Big Set'
+        IconPath=$script:Art; IconIsIco=$false
+        Menu=$true; BgPath=$script:Art; BgAsIs=$false; PanelSide='Right'
+        Divider=$false; ShowTitle=$false; TitleText=''
+        WindowBorder=$true; ButtonStyle='Minimal'; MusicFile=$null
+        Buttons=@('Play','Install','Exit'); ManualPath=$null; ExtrasPath=$null
+        ExtraItems=@(); MediaKey=''; OutDir=$script:BigOut
+    } $script:BigOut
+
     $script:App = $null
 }
 
@@ -583,5 +603,60 @@ Describe 'What the build refuses, and whether it says why' -Tag 'UI' -Skip:(-not
     It 'leaves the disc untouched after a refusal' {
         # A refused build must not have half-written anything.
         Get-EntryCount $script:Win | Should -Be 2
+    }
+}
+
+Describe 'Choosing the disc you are going to burn' -Tag 'UI' -Skip:(-not $script:HaveDesktop) {
+
+    BeforeAll {
+        $script:App = Start-DiscWright -AppPath $script:AppPath
+        $script:Win = $script:App.Window
+        Set-CtlText -Ctl (Get-BoxAfter $script:Win '6)  Output folder*') -Text $script:BigOut
+        Invoke-CtlNamed $script:Win 'Open existing disc*' | Out-Null
+        Complete-FolderDialog -Win $script:Win | Out-Null
+        Start-Sleep -Seconds 2
+    }
+    AfterAll { Stop-DiscWright $script:App; $script:App = $null }
+
+    It 'opens on the setting that behaves the way it always has' {
+        Get-MediaTargetText $script:Win | Should -BeLike 'Fit on one disc*'
+    }
+
+    It 'recommends a size until it is told which disc you own' {
+        # The old line, unchanged: a size DiscWright picked, not a plan.
+        Get-StatusText $script:Win | Should -Match 'Disc: '
+    }
+
+    It 'turns the advice line into a plan once a disc is chosen' {
+        # Index 1 is CD-R, the first real medium. A gigabyte of games does not
+        # fit one, so this is a genuine set and not a relabelled single disc.
+        Set-MediaTarget -Win $script:Win -Index 1
+        Get-MediaTargetText $script:Win | Should -Be 'CD-R 700 MB'
+        $s = Get-StatusText $script:Win
+        $s | Should -Match 'discs of CD-R 700 MB'
+        $s | Should -Not -Match 'Disc: '
+    }
+
+    It 'needs fewer discs when a bigger one is chosen' {
+        # Index 2 is DVD5. The same games now fit on one, and a single disc is
+        # not called a set.
+        Set-MediaTarget -Win $script:Win -Index 2
+        Get-MediaTargetText $script:Win | Should -Be 'DVD5 4.7 GB'
+        Get-StatusText $script:Win | Should -Match '1 disc, DVD5 4\.7 GB'
+    }
+
+    It 'goes back to recommending when the automatic setting is chosen again' {
+        Set-MediaTarget -Win $script:Win -Index 0
+        Get-MediaTargetText $script:Win | Should -BeLike 'Fit on one disc*'
+        Get-StatusText $script:Win | Should -Match 'Disc: '
+    }
+
+    It 'is put back to the automatic setting by New disc' {
+        Set-MediaTarget -Win $script:Win -Index 3
+        Get-MediaTargetText $script:Win | Should -Be 'DVD9 8.5 GB (dual layer)'
+        Invoke-CtlNamed $script:Win 'New disc' | Out-Null
+        Read-MessageBox -Win $script:Win -TitleLike 'New disc' -Button 'Yes' | Out-Null
+        Start-Sleep -Seconds 1
+        Get-MediaTargetText $script:Win | Should -BeLike 'Fit on one disc*'
     }
 }

--- a/tests/ui/UiDriver.psm1
+++ b/tests/ui/UiDriver.psm1
@@ -464,6 +464,32 @@ function Save-WindowShot {
     $bmp.Save($Path, [System.Drawing.Imaging.ImageFormat]::Png); $bmp.Dispose()
 }
 
+function Find-RowButton {
+    <#  .SYNOPSIS
+        The button sitting on the same row as a given label.
+
+        Several rows have a button called "Browse...", so a name alone picks
+        whichever the enumeration reaches first - which is not stable and is not
+        the one the test means. Rows are, so the label's vertical centre is what
+        identifies it.
+    #>
+    param($Win, [string]$LabelLike, [string]$ButtonLike = 'Browse...', [int]$TimeoutSec = 6)
+    $lbl = Find-Ctl -Root $Win -NameLike $LabelLike -TimeoutSec $TimeoutSec
+    if (-not $lbl) { throw "no label matching '$LabelLike'" }
+    $lr = $lbl.Current.BoundingRectangle
+    $ly = $lr.Y + ($lr.Height / 2)
+    $all = $Win.FindAll($script:UiScope::Descendants, $script:UiAny)
+    for ($i = 0; $i -lt $all.Count; $i++) {
+        $e = $all.Item($i)
+        try {
+            if ($e.Current.Name -notlike $ButtonLike) { continue }
+            $r = $e.Current.BoundingRectangle
+            if ([Math]::Abs(($r.Y + $r.Height / 2) - $ly) -le 8) { return $e }
+        } catch {}
+    }
+    return $null
+}
+
 function Find-MediaTarget {
     <#  .SYNOPSIS
         The Target disc dropdown, found by what it currently says.
@@ -539,4 +565,4 @@ Export-ModuleMember -Function Test-UiAvailable, Start-DiscWright, Stop-DiscWrigh
     Find-Ctl, Set-WindowFocus, Invoke-Ctl, Invoke-CtlNamed, Test-CtlEnabled, Set-CtlText,
     Send-Keys, Get-BoxAfter, Get-StatusText, Get-EntryCount, Select-ListRow, Clear-AllEntries,
     Complete-FolderDialog, Complete-FileDialog, Read-MessageBox, Save-WindowShot, ConvertTo-SendKeys, Set-DrivenWindow, Test-DrivingOurWindow,
-    Find-MediaTarget, Get-MediaTargetText, Set-MediaTarget
+    Find-MediaTarget, Get-MediaTargetText, Set-MediaTarget, Find-RowButton

--- a/tests/ui/UiDriver.psm1
+++ b/tests/ui/UiDriver.psm1
@@ -351,7 +351,10 @@ function Get-StatusText {
     for ($i = 0; $i -lt $all.Count; $i++) {
         try {
             $n = $all.Item($i).Current.Name
-            if ($n -match 'Disc: |Detected: |setup_\*|already on this disc|no installer') { $found = $n }
+            # "-> Disc: fits DVD5" is the advice line. "-> 3 discs of DVD5" is
+            # the same line once a target disc is chosen, and it carries no
+            # "Disc: " for the first pattern to catch.
+            if ($n -match 'Disc: |Detected: |setup_\*|already on this disc|no installer|discs? of |disc, |bigger than a ') { $found = $n }
         } catch {}
     }
     return $found
@@ -459,6 +462,50 @@ function Save-WindowShot {
     $bmp.Save($Path, [System.Drawing.Imaging.ImageFormat]::Png); $bmp.Dispose()
 }
 
+function Find-MediaTarget {
+    <#  .SYNOPSIS
+        The Target disc dropdown, found by what it currently says.
+
+        Every control in this application comes through UI Automation as a bare
+        Pane with no patterns at all - no ExpandCollapse, no SelectionItem - so
+        the dropdown cannot be driven the way a dropdown normally would be. It is
+        located by its text and worked with the keyboard, like everything else
+        here. The strings it can hold are unique in the window, which is what
+        makes finding it by text safe.
+    #>
+    param($Win)
+    foreach ($t in @('Fit on one disc*','CD-R 700 MB','DVD5 4.7 GB','DVD9 8.5 GB*','BD-R 25 GB','BD-R DL 50 GB*','BD-R XL 100 GB')) {
+        $c = Find-Ctl $Win $t -TimeoutSec 1
+        if ($c) { return $c }
+    }
+    return $null
+}
+
+function Get-MediaTargetText {
+    <#  .SYNOPSIS What the Target disc dropdown currently reads. #>
+    param($Win)
+    $c = Find-MediaTarget $Win
+    if (-not $c) { return '' }
+    return [string]$c.Current.Name
+}
+
+function Set-MediaTarget {
+    <#  .SYNOPSIS
+        Choose an entry in the Target disc dropdown by its position in the list.
+
+        Absolute, not relative: {HOME} goes to the first entry whatever was
+        selected before, so the same call lands on the same medium no matter what
+        an earlier test left behind.
+    #>
+    param($Win, [int]$Index)
+    $c = Find-MediaTarget $Win
+    if (-not $c) { throw 'the Target disc dropdown is not on the window' }
+    Invoke-Ctl -Ctl $c -SettleMs 300
+    Send-Keys '{HOME}' 150
+    for ($i = 0; $i -lt $Index; $i++) { Send-Keys '{DOWN}' 100 }
+    Send-Keys '{ENTER}' 350
+}
+
 function Clear-AllEntries {
     <#
     .SYNOPSIS
@@ -489,4 +536,5 @@ function Clear-AllEntries {
 Export-ModuleMember -Function Test-UiAvailable, Start-DiscWright, Stop-DiscWright, Wait-Win, Wait-WinForProcess,
     Find-Ctl, Set-WindowFocus, Invoke-Ctl, Invoke-CtlNamed, Test-CtlEnabled, Set-CtlText,
     Send-Keys, Get-BoxAfter, Get-StatusText, Get-EntryCount, Select-ListRow, Clear-AllEntries,
-    Complete-FolderDialog, Complete-FileDialog, Read-MessageBox, Save-WindowShot, ConvertTo-SendKeys, Set-DrivenWindow, Test-DrivingOurWindow
+    Complete-FolderDialog, Complete-FileDialog, Read-MessageBox, Save-WindowShot, ConvertTo-SendKeys, Set-DrivenWindow, Test-DrivingOurWindow,
+    Find-MediaTarget, Get-MediaTargetText, Set-MediaTarget

--- a/tests/ui/UiDriver.psm1
+++ b/tests/ui/UiDriver.psm1
@@ -474,7 +474,7 @@ function Find-MediaTarget {
         makes finding it by text safe.
     #>
     param($Win)
-    foreach ($t in @('Fit on one disc*','CD-R 700 MB','DVD5 4.7 GB','DVD9 8.5 GB*','BD-R 25 GB','BD-R DL 50 GB*','BD-R XL 100 GB')) {
+    foreach ($t in @('Fit on one disc*','CD-R 700 MB*','DVD5 4.7 GB*','DVD9 8.5 GB*','BD-R 25 GB*','BD-R DL 50 GB*','BD-R XL 100 GB*')) {
         $c = Find-Ctl $Win $t -TimeoutSec 1
         if ($c) { return $c }
     }

--- a/tests/ui/UiDriver.psm1
+++ b/tests/ui/UiDriver.psm1
@@ -351,10 +351,12 @@ function Get-StatusText {
     for ($i = 0; $i -lt $all.Count; $i++) {
         try {
             $n = $all.Item($i).Current.Name
-            # "-> Disc: fits DVD5" is the advice line. "-> 3 discs of DVD5" is
-            # the same line once a target disc is chosen, and it carries no
-            # "Disc: " for the first pattern to catch.
-            if ($n -match 'Disc: |Detected: |setup_\*|already on this disc|no installer|discs? of |disc, |bigger than a ') { $found = $n }
+            # Both shapes of the advice line - "... -> Disc: fits DVD5" and
+            # "... -> 3 discs of DVD5" - are joined by that arrow, and nothing
+            # else in the window contains it. Matching on the words instead was
+            # a trap: a checkbox captioned "...on every disc of a set" matched
+            # "discs? of", and this takes the LAST hit, so the caption won.
+            if ($n -match 'Disc: |Detected: |setup_\*|already on this disc|no installer|   ->   ') { $found = $n }
         } catch {}
     }
     return $found


### PR DESCRIPTION
Closes the first half of the multi-disc item on the roadmap: several games across a set. The second half, splitting **one** game across discs, is deliberately not in here.

## What changed

Step 2 gets a **Target disc** dropdown. Left on *Fit on one disc* nothing changes at all — same recommendation, same single ISO, same code path. Choose a real medium and the advice line stops recommending and starts planning:

```
2 games + 2 add-ons (10.6 GB)   ->   3 discs of DVD5 4.7 GB
```

Each disc in the set is a whole disc: own icon, own menu, own label, own ISO. There is no disc 2 that only makes sense with disc 1 in the drawer.

## Three rules, each with a failure behind it

- **Order on the form is order on the discs.** Next-fit, not best-fit. Repacking to save a disc puts the game you listed first on disc 2, and the menu numbers follow the list.
- **A game and its add-ons are atomic.** `ParentIndex` is a *position in the list*. A patch stranded on the next disc renumbers into a game of its own in the menu.
- **Disc-wide manual and extras ride on disc 1 only.** Otherwise a 2 GB extras folder costs 2 GB on every disc. Anything attached to a particular game travels with that game.

`Get-VolumeLabel` reserves the disc number *before* truncating to the 16 characters an ISO9660 volume id holds — truncating the finished label cuts the number off `THE WITCHER ENHANCED EDITION D2` and hands every disc the same volume id.

`Get-MediaRec`'s ladder of magic numbers is now one table, `Get-MediaTiers`, read by both the advice line and the planner.

## Why one game bigger than one disc is still refused

It is refused by name rather than split, because doing it properly is worth more than bolting it on. Probing a real GOG installer with no `.bin` beside it shows this is more promising than expected:

```
DIALOG: "Installer needs the next part (.BIN) file"
  Please specify the location of part 2 and click OK.
  Path: [ ... ]  [Browse...]  [OK]  [Cancel]

inno.log: Asking user for new disk containing "setup_alan_wake_..._-2.bin".
```

GOG ships Inno Setup's disk-spanning prompt **enabled, with their own wording**. The installer also runs from a temp copy of itself, so ejecting disc 1 mid-install is safe, and it defaults the path to the installer's own folder. A set that keeps the same layout on every disc may need nothing but a swap and OK. That is a real "insert disc 2", and it deserves its own change.

## Compatibility

Project file goes to **schema 5**, recording the target disc. Anything older has no key and reads back as *Fit on one disc* — which is exactly what those projects were.

## Tests

**304 logic** (was 252) and **52 window** (was 46), all passing.

The window suite can now drive a dropdown: every control in this app comes through UI Automation as a bare `Pane` with no `ExpandCollapse` or `SelectionItem` pattern, so `Set-MediaTarget` clicks and keys it like everything else here, using `{HOME}` for absolute positioning so a test does not depend on what an earlier one left selected.

Two bugs the new tests caught in this branch's own code:

- `Invoke-BuildSet` returned `,@($isos)` while callers wrapped in `@()`, nesting the list one level deeper than anything read it. The end-to-end build test failed on `Expected 2, but got 1`.
- `Get-PlanInputs` re-walked the extras folder on every keystroke in the disc label, because `Update-MediaLabel` had already measured it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
