### PR TITLE
fix: lock the form during a build, and ask before orphaning add-ons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Whil
 version stays below 1.0.0, the project file format and the on-disc layout may change
 between minor versions.
 
+## [Unreleased]
+
+### Fixed
+
+- **The form is locked while a build runs.** Only the BUILD button was disabled,
+  and the progress callback pumps the message loop to keep the window responsive
+  - so every other control stayed live along with it. The copy itself was never
+  at risk, because a build works from a snapshot taken before it starts. What was
+  at risk was everything after: remove a game mid-build and the project file
+  still saved the snapshot, so the form and `discproject.json` quietly disagreed.
+  Press *New disc* and the form emptied while the build carried on writing the
+  disc it used to describe. The log, the progress bar and the elapsed time stay
+  readable.
+
+### Changed
+
+- **Removing a game asks what to do with its add-ons.** It used to promote them
+  to games of their own, silently. On the disc that means a patch listed in the
+  menu as a game, and installing it runs a patch against a game that is not there
+  - GOG's installer then errors several clicks later, a long way from the cause.
+  Silently deleting them would be no better, so the Remove button now names them
+  and offers both: take them along, or keep them as entries of their own.
+
 ## [0.4.2] — 2026-08-26
 
 ### Changed

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -3251,6 +3251,39 @@ $chkMenu.Add_CheckedChanged({
     Update-ActionButtons   # re-applies the as-is rules on top
 })
 
+# Lock the form while a build runs.
+#
+# Only the BUILD button used to be disabled, and the progress callback pumps the
+# message loop with Application::DoEvents so the window stays responsive - which
+# meant every other control stayed live too. A build works from $s, a snapshot
+# taken before it starts, so the copy itself was never at risk; what was at risk
+# was everything downstream of it. Remove a game mid-build and Save-Project still
+# writes the snapshot, so the form and the saved project quietly disagree. Press
+# New disc and the form empties while a build carries on writing the disc it
+# describes.
+#
+# The log, the progress bar and the elapsed label stay enabled - they are the
+# only things worth looking at while it runs, and a disabled multiline TextBox
+# cannot be scrolled.
+$script:BuildFrozen = $null
+function Set-FormBusy([bool]$busy) {
+    $live = @($txtLog, $pbBuild, $lblElapsed)
+    if ($busy) {
+        # Remember what was enabled rather than enabling everything afterwards:
+        # most of these are greyed by Update-ActionButtons for reasons that have
+        # not changed just because a build happened.
+        $script:BuildFrozen = @{}
+        foreach ($c in $form.Controls) {
+            if ($live -contains $c) { continue }
+            $script:BuildFrozen[$c] = $c.Enabled
+            $c.Enabled = $false
+        }
+    } elseif ($script:BuildFrozen) {
+        foreach ($c in $script:BuildFrozen.Keys) { $c.Enabled = $script:BuildFrozen[$c] }
+        $script:BuildFrozen = $null
+    }
+}
+
 $btnBuild.Add_Click({
     $txtLog.Clear()
     if ((Get-Games).Count -eq 0) { Deny-Build 'no valid GOG game folder.' 'Pick a valid GOG game folder first (step 1).'; return }
@@ -3405,6 +3438,7 @@ $btnBuild.Add_Click({
          Buttons=$buttons; ManualPath=$(if($cbMan.Checked){$state.ManualPath}else{$null}); ExtrasPath=$(if($cbExtra.Checked){$state.ExtrasPath}else{$null});
          ExtraItems=@($lstExtra.Items); OutDir=$txtOut.Text.Trim(); MediaKey=$mediaKey }
     $btnBuild.Enabled=$false
+    Set-FormBusy $true
     $script:BuildDiscTag = ''
     $pbBuild.Value=0; $pbBuild.Visible=$true
     $buildWatch.Restart()
@@ -3426,6 +3460,7 @@ $btnBuild.Add_Click({
     finally {
         if ($buildWatch.IsRunning) { $buildWatch.Stop() }
         $pbBuild.Visible=$false
+        Set-FormBusy $false
         $btnBuild.Enabled=$true; Update-ActionButtons
     }
 })

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -570,15 +570,48 @@ function Get-MenuGames([array]$entries) {
 # An add-on whose own parent is the entry being removed becomes a game of its
 # own. The alternative is deleting it too, which throws away an installer the
 # user chose, without asking.
-function Remove-GameEntry([array]$entries,[int]$index) {
+# The add-ons belonging to one entry, as indices into the list it was given.
+function Get-EntryAddOns([array]$entries,[int]$index) {
+    $out = @()
+    for ($i = 0; $i -lt @($entries).Count; $i++) {
+        if ([int]$entries[$i].ParentIndex -eq $index) { $out += $i }
+    }
+    return ,@($out)
+}
+
+# Remove one entry, and optionally the add-ons hanging off it.
+#
+# $withAddOns defaults false, which is the behaviour this has always had:
+# an orphaned add-on is promoted to a game of its own rather than deleted.
+# That is the wrong default on a disc - a promoted patch shows in the menu
+# as a top-level game, and installing it runs a patch against a game that
+# is not there - so the Remove button asks. The choice lives with the
+# caller because only the caller can ask.
+function Remove-GameEntry([array]$entries,[int]$index,[bool]$withAddOns=$false) {
     if ($index -lt 0 -or $index -ge $entries.Count) { return ,@($entries) }
+
+    $drop = @{ $index = $true }
+    if ($withAddOns) { foreach ($k in (Get-EntryAddOns $entries $index)) { $drop[$k] = $true } }
+
+    # Old index -> new index, for the entries that survive. Built before anything
+    # is rewritten: with more than one entry going, "subtract one if the parent
+    # sat after the removed row" no longer holds.
+    $map = @{}
+    $n = 0
+    for ($i = 0; $i -lt $entries.Count; $i++) {
+        if ($drop.ContainsKey($i)) { continue }
+        $map[$i] = $n; $n++
+    }
+
     $kept = @()
     for ($i = 0; $i -lt $entries.Count; $i++) {
-        if ($i -eq $index) { continue }
+        if ($drop.ContainsKey($i)) { continue }
         $e = $entries[$i]
         $p = [int]$e.ParentIndex
-        if ($p -eq $index)   { $e.Kind = 'Game'; $e.ParentIndex = -1 }
-        elseif ($p -gt $index) { $e.ParentIndex = $p - 1 }
+        if ($p -ge 0) {
+            if ($drop.ContainsKey($p)) { $e.Kind = 'Game'; $e.ParentIndex = -1 }
+            else                       { $e.ParentIndex = $map[$p] }
+        }
         $kept += $e
     }
     return ,@($kept)
@@ -2333,6 +2366,15 @@ function Show-Confirm([string]$msg,[string]$title='DiscWright') {
         [System.Windows.Forms.MessageBoxIcon]::Warning) -eq [System.Windows.Forms.DialogResult]::Yes)
 }
 
+# Yes / No / Cancel, for a question where "no" and "not now" are different
+# answers. Show-Confirm cannot express that - its No and its close button both
+# mean the same thing.
+function Show-Choice([string]$msg,[string]$title='DiscWright') {
+    return [System.Windows.Forms.MessageBox]::Show($msg,$title,
+        [System.Windows.Forms.MessageBoxButtons]::YesNoCancel,
+        [System.Windows.Forms.MessageBoxIcon]::Warning)
+}
+
 # A build that refuses to start is an error, and errors get a window - the log line
 # alone is easy to miss, which makes the BUILD button look like it did nothing.
 function Deny-Build([string]$logMsg,[string]$dlgMsg) { & $log "ERROR: $logMsg"; Show-Warn $dlgMsg }
@@ -3166,7 +3208,30 @@ $btnGameDel.Add_Click({
     # again gives a one-element array holding that list - so removing one of five
     # entries left a single row whose name was all four remaining names run
     # together. Same trap as Get-Games and Get-FirstGame.
-    $state.Games = Remove-GameEntry @($state.Games) $lvGames.SelectedIndices[0]
+    $gi   = $lvGames.SelectedIndices[0]
+    $ent  = @($state.Games)[$gi]
+    # NOT @(Get-EntryAddOns ...). It already returns a list, and wrapping it again
+    # gives a one-element array holding that list - so a game with no add-ons at
+    # all would count as one and raise the dialog with nothing in it. Same trap as
+    # Remove-GameEntry directly below, and Get-Games, and Get-FirstGame.
+    $kids = Get-EntryAddOns @($state.Games) $gi
+    # Removing a game used to promote its add-ons to games of their own, silently.
+    # On the disc that means a patch listed in the menu as a game, whose Install
+    # runs it against a game that is not there - GOG's installer then errors
+    # several clicks later. Deleting them silently would be no better, so ask.
+    $withKids = $false
+    if ($ent -and $ent.Kind -ne 'AddOn' -and $kids.Count) {
+        $names = (@($kids | ForEach-Object { '  - ' + @($state.Games)[$_].GameName }) -join "`r`n")
+        $r = Show-Choice (("{0} has {1} add-on{2} on this disc:`r`n`r`n{3}`r`n`r`n" -f
+                            $ent.GameName, $kids.Count, $(if($kids.Count -eq 1){''}else{'s'}), $names) +
+                          "Yes  - remove them as well`r`n" +
+                          "No   - keep them, each as a game of its own`r`n`r`n" +
+                          "An add-on kept on its own installs a patch for a game that is not on the disc.") `
+                         'Remove add-ons too?'
+        if ($r -eq [System.Windows.Forms.DialogResult]::Cancel) { return }
+        $withKids = ($r -eq [System.Windows.Forms.DialogResult]::Yes)
+    }
+    $state.Games = Remove-GameEntry @($state.Games) $gi $withKids
     # Take back the label DiscWright typed, but only that one. Adding a game to an
     # empty form seeds the label from its name; removing that game used to leave
     # the name behind, and because seeding only fires into an EMPTY box, the next

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -1841,7 +1841,7 @@ Describe 'The comma-return convention is not undone at the call sites' -Tag 'Uni
 
     BeforeAll {
         $script:CommaReturners = @(
-            'Get-Games', 'Get-MenuGames', 'Remove-GameEntry',
+            'Get-Games', 'Get-MenuGames', 'Remove-GameEntry', 'Get-EntryAddOns',
             'Set-GameEntries', 'Set-GameFolders', 'Set-GameFolder'
         )
         $appFile = Join-Path (Split-Path $PSScriptRoot -Parent) 'DiscWright.ps1'
@@ -1909,6 +1909,77 @@ Describe 'Removing an entry the way the button does it' -Tag 'Unit' {
         $after = Remove-GameEntry $script:Five 0
         @($after | Where-Object { $_.Kind -eq 'Game' }).Count | Should -Be 4
         @($after | Where-Object { $_.ParentIndex -ne -1 }).Count | Should -Be 0
+    }
+
+    # Each of these builds its own list. Remove-GameEntry rewrites Kind and
+    # ParentIndex on the entries it is handed rather than on copies, so a shared
+    # fixture arrives at the second test already promoted - which is exactly how
+    # the first draft of these tests "passed" while proving nothing.
+    It 'takes the add-ons with the game when asked to' {
+        $five = @(
+            (New-E 'Hollow Knight'),
+            (New-E 'Update A' 'AddOn' 0), (New-E 'Update B' 'AddOn' 0),
+            (New-E 'Update C' 'AddOn' 0), (New-E 'Update D' 'AddOn' 0)
+        )
+        $after = Remove-GameEntry $five 0 $true
+        @($after).Count | Should -Be 0
+    }
+
+    It 'takes only that game''s add-ons, not somebody else''s' {
+        $two = @(
+            (New-E 'Alan Wake'), (New-E 'Hollow Knight'),
+            (New-E 'AW patch' 'AddOn' 0), (New-E 'HK patch' 'AddOn' 1)
+        )
+        $after = Remove-GameEntry $two 0 $true
+        @($after).Count      | Should -Be 2
+        $after[0].GameName   | Should -Be 'Hollow Knight'
+        $after[1].GameName   | Should -Be 'HK patch'
+    }
+
+    It 'repoints the survivors after several rows go at once' {
+        # The reason removal builds an old-to-new index map. With one row going,
+        # "subtract one if the parent sat after it" holds. With a game and its two
+        # add-ons going, it does not - and a stale ParentIndex silently reattaches
+        # a patch to whatever game slid into the gap.
+        $mix = @(
+            (New-E 'Alan Wake'), (New-E 'AW patch 1' 'AddOn' 0), (New-E 'AW patch 2' 'AddOn' 0),
+            (New-E 'Hollow Knight'), (New-E 'HK patch' 'AddOn' 3)
+        )
+        $after = Remove-GameEntry $mix 0 $true
+        @($after).Count       | Should -Be 2
+        $after[0].GameName    | Should -Be 'Hollow Knight'
+        $after[1].GameName    | Should -Be 'HK patch'
+        $after[1].ParentIndex | Should -Be 0 -Because 'Hollow Knight is index 0 now, not 3'
+        $after[1].Kind        | Should -Be 'AddOn'
+    }
+
+    It 'still promotes when not asked to take them' {
+        $five = @(
+            (New-E 'Hollow Knight'),
+            (New-E 'Update A' 'AddOn' 0), (New-E 'Update B' 'AddOn' 0)
+        )
+        $after = Remove-GameEntry $five 0
+        @($after).Count | Should -Be 2
+        @($after | Where-Object { $_.Kind -eq 'Game' }).Count | Should -Be 2
+    }
+
+    It 'finds the add-ons belonging to one entry' {
+        $five = @(
+            (New-E 'Hollow Knight'),
+            (New-E 'Update A' 'AddOn' 0), (New-E 'Update B' 'AddOn' 0)
+        )
+        $kids = Get-EntryAddOns $five 0
+        $kids -join ',' | Should -Be '1,2'
+        $none = Get-EntryAddOns $five 1
+        @($none).Count  | Should -Be 0
+    }
+
+    It 'leaves the list alone for an index that is not there' {
+        $five = @((New-E 'Hollow Knight'), (New-E 'Update A' 'AddOn' 0))
+        $a = Remove-GameEntry $five 99 $true
+        $b = Remove-GameEntry $five -1 $true
+        @($a).Count | Should -Be 2
+        @($b).Count | Should -Be 2
     }
 }
 

--- a/tests/ui/DiscWright.UI.Tests.ps1
+++ b/tests/ui/DiscWright.UI.Tests.ps1
@@ -508,13 +508,23 @@ Describe 'Removing an entry' -Tag 'UI' -Skip:(-not $script:HaveDesktop) {
         Get-EntryCount $script:Win | Should -Be 2
     }
 
-    It 'promotes orphaned add-ons instead of deleting them with their game' {
-        # Removing the game leaves its add-ons on the disc as games of their own.
-        # Silently discarding an installer the user chose is the worse outcome.
+    It 'asks what to do with the add-ons before removing their game' {
+        # Removing a game used to promote its add-ons to games of their own,
+        # silently. On the disc that means a patch listed in the menu as a game,
+        # whose Install runs it against a game that is not there. Deleting them
+        # silently is no better, so the button asks - and the dialog names them,
+        # because "2 add-ons" is not enough to decide on.
         Select-ListRow -Win $script:Win -Index 0
         Invoke-CtlNamed $script:Win 'Remove' | Out-Null
+        # Answers No, which is the old behaviour made explicit: the add-on stays,
+        # as a game of its own. Yes is covered by the unit tests and by
+        # Clear-AllEntries, which uses it on every run. Answering Yes here would
+        # empty the list and pull the ground out from under the test below.
+        $txt = Read-MessageBox -Win $script:Win -TitleLike 'Remove add-ons too?' -Button 'No'
+        $txt | Should -Not -BeNullOrEmpty -Because 'removing a game with add-ons must ask first'
+        $txt | Should -Match 'add-on'
         Start-Sleep -Seconds 1
-        Get-EntryCount $script:Win | Should -Be 1
+        Get-EntryCount $script:Win | Should -Be 1 -Because 'No keeps the add-on as an entry of its own'
         (Get-StatusText $script:Win) | Should -Not -Match 'add-on'
     }
 

--- a/tests/ui/UiDriver.psm1
+++ b/tests/ui/UiDriver.psm1
@@ -549,6 +549,12 @@ function Clear-AllEntries {
 
         The guard stops a runaway if Remove ever stops emptying the list. A suite
         that fails is useful; one that hangs is not.
+
+        Removing a game that has add-ons raises a Yes/No/Cancel dialog. This
+        answers Yes - taking the add-ons with the game is what "clear every
+        entry" means, and it is also the answer that terminates: No promotes
+        them and leaves more rows to remove. An unanswered dialog is modal, so
+        every later click in the suite would land on nothing.
     #>
     param($Win, [int]$Max = 12)
     $n = 0
@@ -556,6 +562,8 @@ function Clear-AllEntries {
         Select-ListRow -Win $Win -Index 0
         if (-not (Test-CtlEnabled $Win 'Remove')) { break }
         Invoke-CtlNamed $Win 'Remove' | Out-Null
+        # Short timeout: most rows raise no dialog at all, and this runs per row.
+        Read-MessageBox -Win $Win -TitleLike 'Remove add-ons too?' -Button 'Yes' -TimeoutSec 2 | Out-Null
         Start-Sleep -Milliseconds 800
         $n++
     }


### PR DESCRIPTION
Two things found by building a real 18 GB disc.

## 1. The form was clickable while a build ran

Only the BUILD button was disabled. The progress callback calls `Application::DoEvents()` to keep the window responsive while gigabytes copy — which kept **every other control live** too.

The copy itself was never at risk: a build works from `$s`, a snapshot taken before it starts. What was at risk was everything downstream.

- Remove a game mid-build → `Save-Project` still writes the snapshot, so the form and `discproject.json` quietly disagree
- Press *New disc* → the form empties while the build carries on writing the disc it used to describe

`Set-FormBusy` disables every top-level control except the log, the progress bar and the elapsed label — the only three worth looking at while it runs, and a disabled multiline TextBox cannot be scrolled. It remembers what was enabled rather than enabling everything afterwards, since most controls are greyed by `Update-ActionButtons` for reasons a finished build does not change. The unlock is in the existing `finally`, so it runs on failure too.

## 2. Removing a game silently orphaned its add-ons

It promoted them to games of their own. That was deliberate — deleting an installer somebody chose is worse than keeping it — but it **produces a broken disc**: a promoted patch appears in the menu as a top-level game, and its Install runs a patch against a game that is not there. GOG's installer then errors several clicks later, a long way from the cause.

Silently deleting them is no better, so the button asks, **names them**, and offers both answers. Cancel leaves the list untouched.

`Remove-GameEntry` gains a `$withAddOns` flag defaulting to `$false`, so the old behaviour is what *No* means and every existing caller is unchanged. Removal now builds an old-to-new index map instead of subtracting one per parent: with a game and two add-ons going at once, *"subtract one if the parent sat after the removed row"* stops holding, and a stale `ParentIndex` silently reattaches a patch to whatever game slid into the gap. There is a test for exactly that.

## Two bugs the tests caught while writing this

**The comma-return trap, again.** `$kids = @(Get-EntryAddOns ...)` rebuilt the wrapper the comma-return exists to prevent — so a game with **no** add-ons counted as one and would have raised the dialog with nothing in it. `Get-EntryAddOns` is now in the list the static comma-return guard checks, so the next one is caught by the suite rather than by hand.

**A shared mutable fixture.** The first draft of the unit tests reused one entry list. `Remove-GameEntry` rewrites `Kind` and `ParentIndex` on the entries it is handed rather than on copies, so the second test arrived at a list already promoted and "passed" while proving nothing. Each test now builds its own — and that in-place mutation is worth knowing about generally.

## Tests

- **288 logic** (6 new), 0 failed
- **56 window**, 0 failed — the driver's `Clear-AllEntries` now answers *Yes*, which is both what "clear every entry" means and the answer that terminates
- PSScriptAnalyzer: 0 errors, warnings **down** from 8 to 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)
