### PR TITLE
chore(release): 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,31 +9,6 @@ between minor versions.
 
 ## [Unreleased]
 
-### Fixed
-
-- **Play now offers Forces of Corruption on the Empire at War Gold Pack.** The
-  0.4.1 fix that asks which game to launch reads GOG's `goggame-<id>.info` and
-  keeps the tasks marked `category` `game` or `launcher`. That key is optional,
-  and Empire at War's real file leaves it off all eight of its tasks - so every
-  one was discarded, the list came back empty, and Play went on launching the
-  base game with no chooser at all. The bundle the whole feature was built for
-  was the one bundle it did not work on.
-
-  A file that names no categories anywhere is now sorted by what each task points
-  at: `.exe` and `.lnk` start something, `.pdf` and `.rtf` are the manual. The
-  fallback only applies when the file names no categories at all. The Witcher's
-  file names them on five tasks and omits the key on exactly one - Safe Mode,
-  which runs the same executable as the real entry with an extra argument - so
-  there the omission is deliberate and is still honoured.
-
-- **A launch button could read `... War.lnk`.** Empire at War's primary task
-  carries no `name` either, and the filename that stood in for it kept its
-  extension.
-
-- **`\u` escapes in a task name came out raw.** GOG writes them. Unescaping is now
-  one pass over the string rather than a chain of replacements, which also removes
-  the question of which order the chain should have run in.
-
 ### Changed
 
 - **Target disc now answers "does it fit", not "how many discs".** Pick the blank

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Whil
 version stays below 1.0.0, the project file format and the on-disc layout may change
 between minor versions.
 
-## [Unreleased]
+## [0.4.2] — 2026-08-26
 
 ### Changed
 

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -61,7 +61,7 @@ $PROJECT_FILE = 'discproject.json'
 # this cannot quietly drift a release behind. Shown in the title bar and the log,
 # and written into every project file - a bug report that comes with a project
 # file then says for itself which version built the disc.
-$APP_VERSION  = '0.4.1'
+$APP_VERSION  = '0.4.2'
 
 # =================== SMALL HELPERS ===================
 


### PR DESCRIPTION
Cuts 0.4.2.

- `$APP_VERSION` at `DiscWright.ps1:64` — `0.4.1` → `0.4.2`
- `## [Unreleased]` → `## [0.4.2] — 2026-08-26`

**A patch, not a minor.** Disc sets were going to be the 0.5.0 headline; #28 removed them, so `[Unreleased]` is Changed / Removed / Fixed with no new feature.

## Also fixed here

The Empire at War entry was listed **twice** in `[Unreleased]`. #28 rewrote the whole section and wrote that fix into it, but #26 had already put it there — so when #28 rebased onto a main carrying #26, both survived.

The copy kept is #26's own: em dashes like the rest of the file, and it gives `STAR WARS®: Empire At War™ Gold` as the example of the `\u` escapes. Removing the duplicate also leaves the section in Keep a Changelog's order — Changed, Removed, Fixed.

## What 0.4.2 contains

- **Play offers Forces of Corruption** on Empire at War Gold Pack (#26) — its real `.info` has no `category` on any of its eight tasks, so every one was discarded and Play fell back to the base game
- **Target disc answers "does it fit"** rather than "how many discs" (#28)
- **Disc sets removed** (#28) — built, never released, so nothing anyone has run loses a feature
- **Splitting one game across discs ruled out** (#27), with the evidence recorded in ROADMAP.md under *Not planned*

## Tests

278 logic, 0 failed. 56 window, 0 failed (run on #28's tip; this PR changes only a version string and a heading). PSScriptAnalyzer 40, down from 48 before this batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
