### PR TITLE
fix: offer Forces of Corruption on Empire at War Gold Pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,32 @@ between minor versions.
 - The project file is at schema 5, which records the target disc. Anything older
   reads back as *Fit on one disc*, which is what those projects always were.
 
+### Fixed
+
+- **Play now offers Forces of Corruption on the Empire at War Gold Pack.** The
+  0.4.1 fix that asks which game to launch reads GOG's `goggame-<id>.info` and
+  keeps the tasks marked `category` `game` or `launcher`. That key is optional,
+  and Empire at War's real file leaves it off all eight of its tasks — so every
+  one was discarded, the list came back empty, and Play went on launching the
+  base game with no chooser at all. The bundle the whole feature was built for
+  was the one bundle it did not work on.
+
+  A file that names no categories anywhere is now sorted by what each task points
+  at: `.exe` and `.lnk` start something, `.pdf` and `.rtf` are the manual. The
+  fallback only applies when the file names no categories at all. The Witcher's
+  file names them on five tasks and omits the key on exactly one — Safe Mode,
+  which runs the same executable as the real entry with an extra argument — so
+  there the omission is deliberate and is still honoured.
+
+- **A launch button could read `... War.lnk`.** Empire at War's primary task
+  carries no `name` either, and the filename that stood in for it kept its
+  extension.
+
+- **`\u` escapes in a task name came out raw.** GOG writes them — that game's own
+  title is `STAR WARS®: Empire At War™ Gold`. Unescaping is now one
+  pass over the string rather than a chain of replacements, which also removes
+  the question of which order the chain should have run in.
+
 ### Still not handled
 
 - **One game bigger than one disc.** Spreading a single installer's `.bin` parts

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -1301,10 +1301,19 @@ function New-MenuHta([hashtable]$cfg,[string]$out) {
   // One string out of a JSON object, unescaped. Picked apart with a regular
   // expression rather than JSON.parse, which the quirks-mode engine an HTA gets
   // does not have.
+  //
+  // Unescaping is one pass, not a chain of replaces, because a chain has to pick
+  // an order and every order is wrong for something: run \uXXXX first and a path
+  // like "Manuals\\u..." loses its backslash, run it last and a name that really
+  // did escape a backslash can be read as an escape. GOG writes \u escapes for
+  // real - Empire at War's own title is "STAR WARS(R): Empire At War(TM)".
   function jsonStr(block,key){
     var m=block.match(new RegExp('"'+key+'"\\s*:\\s*"((?:[^"\\\\]|\\\\.)*)"'));
     if(!m) return "";
-    return m[1].replace(/\\\\/g,"\\").replace(/\\"/g,'"').replace(/\\\//g,"/");
+    return m[1].replace(/\\u([0-9a-fA-F]{4})|\\(.)/g, function(s,h,c){
+      if(h) return String.fromCharCode(parseInt(h,16));
+      return c=="n" ? "\n" : c=="t" ? "\t" : c;
+    });
   }
   // Real .info files contain both "System\\witcher.exe" and "System//witcher.exe".
   function relPath(s){ return String(s).replace(/\//g,"\\").replace(/\\+/g,"\\"); }
@@ -1321,6 +1330,20 @@ function New-MenuHta([hashtable]$cfg,[string]$out) {
   // else. Only the ones that start the game count - "document" is the manual and the
   // readme, which this menu already has its own buttons for, and a hidden task is the
   // raw exe GOG keeps behind its own launcher.
+  //
+  // "category" is how a task says which of those it is, but it is optional and
+  // Empire at War's real file leaves it off ALL EIGHT of its tasks - so the test
+  // below dropped every one of them, this function returned nothing, and Play went
+  // on launching the base game. That was the whole reported bug.
+  //
+  // So: trust categories when the file names any, and fall back to what the task
+  // points AT when it names none. The fallback has to be conditional rather than
+  // universal. The Witcher's file names categories on five tasks and omits it on
+  // exactly one - Safe Mode, which runs the same exe as the real entry with an
+  // extra argument - so there the omission carries meaning and Safe Mode stays out.
+  // A file with no categories anywhere carries no such meaning, and an extension
+  // separates the two kinds perfectly well: .exe and .lnk start something, .pdf
+  // and .rtf are the manual.
   function playTasks(dir){
     var out=[];
     try{
@@ -1329,18 +1352,25 @@ function New-MenuHta([hashtable]$cfg,[string]$out) {
       for(;!en.atEnd();en.moveNext()){ if(/^goggame-\d+\.info$/i.test(en.item().Name)){ info=en.item().Path; break; } }
       if(!info) return out;
       var st=fso.OpenTextFile(info,1), txt=st.ReadAll(); st.Close();
+      var usesCat=/"category"\s*:/.test(txt);
       var re=/\{[^{}]*\}/g, m;
       while((m=re.exec(txt))!=null){
         var b=m[0];
         if(!/"type"\s*:\s*"FileTask"/.test(b)) continue;
         if(/"isHidden"\s*:\s*true/.test(b)) continue;
-        var cat=jsonStr(b,"category");
-        if(cat!="game" && cat!="launcher") continue;
         var rel=jsonStr(b,"path"); if(!rel) continue;
+        if(usesCat){
+          var cat=jsonStr(b,"category");
+          if(cat!="game" && cat!="launcher") continue;
+        } else if(!/\.(exe|lnk|bat|cmd)$/i.test(rel)) continue;
         var full=fso.BuildPath(dir,relPath(rel));
         if(!fso.FileExists(full)) continue;
+        // Empire at War's primary task carries no "name" either, so the filename
+        // stands in - without its extension, or the button reads "... War.lnk".
+        var nm=jsonStr(b,"name");
+        if(!nm) nm=fso.GetFileName(full).replace(/\.[^.]*$/,"");
         var wd=jsonStr(b,"workingDir");
-        out[out.length]={ n:(jsonStr(b,"name")||fso.GetFileName(full)), p:full,
+        out[out.length]={ n:nm, p:full,
                           a:jsonStr(b,"arguments"),
                           w:(wd ? fso.BuildPath(dir,relPath(wd)) : fso.GetParentFolderName(full)) };
       }

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -1323,10 +1323,15 @@ Describe "Reading GOG's play tasks out of an installed game" -Tag 'Unit' {
             throw "unbalanced braces in $name"
         }
 
-        # A stand-in for Star Wars: Empire at War Gold Pack - one installer, two
-        # games. Nobody here owns that game, so this is a reconstruction; what
-        # makes it worth trusting is that its SHAPE is copied from the four real
-        # .info files on hand rather than invented:
+        # A synthetic .info in the shape of a file that DOES use categories -
+        # which is what Hollow Knight, Resident Evil 0 and The Witcher all look
+        # like. It was written as a stand-in for Star Wars: Empire at War Gold
+        # Pack before anyone had that game's real file; the real one has since
+        # arrived and turned out to use no categories at all, so it now has a
+        # fixture of its own further down and this one keeps the job it is
+        # actually good at: covering category, isHidden and missing-file
+        # filtering. Its shape is copied from the four real .info files on hand
+        # rather than invented:
         #
         #   - pretty-printed, one key per line, a space after every colon. GOG
         #     never writes compact JSON, and an earlier version of this fixture
@@ -1348,12 +1353,17 @@ Describe "Reading GOG's play tasks out of an installed game" -Tag 'Unit' {
         # Empire At War Gold", and the whole depot holds exactly one .info file.
         # EAWX is not a folder name anybody would invent.
         #
-        # What that manifest cannot give is the CONTENTS of the .info: it ships
-        # inside the depot, and the depot answers 403 without an ownership token.
-        # So the playTasks below are still the reconstructed part, and one thing
-        # is still unconfirmed - whether the real file marks Forces of Corruption
-        # with category "game". If it does not, playTasks drops it and Play goes
-        # on launching only the base game.
+        # What that manifest could not give was the CONTENTS of the .info: it
+        # ships inside the depot, and the depot answers 403 without an ownership
+        # token. So the playTasks below were the reconstructed part, and this
+        # comment used to close by naming the one thing still unconfirmed -
+        # whether the real file marks Forces of Corruption with category "game",
+        # because if it did not, playTasks would drop it and Play would go on
+        # launching only the base game.
+        #
+        # That is exactly what was happening. The reporter sent the real file on
+        # 2026-08-26: not one of its eight tasks carries a category. See the
+        # "no categories at all" fixture below, which is that file verbatim.
         $script:TaskDir = Join-Path $script:Sandbox 'installed-bundle'
         New-Item -ItemType Directory -Force -Path (Join-Path $script:TaskDir 'GameData') | Out-Null
         New-Item -ItemType Directory -Force -Path (Join-Path $script:TaskDir 'EAWX') | Out-Null
@@ -1450,6 +1460,105 @@ Describe "Reading GOG's play tasks out of an installed game" -Tag 'Unit' {
         [IO.File]::WriteAllText((Join-Path $script:TaskDir 'goggame-1421404887.info'),
                                 $info, (New-Object Text.UTF8Encoding($false)))
 
+        # The REAL Star Wars: Empire at War Gold Pack .info, pasted verbatim by
+        # the person who reported that Play never offers Forces of Corruption.
+        # Not reconstructed, not reformatted - the \u escapes and the spacing are
+        # as GOG wrote them.
+        #
+        # What matters about it: not one of its eight tasks carries a "category",
+        # so the category test dropped all eight, playTasks returned nothing, and
+        # Play fell back to the registry exe - the base game. Five of the eight
+        # are manuals, which is why the fallback cannot simply be "keep
+        # everything" and tests for the .pdf and .rtf entries staying out.
+        #
+        # Its first task has no "name" either, which is its own small bug: the
+        # filename stood in and the button read "Launch Star Wars - Empire At
+        # War.lnk", extension and all.
+        $script:RealBundleDir = Join-Path $script:Sandbox 'installed-eaw'
+        New-Item -ItemType Directory -Force -Path (Join-Path $script:RealBundleDir 'EAWX') | Out-Null
+        New-Item -ItemType Directory -Force -Path (Join-Path $script:RealBundleDir 'Manuals') | Out-Null
+        foreach ($f in @(
+            'Launch Star Wars - Empire At War.lnk'
+            'EAWX\swfoc.exe'
+            'Language.exe'
+            'Manuals\Star_Wars_Empire_at_War_Trouble.rtf'
+            'Manuals\Star Wars - Empire at War - reference_card.pdf'
+            'Manuals\Star Wars - Empire at War - tech tree.pdf'
+            'Manuals\Star_Wars_Empire_at_War_Manual.pdf'
+            'Manuals\Star Wars Empire At War - Forces of Corruption - Manual.pdf')) {
+            Set-Content -LiteralPath (Join-Path $script:RealBundleDir $f) -Value 'x' -Encoding Ascii
+        }
+        $realInfo = @'
+{
+    "gameId" : "1421404887",
+    "rootGameId" : "1421404887",
+    "standalone" : true,
+    "dependencyGameId" : "",
+    "language"         : "english",
+    "name"             : "STAR WARS\u00AE: Empire At War\u2122 Gold",
+    "playTasks"        : [
+        {
+            "isPrimary" : true,
+            "type"      : "FileTask",
+            "path"      : "Launch Star Wars - Empire At War.lnk",
+            "workingDir" : ""
+        },
+        {
+            "name" : "Star Wars - Empire At War - Forces of Corruption",
+            "type" : "FileTask",
+            "path" : "EAWX\\swfoc.exe",
+            "workingDir" : "EAWX",
+            "arguments"  : "LANGUAGE=ENGLISH"
+        },
+        {
+            "name" : "Language Settings",
+            "type" : "FileTask",
+            "path" : "Language.exe",
+            "workingDir" : ""
+        },
+        {
+            "name" : "Troubleshooting Guide",
+            "type" : "FileTask",
+            "path" : "Manuals\\Star_Wars_Empire_at_War_Trouble.rtf",
+            "workingDir" : "Manuals"
+        },
+        {
+            "name" : "Reference Card",
+            "type" : "FileTask",
+            "path" : "Manuals\\Star Wars - Empire at War - reference_card.pdf",
+            "workingDir" : "Manuals"
+        },
+        {
+            "name" : "Tech Tree",
+            "type" : "FileTask",
+            "path" : "Manuals\\Star Wars - Empire at War - tech tree.pdf",
+            "workingDir" : "Manuals"
+        },
+        {
+            "name" : "Star Wars - Empire at War Manual",
+            "type" : "FileTask",
+            "path" : "Manuals\\Star_Wars_Empire_at_War_Manual.pdf",
+            "workingDir" : "Manuals"
+        },
+        {
+            "name" : "Star Wars - Empire at War - Forces of Corruption Manual",
+            "type" : "FileTask",
+            "path" : "Manuals\\Star Wars Empire At War - Forces of Corruption - Manual.pdf",
+            "workingDir" : "Manuals"
+        }
+    ],
+    "supportTasks"     : [
+        {
+            "name" : "Support",
+            "type" : "URLTask",
+            "link" : "http://www.gog.com/en/support/star_wars_empire_at_war_gold_pack"
+        }
+    ]
+}
+'@
+        [IO.File]::WriteAllText((Join-Path $script:RealBundleDir 'goggame-1421404887.info'),
+                                $realInfo, (New-Object Text.UTF8Encoding($false)))
+
         $script:PlainDir = Join-Path $script:Sandbox 'installed-plain'
         New-Item -ItemType Directory -Force -Path $script:PlainDir | Out-Null
 
@@ -1501,6 +1610,56 @@ Describe "Reading GOG's play tasks out of an installed game" -Tag 'Unit' {
         # Fewer than two tasks means doPlay uses the registry exe exactly as it
         # always has. Every disc built before this keeps behaving identically.
         (Invoke-PlayTasks $script:PlainDir).Count | Should -Be 0
+    }
+
+    It 'reaches Forces of Corruption in the real Empire at War file' -Skip:(-not $script:HaveCScript) {
+        # The reported bug, in one assertion. Every task in that file is missing
+        # its "category", so before the fallback this returned nothing at all and
+        # Play launched the base game with no chooser.
+        $t = Invoke-PlayTasks $script:RealBundleDir
+        @($t | Where-Object { $_.Name -eq 'Star Wars - Empire At War - Forces of Corruption' }).Count |
+            Should -Be 1
+    }
+
+    It 'offers a chooser rather than one target for the real Empire at War file' -Skip:(-not $script:HaveCScript) {
+        # doPlay shows the chooser on t.length > 1 and otherwise launches the
+        # registry exe, so the count is what decides whether the fix is visible.
+        (Invoke-PlayTasks $script:RealBundleDir).Count | Should -BeGreaterThan 1
+    }
+
+    It 'keeps the manuals out even with no category to go on' -Skip:(-not $script:HaveCScript) {
+        # Five of the eight tasks are a .rtf or a .pdf. Nothing but the extension
+        # distinguishes them here, which is why the fallback tests it.
+        $t = Invoke-PlayTasks $script:RealBundleDir
+        @($t | Where-Object { $_.Path -match '\.(pdf|rtf)$' }).Count | Should -Be 0
+        @($t | Where-Object { $_.Name -in @('Tech Tree','Reference Card','Troubleshooting Guide') }).Count |
+            Should -Be 0
+    }
+
+    It 'names the unnamed primary task without its extension' -Skip:(-not $script:HaveCScript) {
+        # That task carries no "name", so the filename stands in - and a button
+        # reading "Launch Star Wars - Empire At War.lnk" looks like a bug.
+        $t = Invoke-PlayTasks $script:RealBundleDir
+        @($t | Where-Object { $_.Name -eq 'Launch Star Wars - Empire At War' }).Count | Should -Be 1
+        @($t | Where-Object { $_.Name -match '\.lnk$' }).Count | Should -Be 0
+    }
+
+    It 'passes the arguments and working directory the real file asks for' -Skip:(-not $script:HaveCScript) {
+        $t = @(Invoke-PlayTasks $script:RealBundleDir |
+               Where-Object { $_.Name -eq 'Star Wars - Empire At War - Forces of Corruption' })
+        $t[0].Args    | Should -Be 'LANGUAGE=ENGLISH'
+        $t[0].WorkDir | Should -Be (Join-Path $script:RealBundleDir 'EAWX')
+    }
+
+    It 'still trusts categories when the file uses them' -Skip:(-not $script:HaveCScript) {
+        # The guard that keeps the fallback from spreading. The Witcher's file
+        # names categories on five tasks and omits it on exactly one - Safe Mode -
+        # so there the omission means something and the extension test must not
+        # run. Without this guard Safe Mode returns as a second copy of the same
+        # game, and a single-game disc grows a chooser it never had.
+        $t = Invoke-PlayTasks $script:TaskDir
+        $t.Count | Should -Be 2
+        @($t | Where-Object { $_.Name -eq 'Safe Mode' }).Count | Should -Be 0
     }
 }
 


### PR DESCRIPTION
Closes the Empire at War report against 0.4.1: Play still launched the base game with no chooser.

## Cause

`playTasks()` reads GOG's `goggame-<id>.info` and keeps the tasks marked `category` `game` or `launcher`. **That key is optional, and Empire at War's real file leaves it off all eight of its tasks** — so every one was discarded, the list came back empty, and `doPlay` fell back to the registry exe.

The file is the real one, pasted by the reporter on 2026-08-26, not reconstructed. The fixture had been written by hand with a category on every task, and its own comment named this as the single unconfirmed assumption:

> one thing is still unconfirmed - whether the real file marks Forces of Corruption with category "game". If it does not, playTasks drops it and Play goes on launching only the base game.

It does not.

## Fix

A file that names **no** categories anywhere is sorted by what each task points at: `.exe`, `.lnk`, `.bat`, `.cmd` start something, anything else does not.

The fallback is conditional on purpose. Checked against every real `.info` on hand:

| File | FileTasks | with `category` |
|---|---|---|
| Hollow Knight | 1 | 1 |
| Resident Evil 0 | 1 | 1 |
| The Witcher | 5 | 4 — Safe Mode has none |
| **Empire at War** | **8** | **0** |

The Witcher omits the key on exactly one task — Safe Mode, which runs the same executable as the real entry with an extra argument — so there the omission carries meaning and Safe Mode must stay out. A test pins that; without the guard it returns as a second copy of the same game and a single-game disc grows a chooser it never had.

Two smaller bugs in the same file:

- its primary task carries no `name` either, so the filename stood in and kept its extension — the button read `Launch Star Wars - Empire At War.lnk`
- `jsonStr` did not handle `\uXXXX`, which GOG writes (that game's own title is one). Unescaping is now a single pass rather than a chain of replacements, which removes the question of what order the chain should have run in

## Verification

Ran the real JS through cscript against the real file, rather than trusting the assertions alone:

```
chooser entries: 3
  [1] Launch Star Wars - Empire At War
       exe  : ...\Launch Star Wars - Empire At War.lnk
  [2] Star Wars - Empire At War - Forces of Corruption
       exe  : ...\EAWX\swfoc.exe
       args : LANGUAGE=ENGLISH
       wd   : ...\EAWX
  [3] Language Settings
       exe  : ...\Language.exe
```

Language Settings rides along because with no categories nothing distinguishes it from a game. It is launchable and GOG Galaxy lists it too.

## Worth knowing

A chooser now appears where none did before for **any** game whose `.info` omits categories and has two or more launchable files. Three of the four real `.info` files on hand use categories and are unaffected, but the class is larger than Empire at War alone. That is the intended behaviour, not a side effect.

## Tests

- **342 logic** (was 336 — six new), 0 failed
- **60 window**, 0 failed
- PSScriptAnalyzer unchanged from main at 48 findings. An earlier draft put the ® and ™ symbols literally in a comment, which made this BOM-less file non-ASCII and would have had PowerShell 5.1 read it as ANSI; the analyzer's `PSUseBOMForUnicodeEncodedFile` caught it and the file is pure ASCII again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
