### PR TITLE
chore(release): 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Whil
 version stays below 1.0.0, the project file format and the on-disc layout may change
 between minor versions.
 
-## [Unreleased]
+## [0.4.3] — 2026-08-27
 
 ### Fixed
 
@@ -436,7 +436,9 @@ First public release.
 - `extras/DiscLabel.ps1`, a parked printable disc-face generator, kept out of the app to
   keep the tool to one job.
 
-[Unreleased]: https://github.com/lazardjokovic/discwright/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/lazardjokovic/discwright/compare/v0.4.3...HEAD
+[0.4.3]: https://github.com/lazardjokovic/discwright/compare/v0.4.2...v0.4.3
+[0.4.2]: https://github.com/lazardjokovic/discwright/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/lazardjokovic/discwright/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/lazardjokovic/discwright/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/lazardjokovic/discwright/compare/v0.3.0...v0.3.1

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -61,7 +61,7 @@ $PROJECT_FILE = 'discproject.json'
 # this cannot quietly drift a release behind. Shown in the title bar and the log,
 # and written into every project file - a bug report that comes with a project
 # file then says for itself which version built the disc.
-$APP_VERSION  = '0.4.2'
+$APP_VERSION  = '0.4.3'
 
 # =================== SMALL HELPERS ===================
 


### PR DESCRIPTION
Cuts 0.4.3: `$APP_VERSION` to `0.4.3` and the `[Unreleased]` heading becomes
`## [0.4.3]`.

Three fixes since 0.4.2, and one change to what removing a game does:

- Game names keep their special characters in the menu (#34)
- The form is locked while a build runs (#33)
- Removing a game asks what to do with its add-ons (#33)

Also repairs the compare links at the foot of the changelog. `[Unreleased]` was
still pointing at `v0.4.1` and there was no `[0.4.2]` row at all - the last
release renamed the heading and left the links behind.

## Verification

- 292 logic tests and 56 window tests pass on the merge base; 292 logic tests
  re-run after the bump.
- The `version-matches-tag` job will check the constant against the tag when it
  is pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
