### PR TITLE
fix: stop a truncated disc label ending in an underscore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Whil
 version stays below 1.0.0, the project file format and the on-disc layout may change
 between minor versions.
 
+## [Unreleased]
+
+### Fixed
+
+- **A long disc label no longer ends in a stray underscore in This PC.** The
+  ISO9660 volume identifier is 16 characters and everything that is not
+  alphanumeric folds to an underscore. The fold was trimmed before truncating
+  but not after, so a label whose cut landed on a word boundary kept the
+  separator: *THE WITCHER ENH EDITION* reached the drive as `THE_WITCHER_ENH_`.
+  Cosmetic, and only on labels long enough to be cut, but it is the name the
+  disc carries.
+
 ## [0.4.3] — 2026-08-27
 
 ### Fixed

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -463,7 +463,9 @@ function Get-BuildTargets([string]$outDir, [string]$label) {
 # user typed is the only thing that has to fit.
 function Get-VolumeLabel([string]$label) {
     $base = (("$label" -replace '[^A-Za-z0-9_]','_')).Trim('_')
-    if ($base.Length -gt 16) { $base = $base.Substring(0, 16) }
+    # Trim again after truncating, not only before: cutting at 16 can land on a
+    # folded space and leave 'THE WITCHER ENH EDITION' as 'THE_WITCHER_ENH_'.
+    if ($base.Length -gt 16) { $base = $base.Substring(0, 16).TrimEnd('_') }
     if ([string]::IsNullOrEmpty($base)) { $base = 'DISC' }
     return $base
 }

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -179,6 +179,46 @@ Describe 'Get-GameFolderName' -Tag 'Unit' {
     }
 }
 
+Describe 'Get-VolumeLabel' -Tag 'Unit' {
+
+    # The ISO9660 volume identifier is 16 characters and New-Iso folds anything
+    # that is not alphanumeric to an underscore. This used to reserve room for a
+    # "_D2" suffix; disc sets are gone and so is the reservation, which is what
+    # made the truncation edge worth pinning down.
+
+    It 'keeps a label that already fits' {
+        Get-VolumeLabel 'Alan Wake' | Should -Be 'Alan_Wake'
+    }
+
+    It 'folds anything that is not alphanumeric to an underscore' {
+        # The colon and the space each fold, so this keeps both underscores.
+        Get-VolumeLabel 'Broken Sword: Shadow' | Should -Be 'Broken_Sword__Sh'
+    }
+
+    It 'caps the volume id at the 16 characters ISO9660 allows' {
+        (Get-VolumeLabel 'THE WITCHER ENHANCED EDITION').Length | Should -Be 16
+    }
+
+    It 'does not leave a trailing underscore when the cut lands on a word boundary' {
+        # 'THE WITCHER ENH EDITION' folds to THE_WITCHER_ENH_EDITION, and the
+        # first sixteen characters of that end on the separator. Trimming only
+        # before truncating left the disc named THE_WITCHER_ENH_ in This PC.
+        Get-VolumeLabel 'THE WITCHER ENH EDITION' | Should -Be 'THE_WITCHER_ENH'
+        Get-VolumeLabel 'A B C D E F G H I'       | Should -Not -Match '_$'
+    }
+
+    It 'never reserves room for a disc number that no longer exists' {
+        # Sets are gone. A leftover reservation would show up as a stray _D
+        # fragment on the end of a long label.
+        Get-VolumeLabel 'THE WITCHER ENHANCED EDITION' | Should -Not -Match '_D\d?$'
+    }
+
+    It 'falls back to DISC when nothing survives the fold' {
+        Get-VolumeLabel '!!!' | Should -Be 'DISC'
+        Get-VolumeLabel ''    | Should -Be 'DISC'
+    }
+}
+
 Describe 'Test-ReservedDiscName' -Tag 'Unit' {
 
     It 'reserves <Name>' -ForEach @(


### PR DESCRIPTION
`Get-VolumeLabel` folds everything non-alphanumeric to an underscore and caps the
result at the 16 characters ISO9660 allows for a volume identifier. It trimmed the
underscores **before** truncating and not after, so a label whose cut landed on a
word boundary kept the separator:

```
THE WITCHER ENH EDITION  ->  THE_WITCHER_ENH_
A B C D E F G H I        ->  A_B_C_D_E_F_G_H_
```

One line, and only visible on labels long enough to be cut. It gets its own PR
because it changes the name a disc carries in This PC.

## How it was found

`docs/MANUAL-CHECKS.md` has said this since 0.4.2, in check 3:

> **Failure looks like:** a name cut mid-word in an ugly place, **a trailing
> underscore**, or a leftover `_D` fragment.

That check was written an hour after 0.4.2 shipped and has never been run. The
defect turned up within minutes of writing the same check as a test.

## Tests

`Get-VolumeLabel` had none at all. It has six now: a label that already fits, the
fold, the 16-character cap, the truncation edge above, the absence of the `_D`
fragment disc sets used to reserve room for, and the `DISC` fallback when nothing
survives the fold.

Mutation-checked rather than assumed — with the `TrimEnd` reverted, *does not
leave a trailing underscore when the cut lands on a word boundary* fails with
`Expected 'THE_WITCHER_ENH', but was 'THE_WITCHER_ENH_'`.

Locally: 298 logic tests pass, 0 fail. PSScriptAnalyzer 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
