### PR TITLE
fix: keep special characters in game names out of the ASCII grinder

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,6 +18,10 @@ concurrency:
 jobs:
   powershell:
     runs-on: windows-latest
+    # A hung job is not a failed job: without this it holds a runner until the
+    # six-hour default. Pester 6 hangs this suite (see the Pester step below),
+    # which is exactly the shape of failure a timeout has to cover.
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v4
@@ -51,11 +55,23 @@ jobs:
       - name: Pester
         shell: powershell
         run: |
-          if (-not (Get-Module -ListAvailable Pester | Where-Object { $_.Version.Major -ge 5 })) {
+          # Pester 5, deliberately, and not merely "5 or later" - the same
+          # pin tests/Invoke-Tests.ps1 makes, for the reason written out there:
+          # under 6.1.0 every file in this suite hangs in BeforeAll. Hosted
+          # runners ship 5.x today, so -MinimumVersion 5.0 happens to import 5.x
+          # today. It would import 6.x the day that changes, and a hung job just
+          # runs until the timeout above rather than telling anybody why.
+          $p5 = Get-Module -ListAvailable Pester |
+                Where-Object { $_.Version.Major -eq 5 } |
+                Sort-Object Version -Descending | Select-Object -First 1
+          if (-not $p5) {
               Set-PSRepository PSGallery -InstallationPolicy Trusted
-              Install-Module Pester -Force -SkipPublisherCheck -Scope CurrentUser -MinimumVersion 5.0
+              Install-Module Pester -Force -SkipPublisherCheck -Scope CurrentUser -MinimumVersion 5.0 -MaximumVersion 5.999.999
+              $p5 = Get-Module -ListAvailable Pester |
+                    Where-Object { $_.Version.Major -eq 5 } |
+                    Sort-Object Version -Descending | Select-Object -First 1
           }
-          Import-Module Pester -MinimumVersion 5.0 -Force
+          Import-Module $p5.Path -Force
           Write-Host "Pester $((Get-Module Pester).Version)"
 
           $cfg = New-PesterConfiguration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ between minor versions.
 
 ### Fixed
 
+- **Game names keep their special characters in the menu.** `menu.hta` is written
+  as an ASCII file and nothing escaped what would not fit, so every character
+  above 7-bit was replaced with a literal `?` on the way out: a disc built from
+  the Star Wars pack offered *Star Wars?: Empire at War?*. Names are now escaped
+  before they go in - `&#8482;` where the name lands in markup, `\u2122` where it
+  lands in the menu's JavaScript - so the file stays ASCII and the characters
+  arrive whole. Escaped rather than rewritten as `(TM)`, because the menu matches
+  these strings against the game the installer registered and against folder names
+  on the disc; a name that only looked right would stop Play from finding
+  anything.
+
 - **The form is locked while a build runs.** Only the BUILD button was disabled,
   and the progress callback pumps the message loop to keep the window responsive
   - so every other control stayed live along with it. The copy itself was never

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -122,6 +122,42 @@ function Format-Size([double]$bytes) {
     return ('{0:N0} bytes' -f $bytes)
 }
 
+# menu.hta is written as pure ASCII (see New-MenuHta), so anything above 7-bit
+# has to leave here as an escape. Written as itself it does not survive the file:
+# Set-Content turns it into a literal "?", which is how a disc built from the Star
+# Wars pack came out offering "Star Wars?: Empire at War?".
+#
+# Escaped, not transliterated. The escape rebuilds the exact same character when
+# the menu runs, and the menu matches these strings against real names - MatchName
+# against what the installer registered, the setup paths against folders on the
+# disc. A "(TM)" that merely looked right would break both.
+
+# For HTML markup: numeric entities, counted in code points rather than in UTF-16
+# units, since half a surrogate pair is not a character an entity can name.
+function ConvertTo-AsciiEntity([string]$s) {
+    $sb = New-Object System.Text.StringBuilder
+    for ($i = 0; $i -lt $s.Length; $i++) {
+        $cp = [int]$s[$i]
+        if ([char]::IsHighSurrogate($s[$i]) -and ($i + 1) -lt $s.Length -and [char]::IsLowSurrogate($s[$i+1])) {
+            $cp = [char]::ConvertToUtf32($s[$i],$s[$i+1]); $i++
+        }
+        if ($cp -gt 0x7F) { [void]$sb.Append('&#').Append($cp).Append(';') }
+        else { [void]$sb.Append([char]$cp) }
+    }
+    return $sb.ToString()
+}
+
+# For JS string literals: \uXXXX per UTF-16 unit, which is how JScript spells a
+# surrogate pair anyway, so no code-point walk is needed here.
+function ConvertTo-AsciiEscape([string]$s) {
+    $sb = New-Object System.Text.StringBuilder
+    foreach ($ch in $s.ToCharArray()) {
+        if ([int]$ch -gt 0x7F) { [void]$sb.Append('\u').Append(('{0:x4}' -f [int]$ch)) }
+        else { [void]$sb.Append($ch) }
+    }
+    return $sb.ToString()
+}
+
 # For text that lands in HTML markup (title, button captions).
 function ConvertTo-HtmlText([string]$s) {
     if ([string]::IsNullOrEmpty($s)) { return '' }
@@ -130,7 +166,8 @@ function ConvertTo-HtmlText([string]$s) {
     # is a rule somebody has to remember.
     $s = Remove-ControlChars $s
     if ([string]::IsNullOrEmpty($s)) { return '' }
-    return ($s -replace '&','&amp;' -replace '<','&lt;' -replace '>','&gt;' -replace '"','&quot;')
+    $s = $s -replace '&','&amp;' -replace '<','&lt;' -replace '>','&gt;' -replace '"','&quot;'
+    return (ConvertTo-AsciiEntity $s)
 }
 
 # For text that lands inside a JS string literal. HTML entities are NOT decoded
@@ -144,7 +181,8 @@ function ConvertTo-JsString([string]$s) {
     # needs them.
     $s = Remove-ControlChars $s
     if ([string]::IsNullOrEmpty($s)) { return '' }
-    return ($s -replace '\\','\\' -replace '"','\"' -replace '<','\x3c' -replace '>','\x3e')
+    $s = $s -replace '\\','\\' -replace '"','\"' -replace '<','\x3c' -replace '>','\x3e'
+    return (ConvertTo-AsciiEscape $s)
 }
 
 # =================== BUILD PIPELINE ===================
@@ -2447,7 +2485,6 @@ function Update-ActionButtons {
     # exact file is going to be overwritten" rather than "there is something in that
     # folder somewhere".
     $bt     = Get-BuildTargets $t $txtLabel.Text.Trim()
-    $isoNow = $(if (@($bt.Isos).Count) { $bt.Isos[0] } else { '' })
     $names  = ($bt.Isos | Where-Object { $_ } | ForEach-Object { Split-Path $_ -Leaf }) -join ', '
     if ($bt.Existing -gt 0) {
         $btnBuild.Text = 'REBUILD ISO'
@@ -2482,9 +2519,6 @@ function Update-ActionButtons {
     $tips.SetToolTip($txtTitle, $(if(-not $composites){$whyOff}
                                   elseif(-not $chkTitle.Checked){'Tick "Show title" first'}
                                   else{'Leave blank to use the disc label from step 2'}))
-
-    # Nothing disc-wide to carry means nothing for this to decide about.
-    $hasWide = ($cbMan.Checked -and $state.ManualPath) -or ($cbExtra.Checked -and $state.ExtrasPath) -or ($lstExtra.Items.Count -gt 0)
 }
 
 # Renders the CURRENT settings into a temp folder so look changes can be checked

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,6 +49,24 @@ folder or just use their names is a real choice rather than a detail.
 Small, and worth doing. It changes where files land on a disc, so it wants its own
 release note rather than riding along with something else.
 
+**Let a game be renamed for the menu.** Asked for by the same person who found the
+question marks, once the characters were arriving intact and the name was worth
+reading. The name today is the installer's own `ProductName`, which is what GOG put
+in the file rather than what anyone would choose - full of trademark symbols,
+subtitles and edition suffixes, and sometimes just wrong.
+
+The groundwork is already there. An entry carries a display name and a match name
+separately, because the menu needs the registered name to find an installed game and
+should never have been using the caption for that. So a rename can change what is
+shown without touching what is matched - which is the part that would otherwise make
+this risky.
+
+What still has to be decided is how far the new name reaches. The disc's folder names
+are built from it (`Games\01 - Hollow Knight`), and so is the volume label on a
+single-game disc. Renaming the menu but not the folders would leave a disc whose two
+halves disagree; renaming both means a rename after a build produces a different disc
+layout from the same games. Neither is obviously right yet.
+
 ## Delivered
 
 **More than one installer on a disc** — shipped in 0.3.0, and the most-asked-for thing

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -2230,6 +2230,21 @@ Describe 'Control characters cannot escape into what a disc carries' -Tag 'Unit'
         ConvertTo-JsString 'He said "hi" \ <script>' | Should -Be 'He said \"hi\" \\ \x3cscript\x3e'
         ConvertTo-HtmlText '<b>&"'                   | Should -Be '&lt;b&gt;&amp;&quot;'
     }
+
+    It 'escapes what is above ASCII rather than letting the file eat it' {
+        # menu.hta is written as an ASCII file, so an unescaped character above
+        # 7-bit does not reach the menu at all - Set-Content replaces it with a
+        # literal "?". Built from code points because this file has to stay pure
+        # ASCII itself.
+        $tm = [char]0x2122
+        ConvertTo-JsString ('Empire at War' + $tm) | Should -Be 'Empire at War\u2122'
+        ConvertTo-HtmlText ('Empire at War' + $tm) | Should -Be 'Empire at War&#8482;'
+        # A surrogate pair is one character to an HTML entity, which names a code
+        # point, and two escapes to JavaScript, which counts UTF-16 units.
+        $astral = [string][char]0xD83D + [char]0xDE00
+        ConvertTo-HtmlText $astral | Should -Be '&#128512;'
+        ConvertTo-JsString $astral | Should -Be '\ud83d\ude00'
+    }
 }
 
 Describe 'Which disc sizes DiscWright knows about' {
@@ -2432,5 +2447,86 @@ catch (e) { WScript.Echo("SYNTAX ERROR: " + e.message); }
         foreach ($dead in 'DISCNUM','DISCOF','discLine','capd') {
             $script:MenuJs | Should -Not -Match $dead
         }
+    }
+}
+
+Describe 'A game name with characters outside plain ASCII' {
+
+    # Reported against 0.4.2 by someone who built the Star Wars pack: the menu
+    # offered "Star Wars?: Empire at War?". menu.hta is written with
+    # Set-Content -Encoding ASCII, so the name was destroyed by the file rather
+    # than by the menu - every character above 7-bit became a literal "?".
+    #
+    # Escaping, not transliterating, is what the fix does, and the last test
+    # here is the reason: the menu compares these strings against real names,
+    # MatchName against what the installer registered and Setup against a folder
+    # on the disc. A "(TM)" that only looked right would break both.
+    #
+    # The name is built from code points because this test file has to stay pure
+    # ASCII itself - the repo is BOM-less, so PowerShell 5.1 would read a
+    # non-ASCII byte in the ANSI codepage, and CI rejects one.
+
+    BeforeDiscovery {
+        $script:HaveCScriptFancy = @(
+            "$env:SystemRoot\System32\cscript.exe"
+            (Get-Command cscript.exe -ErrorAction SilentlyContinue | ForEach-Object { $_.Source })
+        ) | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
+    }
+
+    BeforeAll {
+        $script:CScriptFancy = @(
+            "$env:SystemRoot\System32\cscript.exe"
+            (Get-Command cscript.exe -ErrorAction SilentlyContinue | ForEach-Object { $_.Source })
+        ) | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
+
+        $script:Fancy = 'Star Wars' + [char]0x2122 + ': Empire at War' + [char]0x00AE
+        $script:FancyHta = Join-Path $script:Sandbox 'fancy-menu.hta'
+        New-MenuHta @{
+            GameName = $script:Fancy
+            Games    = @(@{ Name=$script:Fancy; MatchName=$script:Fancy
+                            Setup=('Games\01 - ' + $script:Fancy + '\setup.exe'); AddOns=@() })
+            Buttons  = @('Play','Install','Exit')
+            MusicFile = ''; ManualFile = ''; PanelSide = 'Right'; IconName = 'disc.ico'
+            WindowBorder = $true; ButtonStyle = 'Minimal'
+        } $script:FancyHta
+        $script:FancyText = Get-Content -LiteralPath $script:FancyHta -Raw
+    }
+
+    It 'writes a menu with nothing left for an ASCII file to destroy' {
+        $bytes = [IO.File]::ReadAllBytes($script:FancyHta)
+        @($bytes | Where-Object { $_ -gt 127 }).Count | Should -Be 0
+        # The reported symptom, named directly. Checked here rather than by
+        # looking for "?" anywhere, because the menu's JavaScript is full of
+        # ternaries and always has been.
+        $script:FancyText | Should -Not -Match 'Star Wars\?'
+        $script:FancyText | Should -Not -Match 'Empire at War\?'
+    }
+
+    It 'escapes for markup and for JavaScript in their own syntaxes' {
+        # HTML entities are not decoded inside <script>, so one escape cannot
+        # serve both places the name lands.
+        $script:FancyText | Should -Match '<title>Star Wars&#8482;: Empire at War&#174;</title>'
+        $script:FancyText | Should -Match 'n:"Star Wars\\u2122: Empire at War\\u00ae"'
+    }
+
+    It 'rebuilds the original characters exactly when the menu runs' -Skip:(-not $script:HaveCScriptFancy) {
+        # The assertion that matters. Compared as code points rather than as
+        # text, so nothing is riding on how a console pipe encodes its output -
+        # which is the very thing that caused the bug.
+        $m = [regex]::Match($script:FancyText, '(?m)^\s*var GAMES=(.+?);\s')
+        $m.Success | Should -BeTrue -Because 'the GAMES array has to be findable to be evaluated'
+        $probe = @'
+var GAMES = eval(WScript.StdIn.ReadAll());
+var s = GAMES[0].n, out = [];
+for (var i = 0; i < s.length; i++) out.push(s.charCodeAt(i));
+WScript.Echo(out.join(","));
+'@
+        $pf = Join-Path $script:Sandbox 'fancyparse.js'
+        $bf = Join-Path $script:Sandbox 'fancygames.js'
+        Set-Content -LiteralPath $pf -Value $probe -Encoding Ascii
+        Set-Content -LiteralPath $bf -Value $m.Groups[1].Value -Encoding Ascii
+        $out = (cmd /c "`"$script:CScriptFancy`" //Nologo //E:JScript `"$pf`" < `"$bf`"" 2>&1) -join ' '
+        $want = ($script:Fancy.ToCharArray() | ForEach-Object { [int]$_ }) -join ','
+        $out.Trim() | Should -Be $want
     }
 }


### PR DESCRIPTION


🤖 Generated with [Claude Code](https://claude.com/claude-code)
