### PR TITLE
test: automate the manual checks that a machine can actually do

### DIFF
--- a/docs/MANUAL-CHECKS.md
+++ b/docs/MANUAL-CHECKS.md
@@ -1,100 +1,160 @@
 # Manual checks before a release
 
-The test suite covers a lot — 282 logic tests and 56 window tests — but three
-things it structurally cannot reach:
+The automated suite is 328 logic tests and 66 window tests, and it runs in about
+four minutes:
 
-- **whether a burned disc actually works.** Mounting an ISO, reading the drive
-  icon out of This PC and watching AutoRun fire is a different kind of test from
-  the ones in `tests/`.
-- **whether the menu looks right.** A test can prove the menu's JavaScript parses
-  (`tests/DiscWright.Tests.ps1`, *The menu's JavaScript is valid JavaScript*). It
-  cannot tell you the caption sits where it should.
-- **whether an old project file still opens.** Only real files written by older
-  versions prove that, and they live on your machine, not in the repo.
+```
+.\tests\Invoke-Tests.ps1
+```
 
-So: this list. Work down it, tick as you go. Each check says what to do, what you
-should see, and what a failure looks like — because "it looked fine" is not a
-result if you did not know what wrong would have looked like.
+It builds a real ISO, mounts it, and reads it back through Windows' own storage
+stack. It opens project files written by every older schema, including a real one
+0.4.2 wrote. It opens the menu and checks the characters in a game's name come
+out the other side. **Do not add a check to this page for anything in that list**
+— there is a table at the bottom saying where each of those lives.
+
+What is left here is the short list a machine cannot do: things only a person can
+judge, and things only a person can trigger.
 
 **Start DiscWright** by double-clicking `Run DiscWright.cmd` in the repo root, or
 the `DiscWright.lnk` shortcut.
 
+## Finding things in the window
+
+The window is one column of numbered steps, and the numbers are on screen — you
+never have to count controls to find one.
+
+| On screen | What it is |
+| --- | --- |
+| **1)  Installers on this disc** | the games list, with **Add game...** and **Add-on...** |
+| **2)  Disc label (shown in This PC)** | the label box, and **Target disc:** beside it |
+| **3)  Disc icon** | the `.ico` / `.png` / `.jpg` picker |
+| **4)  Autorun menu** | the menu on/off tick, background image, title, buttons |
+| **5)  Extra content** | files copied to the disc root as-is |
+| **6)  Output folder** | where the ISO and the `disc\` staging folder go |
+
+Across the top sit **New disc**, **Open existing disc...**, **Show disc folder**
+and **Preview menu**. **BUILD ISO** is at the bottom, beside the log box.
+
 ---
 
-## 1. The menu preview
+## 1. Does the menu look right?
 
-The most valuable check on this page. The menu is ~23,000 characters of
-JavaScript embedded in a PowerShell string; a test now proves it parses, but
-nothing automated can see it.
+A test opens the preview, proves the JavaScript ran without a script error, and
+reads the window title back to confirm the characters survived. UI Automation
+cannot see inside the rendered document, so **layout is the whole of this check**.
 
-- [ ] **Step 1** — *Add game...* and pick any GOG folder.
-- [ ] **Step 4** — make sure the **Autorun menu** checkbox is ticked, then
-      *Browse...* next to **Background image** and pick any PNG or JPG.
-- [ ] **Preview menu** (top right) is now enabled. Click it.
+- [ ] In **4)  Autorun menu**, tick **Autorun menu**.
+- [ ] Click **Browse...** beside **Background image** and pick any PNG or JPG.
+- [ ] Click **Preview menu**, top right. (It stays greyed until both of the above
+      are done — hover it and the tooltip says which is missing. You do not need
+      a game.)
 
-**Should see:** the menu window opens, with the game's name as the caption above
-the buttons.
+**Should see:** the caption sits above the buttons with the buttons evenly spaced
+under it, nothing overlapping the panel edge, nothing clipped, and the text
+readable against your background.
 
-**Failure looks like:** the window not opening at all (a JavaScript error the
-parse test could not catch — an undefined reference rather than a syntax error);
-or an **empty gap under the game's name**, which would mean the removed
-*"Disc 2 of 3"* caption left an empty element behind.
+**Failure looks like:** a caption running under the panel edge or off it; buttons
+crowded against the bottom; an empty gap under the caption; text the same tone as
+the background behind it.
 
-> Install and Manual do nothing in preview. That is expected — the log window
-> says so when the preview opens.
+> **Install** and **Manual** do nothing in preview. The log box says so when the
+> preview opens.
 
-## 2. A real disc, end to end
+The interesting case is a long name with many buttons — a game with four add-ons
+already needs eight buttons, and the menu shrinks them to fit. That shrink is
+arithmetic no test is watching the result of.
 
-This is the path where the multi-disc build function was removed and everything
-now goes through the single-disc one.
+## 2. Does This PC draw your icon and label?
 
-- [ ] Fill in steps 1–6 for one game and **BUILD ISO**.
-- [ ] Find the ISO in your output folder, right-click → **Mount**.
+A test mounts a built ISO and confirms `autorun.inf` names your icon, that the
+icon file is really on the disc, and that the volume label Windows reports is the
+one the app computed. Whether **Explorer draws it** is shell behaviour — and
+Explorer caches icon bitmaps per path, which is the whole reason the icon is
+named after the disc rather than `disc.ico`.
+
+- [ ] Build a disc, then right-click the ISO → **Mount**.
 - [ ] Open **This PC**.
 
-**Should see:** the mounted drive carries your disc icon and your disc label —
-not a generic drive icon, not the volume id.
+**Should see:** the drive carries your icon and your disc label, in full — not a
+generic drive icon, not the shortened volume id underneath.
 
-- [ ] Double-click the drive.
-
-**Should see:** the menu opens. **Install** launches GOG's installer.
+**Failure looks like:** a generic optical-drive icon; **the icon from a disc you
+mounted earlier** (the cache defeating the per-disc naming); the volume id
+(`THE_WITCHER_ENHA`) instead of the label you typed.
 
 - [ ] Right-click the drive → **Eject** when done.
 
-**Failure looks like:** a generic icon (the icon did not make it onto the disc),
-the wrong name in This PC, or the menu not opening on double-click.
+## 3. Does AutoRun fire?
 
-## 3. A long disc label
+Tests confirm `autorun.inf` is present and well formed and that everything it
+points at exists on the disc. Whether Windows *acts* on it depends on AutoPlay
+policy and a real double-click, neither of which a test can supply.
 
-`Get-VolumeLabel` was simplified — it used to reserve room for a `_D2` suffix and
-no longer does. The ISO9660 volume id is capped at 16 characters.
+- [ ] With the ISO still mounted, double-click the drive in This PC.
 
-- [ ] **Step 2** — type a label clearly longer than 16 characters, e.g.
-      `THE WITCHER ENHANCED EDITION`.
-- [ ] Build, mount, look at This PC.
+**Should see:** the menu opens.
 
-**Should see:** a sensibly truncated name. The full label is what This PC shows
-via AutoRun; the 16-character limit applies to the volume id underneath.
+**Failure looks like:** the drive opening as a folder, or nothing happening. Check
+AutoPlay is not switched off in Settings before blaming the disc.
 
-**Failure looks like:** a name cut mid-word in an ugly place, a trailing
-underscore, or a leftover `_D` fragment.
+## 4. Does a real GOG installer install?
 
-## 4. An old project file
+Every fixture in the suite is a sparse stub with a GOG-shaped filename. Nothing
+in the repo has ever been a real installer, so nothing automated has ever watched
+one run.
 
-Only if you have one written before this release.
+- [ ] From the mounted disc's menu, click **Install**.
 
-- [ ] **Step 6** — point the output folder at a folder holding an older
-      `discproject.json`.
-- [ ] **Open existing disc...**
+**Should see:** GOG's installer starts and completes against a real download.
 
-**Should see:** the games, label, icon and menu settings all come back. If that
-project named a target disc, **Target disc** in step 2 comes back on it.
+- [ ] If the game registers itself, reopen the menu and click **Play**.
 
-**Failure looks like:** an error on open, or Target disc falling back to
-*Recommend a disc for me* when the project named a real one.
+**Should see:** the game launches. Play finds an installed copy through the
+registry keys GOG's installer writes, matched on the game's registered name —
+which is why a game renamed for the menu must still match on its original name.
 
-> Old projects carry an `ExtrasEveryDisc` field from the disc-sets feature. It is
-> ignored now, which is correct — it should not cause an error either.
+**Failure looks like:** Install doing nothing (the path on the disc and the path
+in the menu disagree), or Play saying it cannot find the game after a successful
+install.
+
+## 5. A burned disc
+
+Only if you are burning one. Everything above is about an ISO; a burner is a
+different piece of hardware with its own failure modes.
+
+- [ ] Burn, put it in a drive, and work through checks 2 to 4 on the real disc.
+
+---
+
+## What is already automated, and where
+
+Do not re-add any of these as a manual check.
+
+| Covered | Where |
+| --- | --- |
+| ISO is real UDF 2.50 and passes an integrity read | *Building a disc* → `inside the finished ISO` |
+| ISO mounts; drive letter, filesystem, read-only | *The finished ISO as Windows itself reads it* |
+| Volume label Windows reports matches the app's own | same |
+| No trailing `_` or leftover `_D` in the volume id | same, and *Get-VolumeLabel* |
+| Full label survives into `autorun.inf` | same |
+| Icon and menu named in `autorun.inf` exist on the disc | same |
+| The installer is reachable at the path the menu was given | same |
+| Menu JavaScript parses, and defines what it calls | *The menu's JavaScript is valid JavaScript* |
+| Menu opens without a runtime script error | *Previewing the menu* |
+| `™` and `®` reach the screen intact | same, and *A game name with characters outside plain ASCII* |
+| Project files from v1, v2, v3 and a real 0.4.2 file | *Project file* |
+| `ExtrasEveryDisc` from the removed disc-sets feature | same |
+| Target disc saved and restored | same, and *Reopening a project that named a target disc* |
+| A build driven from the window, start to ISO on disk | *The form while a real build runs* |
+| The form locks during a build and restores what was enabled | *Locking the form while a build runs* |
+
+One thing deliberately has **no** test: whether the form *looks* frozen while a
+build runs. The only moment it is observable from outside is while the completion
+box is up, and a modal box makes UI Automation report every control on its owner
+as disabled anyway — a window test written that way passes with the lock removed
+entirely. The lock is tested on real controls instead, and the wiring is checked
+in the syntax tree.
 
 ---
 

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -219,6 +219,105 @@ Describe 'Get-VolumeLabel' -Tag 'Unit' {
     }
 }
 
+Describe 'Locking the form while a build runs' -Tag 'Unit' {
+
+    # Added in 0.4.3 and shipped without ever running a build from the window.
+    # It cannot be tested through the window either, which is worth writing down
+    # so nobody spends an afternoon rediscovering it: the only moment the form is
+    # observably frozen is while the "Build complete" box is up, and a modal box
+    # makes UI Automation report every control on the owner as disabled anyway.
+    # A window test written that way passes with the lock removed entirely.
+    #
+    # So it is tested here, on real WinForms controls, plus the wiring check
+    # below that the build handler still calls it.
+
+    BeforeAll {
+        Add-Type -AssemblyName System.Windows.Forms
+
+        # Script scope for the same reason as PROJECT_FILE above: Set-FormBusy
+        # looks these up dynamically from wherever it is called.
+        $script:form       = New-Object System.Windows.Forms.Form
+        $script:txtLog     = New-Object System.Windows.Forms.TextBox
+        $script:pbBuild    = New-Object System.Windows.Forms.ProgressBar
+        $script:lblElapsed = New-Object System.Windows.Forms.Label
+        $script:btnOne     = New-Object System.Windows.Forms.Button
+        # Greyed before the build for a reason of its own - nothing is selected.
+        # This is the control the restore has to leave alone.
+        $script:btnGreyed  = New-Object System.Windows.Forms.Button
+        $script:btnGreyed.Enabled = $false
+        $script:form.Controls.AddRange(@(
+            $script:txtLog, $script:pbBuild, $script:lblElapsed,
+            $script:btnOne, $script:btnGreyed))
+        $script:BuildFrozen = $null
+    }
+
+    AfterAll {
+        if ($script:form) { $script:form.Dispose(); $script:form = $null }
+    }
+
+    It 'disables the controls a person could otherwise touch mid-build' {
+        Set-FormBusy $true
+        $script:btnOne.Enabled | Should -BeFalse
+    }
+
+    It 'leaves the log, the progress bar and the elapsed label alive' {
+        # They are the only things worth looking at while it runs, and a disabled
+        # multiline TextBox cannot even be scrolled.
+        $script:txtLog.Enabled     | Should -BeTrue
+        $script:pbBuild.Enabled    | Should -BeTrue
+        $script:lblElapsed.Enabled | Should -BeTrue
+    }
+
+    It 'gives back exactly what was enabled before, not everything' {
+        # The bug this shape avoids: re-enabling the form wholesale would wake
+        # controls that were greyed for reasons that have not changed just
+        # because a build happened.
+        Set-FormBusy $false
+        $script:btnOne.Enabled    | Should -BeTrue
+        $script:btnGreyed.Enabled | Should -BeFalse
+    }
+
+    It 'is safe to unlock a form that was never locked' {
+        # The unlock lives in a finally, so it runs even on a path that threw
+        # before the lock was taken.
+        $script:BuildFrozen = $null
+        { Set-FormBusy $false } | Should -Not -Throw
+    }
+
+    Context 'wired into the build' {
+
+        BeforeAll {
+            $src = Join-Path (Split-Path $PSScriptRoot -Parent) 'DiscWright.ps1'
+            $tree = [System.Management.Automation.Language.Parser]::ParseFile($src, [ref]$null, [ref]$null)
+            $script:BusyCalls = @($tree.FindAll({ param($n)
+                $n -is [System.Management.Automation.Language.CommandAst] -and
+                $n.GetCommandName() -eq 'Set-FormBusy' }, $true))
+
+            function Test-InFinally($node) {
+                $n = $node.Parent
+                while ($n) {
+                    if ($n -is [System.Management.Automation.Language.TryStatementAst] -and $n.Finally -and
+                        $n.Finally.Extent.StartOffset -le $node.Extent.StartOffset -and
+                        $n.Finally.Extent.EndOffset   -ge $node.Extent.EndOffset) { return $true }
+                    $n = $n.Parent
+                }
+                return $false
+            }
+        }
+
+        It 'locks the form when a build starts' {
+            @($script:BusyCalls | Where-Object { $_.CommandElements[1].Extent.Text -eq '$true' }).Count |
+                Should -Be 1
+        }
+
+        It 'unlocks it in a finally, so a failed build cannot leave it dead' {
+            $unlock = @($script:BusyCalls | Where-Object { $_.CommandElements[1].Extent.Text -eq '$false' })
+            $unlock.Count | Should -Be 1
+            Test-InFinally $unlock[0] | Should -BeTrue
+        }
+    }
+}
+
 Describe 'Test-ReservedDiscName' -Tag 'Unit' {
 
     It 'reserves <Name>' -ForEach @(
@@ -685,6 +784,170 @@ Describe 'Project file' -Tag 'Unit' {
         }
     }
 
+    Context 'a project written by v0.2.0' {
+
+        BeforeAll {
+            # Schema 2 introduced the Games array and nothing else: no Kind, no
+            # Parent, no Setup, no Manual, no Extras. Written by hand for the
+            # same reason as the v1 file above - a round-trip of our own output
+            # proves we can read what we just wrote, not what somebody's older
+            # DiscWright wrote two schemas ago.
+            $script:V2Out = Join-Path $script:Sandbox 'proj-v2-old'
+            New-Item -ItemType Directory -Force -Path $script:V2Out | Out-Null
+            @{ Version=2; SavedUtc='2026-08-17T10:00:00'
+               SourceFolder=$script:PGames[0].Folder; GameName='Game One'; Label='Trilogy'
+               Games=@(
+                   @{ Folder=$script:PGames[0].Folder; GameName='Game One' }
+                   @{ Folder=$script:PGames[1].Folder; GameName='Game Two' }
+                   @{ Folder=$script:PGames[2].Folder; GameName='Game Three' }
+               )
+               IconPath=$script:Art; IconIsIco=$false; Menu=$true; BgPath=$script:Bg; BgAsIs=$false
+               PanelSide='Right'; Divider=$false; ShowTitle=$false; TitleText=''
+               WindowBorder=$true; ButtonStyle='Minimal'; MusicFile=$null
+               Buttons=@('Play','Install','Exit'); ManualPath=$null; ExtrasPath=$null; ExtraItems=@()
+               OutDir=$script:V2Out } | ConvertTo-Json -Depth 4 |
+                Set-Content (Join-Path $script:V2Out 'discproject.json') -Encoding UTF8
+            $script:V2Back = Import-Project (Join-Path $script:V2Out 'discproject.json')
+        }
+
+        It 'still opens' {
+            $script:V2Back | Should -Not -BeNullOrEmpty
+        }
+
+        It 'returns every game in the array, not just the v1 SourceFolder' {
+            @($script:V2Back.GameFolders).Count | Should -Be 3
+        }
+
+        It 'reads entries with no Kind as all games and no add-ons' {
+            # Which is exactly what a version 2 disc was: add-ons did not exist.
+            @($script:V2Back.GameEntries | Where-Object { $_.Kind -eq 'Game' }).Count    | Should -Be 3
+            @($script:V2Back.GameEntries | Where-Object { $_.ParentIndex -ne -1 }).Count | Should -Be 0
+        }
+
+        It 'leaves Setup unset so the installer is detected again' {
+            # v2 recorded only the folder. Inventing a Setup here would be worse
+            # than leaving it blank - re-detection finds the real one.
+            @($script:V2Back.GameEntries | Where-Object { $_.Setup }).Count | Should -Be 0
+        }
+    }
+
+    Context 'a project written by v0.3.x' {
+
+        BeforeAll {
+            # Schema 3 added Kind, Parent and Setup. Manual and Extras arrived in
+            # 4, so an add-on parented correctly but nothing had media of its own.
+            $script:V3Out = Join-Path $script:Sandbox 'proj-v3-old'
+            New-Item -ItemType Directory -Force -Path $script:V3Out | Out-Null
+            @{ Version=3; SavedUtc='2026-08-18T10:00:00'
+               SourceFolder=$script:PGames[0].Folder; GameName='Game One'; Label='Trilogy'
+               Games=@(
+                   @{ Folder=$script:PGames[0].Folder; GameName='Game One'
+                      Setup=$script:PGames[0].SetupExe.FullName; Kind='Game'; Parent=-1 }
+                   @{ Folder=$script:PGames[0].Folder; GameName='Patch 1.1'
+                      Setup=$script:PGames[0].SetupExe.FullName; Kind='AddOn'; Parent=0 }
+                   @{ Folder=$script:PGames[1].Folder; GameName='Game Two'
+                      Setup=$script:PGames[1].SetupExe.FullName; Kind='Game'; Parent=-1 }
+               )
+               IconPath=$script:Art; IconIsIco=$false; Menu=$true; BgPath=$script:Bg; BgAsIs=$false
+               PanelSide='Right'; Divider=$false; ShowTitle=$false; TitleText=''
+               WindowBorder=$true; ButtonStyle='Minimal'; MusicFile=$null
+               Buttons=@('Play','Install','Exit'); ManualPath=$null; ExtrasPath=$null; ExtraItems=@()
+               OutDir=$script:V3Out } | ConvertTo-Json -Depth 4 |
+                Set-Content (Join-Path $script:V3Out 'discproject.json') -Encoding UTF8
+            $script:V3Back = Import-Project (Join-Path $script:V3Out 'discproject.json')
+        }
+
+        It 'still opens' {
+            $script:V3Back | Should -Not -BeNullOrEmpty
+        }
+
+        It 'keeps the add-on attached to the game it belongs to' {
+            $addOns = @($script:V3Back.GameEntries | Where-Object { $_.Kind -eq 'AddOn' })
+            $addOns.Count          | Should -Be 1
+            $addOns[0].ParentIndex | Should -Be 0
+        }
+
+        It 'reads an entry from before per-entry media as having none of its own' {
+            # Version 4 added Manual and Extras. Absent here, which has to read
+            # back as blank rather than as a path that was never written.
+            @($script:V3Back.GameEntries | Where-Object { $_.Manual }).Count | Should -Be 0
+            @($script:V3Back.GameEntries | Where-Object { $_.Extras }).Count | Should -Be 0
+        }
+    }
+
+    It 'ignores ExtrasEveryDisc left behind by the disc-sets feature' {
+        # Disc sets were removed in 0.4.2. Projects written while they existed
+        # carry a key nothing reads any more; the only requirement is that its
+        # presence is not an error. Save-Project writes a fixed set of keys, so
+        # this has to be injected into the file afterwards - passing it in the
+        # settings hashtable never reaches the JSON, and a test that did that
+        # would pass while proving nothing.
+        $out = Join-Path $script:POut 'extraseverydisc'
+        New-Item -ItemType Directory -Force -Path $out | Out-Null
+        Save-Project (New-BuildSettings -Games $script:PGames -Label 'Trilogy' -OutDir $out) $out
+        $f = Join-Path $out 'discproject.json'
+        $j = Get-Content -Raw $f | ConvertFrom-Json
+        $j | Add-Member -NotePropertyName 'ExtrasEveryDisc' -NotePropertyValue $true
+        $j | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $f -Encoding UTF8
+        $back = Import-Project $f
+        $back                      | Should -Not -BeNullOrEmpty
+        @($back.GameFolders).Count | Should -Be 3
+        $back.Label                | Should -Be 'Trilogy'
+    }
+
+    Context 'a real project file written by 0.4.2' {
+
+        BeforeAll {
+            # Not a reconstruction. This is the file 0.4.2 actually wrote for a
+            # five-entry disc, kept in the repo so that "does an old project still
+            # open" has an answer which does not depend on what happens to be left
+            # on somebody's machine. Its paths point at folders that no longer
+            # exist, which is the normal state of an old project and is why
+            # Import-Project does not check them.
+            $script:RealPath = Join-Path $PSScriptRoot 'fixtures\discproject-0.4.2.json'
+            $script:RealBack = Import-Project $script:RealPath
+        }
+
+        It 'is still in the repo' {
+            Test-Path $script:RealPath | Should -BeTrue
+        }
+
+        It 'opens' {
+            $script:RealBack | Should -Not -BeNullOrEmpty
+        }
+
+        It 'reads through the UTF-8 BOM every project file carries' {
+            # PowerShell 5.1 writes a BOM for -Encoding UTF8, so every project
+            # file in the wild has one. A reader that chokes on it opens nothing,
+            # and this fixture is only evidence if it still has its BOM.
+            ([IO.File]::ReadAllBytes($script:RealPath)[0..2] -join ',') | Should -Be '239,187,191'
+        }
+
+        It 'returns all five entries' {
+            @($script:RealBack.GameEntries).Count | Should -Be 5
+        }
+
+        It 'keeps the two updates filed under their games rather than beside them' {
+            $addOns = @($script:RealBack.GameEntries | Where-Object { $_.Kind -eq 'AddOn' })
+            $addOns.Count | Should -Be 2
+            (@($addOns | ForEach-Object { $_.ParentIndex }) -join ',') | Should -Be '0,2'
+        }
+
+        It 'brings back the label, the icon, the background and the music' {
+            $script:RealBack.Label     | Should -Be 'Alan Wake'
+            $script:RealBack.IconPath  | Should -Match 'alanwake-icon\.ico$'
+            $script:RealBack.BgPath    | Should -Match 'alanwake-background\.jpg$'
+            $script:RealBack.MusicFile | Should -Match '\.mp3$'
+        }
+
+        It 'reads its empty MediaKey as the automatic setting' {
+            # The disc this file describes was built without picking a target
+            # disc, so reopening it has to land on "recommend a disc for me" -
+            # not on a medium nobody ever chose.
+            $script:RealBack.MediaKey | Should -Be ''
+        }
+    }
+
     It 'survives a project file that is not valid JSON' {
         $junk = Join-Path $script:Sandbox 'junk'
         New-Item -ItemType Directory -Force -Path $junk | Out-Null
@@ -943,6 +1206,127 @@ Describe 'Building a disc' -Tag 'Build' -Skip:(-not $script:CanBuildIso) {
 # ---------------------------------------------------------------------------
 # Multi-game chooser and add-ons
 # ---------------------------------------------------------------------------
+
+Describe 'The finished ISO as Windows itself reads it' -Tag 'Build' -Skip:(-not $script:CanBuildIso) {
+
+    # 7-Zip proves the image is well formed. It does not prove Windows will mount
+    # it, and mounting is the first thing anybody does with the file - right-click,
+    # Mount, look at This PC. Everything here goes through the real storage stack
+    # instead: the volume label Explorer shows, the autorun.inf it reads, the icon
+    # and the menu it is pointed at.
+    #
+    # Mounting needs no elevation - measured on Windows 11, not assumed. A machine
+    # that refuses anyway is not a DiscWright defect, so these skip with the reason
+    # rather than failing and blaming the code.
+
+    BeforeAll {
+        $script:MountLabel = 'THE WITCHER ENH EDITION'
+        $script:MountOut   = Join-Path $script:Sandbox 'build-mount'
+        New-Item -ItemType Directory -Force -Path $script:MountOut | Out-Null
+        $script:MountIso = Invoke-Build (New-BuildSettings `
+            -Games @((Get-GameInfo (New-FixtureGame -Slug 'mount_one' -ExeMb 2))) `
+            -Label $script:MountLabel -OutDir $script:MountOut) $script:LogSink
+
+        $script:MountVol = $null; $script:MountErr = $null; $script:MountRoot = $null
+        try {
+            $img = Mount-DiskImage -ImagePath $script:MountIso -StorageType ISO -PassThru -ErrorAction Stop
+            # The volume can trail the mount by a moment, so this waits for a
+            # drive letter rather than reading one that is not there yet and
+            # reporting it as a defect in the image.
+            for ($i = 0; $i -lt 20; $i++) {
+                $v = $img | Get-Volume -ErrorAction SilentlyContinue
+                if ($v -and $v.DriveLetter) { $script:MountVol = $v; break }
+                Start-Sleep -Milliseconds 250
+            }
+            if (-not $script:MountVol) { $script:MountErr = 'mounted, but no drive letter appeared' }
+            else { $script:MountRoot = "$($script:MountVol.DriveLetter):\" }
+        } catch { $script:MountErr = $_.Exception.Message }
+
+        function Test-Mounted {
+            if (-not $script:MountVol) {
+                Set-ItResult -Skipped -Because "this machine would not mount the image: $script:MountErr"
+            }
+        }
+
+        $script:MountInf = ''
+        if ($script:MountRoot) {
+            $p = Join-Path $script:MountRoot 'autorun.inf'
+            if (Test-Path $p) { $script:MountInf = Get-Content -Raw -LiteralPath $p }
+        }
+    }
+
+    AfterAll {
+        if ($script:MountIso) {
+            Dismount-DiskImage -ImagePath $script:MountIso -ErrorAction SilentlyContinue | Out-Null
+        }
+    }
+
+    It 'mounts as a drive Windows will open' {
+        Test-Mounted
+        $script:MountVol.DriveLetter | Should -Not -BeNullOrEmpty
+    }
+
+    It 'is UDF to Windows, not only to 7-Zip' {
+        Test-Mounted
+        $script:MountVol.FileSystem | Should -Be 'UDF'
+    }
+
+    It 'carries the volume id the app computed for the label' {
+        # Ties Get-VolumeLabel to what the operating system actually reports,
+        # which is the only place the two could ever have disagreed.
+        Test-Mounted
+        $script:MountVol.FileSystemLabel | Should -Be (Get-VolumeLabel $script:MountLabel)
+    }
+
+    It 'does not show a truncation artefact in This PC' {
+        # The two failures the manual check told a person to look for: a stray
+        # trailing underscore, and a leftover _D fragment from disc sets.
+        Test-Mounted
+        $script:MountVol.FileSystemLabel | Should -Not -Match '_$'
+        $script:MountVol.FileSystemLabel | Should -Not -Match '_D\d?$'
+    }
+
+    It 'puts the full label in autorun.inf, which is what This PC really shows' {
+        # The 16-character cap is the volume id underneath. AutoRun overrides it
+        # with the label as typed, and that override is the whole reason a disc
+        # called THE WITCHER ENH EDITION does not read as THE_WITCHER_ENH.
+        Test-Mounted
+        $script:MountInf | Should -Match ('(?m)^label=' + [regex]::Escape($script:MountLabel) + '\s*$')
+    }
+
+    It 'names an icon that is really on the disc' {
+        Test-Mounted
+        $script:MountInf | Should -Match '(?m)^icon='
+        $icon = ([regex]::Match($script:MountInf, '(?m)^icon=(.+?)\s*$')).Groups[1].Value
+        $icon | Should -Be (Get-DiscIconName $script:MountLabel)
+        Test-Path (Join-Path $script:MountRoot $icon) | Should -BeTrue
+    }
+
+    It 'points AutoRun at a menu that is really on the disc' {
+        # A shellexecute naming a file that is not there is a disc that opens
+        # nothing when double-clicked, and no listing test can see it.
+        Test-Mounted
+        $script:MountInf | Should -Match '(?m)^shellexecute='
+        $target = ([regex]::Match($script:MountInf, '(?m)^shellexecute=(.+?)\s*$')).Groups[1].Value
+        Test-Path (Join-Path $script:MountRoot $target) | Should -BeTrue
+    }
+
+    It 'reaches the installer through the path the menu was given' {
+        # The menu builds its Setup path at build time from the disc layout. If
+        # that path and the files on the disc ever disagree, Install fails on a
+        # burned disc and nowhere else.
+        Test-Mounted
+        $games = @(Get-GameInfo (Join-Path $script:Sandbox 'src\mount_one'))
+        $rel = Get-DiscEntrySetup $games 0
+        Test-Path (Join-Path $script:MountRoot $rel) | Should -BeTrue
+    }
+
+    It 'opens read-only, the way a burned disc does' {
+        Test-Mounted
+        { New-Item -ItemType File -Path (Join-Path $script:MountRoot 'nope.txt') -ErrorAction Stop } |
+            Should -Throw
+    }
+}
 
 Describe 'Where an entry lands on the disc' {
 

--- a/tests/fixtures/discproject-0.4.2.json
+++ b/tests/fixtures/discproject-0.4.2.json
@@ -1,0 +1,81 @@
+﻿{
+    "Version":  5,
+    "AppVersion":  "0.4.2",
+    "SavedUtc":  "2026-08-26T21:05:49",
+    "SourceFolder":  "F:\\DWdemo\\Alan Wake",
+    "GameName":  "Alan Wake",
+    "Games":  [
+                  {
+                      "Folder":  "F:\\DWdemo\\Alan Wake",
+                      "GameName":  "Alan Wake",
+                      "Setup":  "F:\\DWdemo\\Alan Wake\\setup_alan_wake_1.1_music_lang_fix_(80728).exe",
+                      "Kind":  "Game",
+                      "Parent":  -1,
+                      "Manual":  null,
+                      "Extras":  null
+                  },
+                  {
+                      "Folder":  "F:\\DWdemo\\Dead Space",
+                      "GameName":  "Dead Space",
+                      "Setup":  "F:\\DWdemo\\Dead Space\\setup_dead_space_2.0.0.2.exe",
+                      "Kind":  "Game",
+                      "Parent":  -1,
+                      "Manual":  null,
+                      "Extras":  null
+                  },
+                  {
+                      "Folder":  "F:\\DWdemo\\Hollow Knight",
+                      "GameName":  "Hollow Knight",
+                      "Setup":  "F:\\DWdemo\\Hollow Knight\\setup_hollow_knight_1.5.12620_(64bit)_(89718).exe",
+                      "Kind":  "Game",
+                      "Parent":  -1,
+                      "Manual":  null,
+                      "Extras":  null
+                  },
+                  {
+                      "Folder":  "F:\\DWdemo\\Alan Wake",
+                      "GameName":  "Update 1.1 music fixed (75607)",
+                      "Setup":  "F:\\DWdemo\\Alan Wake\\patch_alan_wake_1.0_Hotfix_(24778)_to_1.1_music_fixed_(75607).exe",
+                      "Kind":  "AddOn",
+                      "Parent":  0,
+                      "Manual":  null,
+                      "Extras":  null
+                  },
+                  {
+                      "Folder":  "F:\\DWdemo\\Hollow Knight",
+                      "GameName":  "Update 1.5.78.11833a (85515)",
+                      "Setup":  "F:\\DWdemo\\Hollow Knight\\patch_hollow_knight_1.5.78.11833_(50884)_to_1.5.78.11833a_(85515).exe",
+                      "Kind":  "AddOn",
+                      "Parent":  2,
+                      "Manual":  null,
+                      "Extras":  null
+                  }
+              ],
+    "Label":  "Alan Wake",
+    "IconPath":  "F:\\DWdemo\\artwork\\alanwake-icon.ico",
+    "IconIsIco":  true,
+    "Menu":  true,
+    "BgPath":  "F:\\DWdemo\\artwork\\alanwake-background.jpg",
+    "BgAsIs":  false,
+    "PanelSide":  "Right",
+    "Divider":  false,
+    "ShowTitle":  true,
+    "TitleText":  "Alan Wake",
+    "WindowBorder":  false,
+    "ButtonStyle":  "Minimal",
+    "MusicFile":  "F:\\DWdemo\\music\\Dusk of a Northern Kingdom.mp3",
+    "Buttons":  [
+                    "Play",
+                    "Install",
+                    "Manual",
+                    "Extras",
+                    "Exit"
+                ],
+    "ManualPath":  "F:\\DWdemo\\media\\AlanWake_manual\\alan_wake_manual\\Alan Wake manual.pdf",
+    "ExtrasPath":  "F:\\DWdemo\\media\\DiscExtras",
+    "ExtraItems":  [
+                       "F:\\DWdemo\\artwork"
+                   ],
+    "MediaKey":  "",
+    "OutDir":  "C:\\DWDemo2"
+}

--- a/tests/ui/DiscWright.UI.Tests.ps1
+++ b/tests/ui/DiscWright.UI.Tests.ps1
@@ -148,6 +148,28 @@ BeforeAll {
         ExtraItems=@(); MediaKey='CD'; ExtrasEveryDisc=$false; OutDir=$script:BigOutEx
     } $script:BigOutEx
 
+    # A project whose disc label carries the characters that used to be eaten by
+    # the ASCII file the menu is written to. Saved rather than typed: SendKeys is
+    # not a reliable way to enter a trademark sign, and the point of the fixture
+    # is the menu, not the typing.
+    $script:FancyLabel = 'Star Wars' + [char]0x2122 + ' Empire at War' + [char]0x00AE
+    $script:FancyOut = Join-Path $script:Sandbox 'fancyproj'
+    New-Item -ItemType Directory -Force -Path $script:FancyOut | Out-Null
+    Save-Project @{
+        Games=@((Get-GameInfo $script:GameA)); Label=$script:FancyLabel
+        IconPath=$script:Art; IconIsIco=$false
+        Menu=$true; BgPath=$script:Art; BgAsIs=$false; PanelSide='Right'
+        Divider=$false; ShowTitle=$false; TitleText=''
+        WindowBorder=$true; ButtonStyle='Minimal'; MusicFile=$null
+        Buttons=@('Play','Install','Exit'); ManualPath=$null; ExtrasPath=$null
+        ExtraItems=@(); MediaKey=''; OutDir=$script:FancyOut
+    } $script:FancyOut
+
+    # Somewhere for the one build these tests actually run to land. Empty, so the
+    # button reads BUILD ISO rather than REBUILD ISO and nothing is overwritten.
+    $script:LockOut = Join-Path $script:Sandbox 'lockbuild'
+    New-Item -ItemType Directory -Force -Path $script:LockOut | Out-Null
+
     $script:App = $null
 }
 
@@ -649,6 +671,102 @@ Describe 'What the build refuses, and whether it says why' -Tag 'UI' -Skip:(-not
     }
 }
 
+
+Describe 'Previewing the menu' -Tag 'UI' -Skip:(-not $script:HaveDesktop) {
+
+    # The menu is ~23,000 characters of JScript that otherwise only ever runs on
+    # a finished disc. tests/DiscWright.Tests.ps1 proves it parses; parsing says
+    # nothing about an undefined reference, which throws only when the menu is
+    # opened. This opens it.
+    #
+    # How the script-error assertion was arrived at, rather than guessed: a menu
+    # deliberately broken with an undefined reference inside capFor puts a child
+    # called "Script Error" in the HTA window, and a healthy one does not. The
+    # window itself appears either way, so its presence alone proves nothing.
+    #
+    # What is still left for a person is layout - whether the caption sits where
+    # it should. UI Automation sees the HTA's window and its title and no more:
+    # the rendered document is not in the tree.
+
+    BeforeAll {
+        $script:App = Start-DiscWright -AppPath $script:AppPath
+        $script:Win = $script:App.Window
+        $script:MshtaBefore = @(Get-Process mshta -ErrorAction SilentlyContinue | ForEach-Object { $_.Id })
+
+        # Preview needs the menu ticked and a background chosen, and nothing else.
+        # Reopening the fixture supplies both, and puts a label on the disc that
+        # cannot survive being written to an ASCII file unescaped.
+        Set-CtlText -Ctl (Get-BoxAfter $script:Win '6)  Output folder*') -Text $script:FancyOut
+        Invoke-CtlNamed $script:Win 'Open existing disc*' | Out-Null
+        Complete-FolderDialog -Win $script:Win | Out-Null
+        Start-Sleep -Seconds 2
+
+        $script:PreviewWin = $null
+        $script:PreviewProc = $null
+        if ((Test-CtlEnabled $script:Win 'Preview menu') -eq $true) {
+            Invoke-CtlNamed $script:Win 'Preview menu' | Out-Null
+            for ($i = 0; $i -lt 40; $i++) {
+                $new = @(Get-Process mshta -ErrorAction SilentlyContinue |
+                         Where-Object { $script:MshtaBefore -notcontains $_.Id })
+                if ($new.Count) { $script:PreviewProc = $new[0]; break }
+                Start-Sleep -Milliseconds 250
+            }
+            if ($script:PreviewProc) {
+                $script:PreviewWin = Wait-AnyWinForProcess -ProcessId $script:PreviewProc.Id -TimeoutSec 20
+            }
+        }
+        # Read once, after the menu has had time to run its init, so every test
+        # below is looking at the same settled window.
+        Start-Sleep -Seconds 2
+        $script:PreviewTitle = ''
+        $script:PreviewKids  = @()
+        if ($script:PreviewWin) {
+            try { $script:PreviewTitle = $script:PreviewWin.Current.Name } catch {}
+            $all = $script:PreviewWin.FindAll(
+                [System.Windows.Automation.TreeScope]::Descendants,
+                [System.Windows.Automation.Condition]::TrueCondition)
+            for ($i = 0; $i -lt $all.Count; $i++) {
+                try { $n = $all.Item($i).Current.Name; if ($n) { $script:PreviewKids += $n } } catch {}
+            }
+        }
+    }
+
+    AfterAll {
+        # Only what this block started. Killing every mshta would take out
+        # whatever the person at the machine happened to have open.
+        Get-Process mshta -ErrorAction SilentlyContinue |
+            Where-Object { $script:MshtaBefore -notcontains $_.Id } |
+            ForEach-Object { Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue }
+        Stop-DiscWright $script:App; $script:App = $null
+    }
+
+    It 'wakes Preview menu once the menu is on and a background is chosen' {
+        Test-CtlEnabled $script:Win 'Preview menu' | Should -BeTrue
+    }
+
+    It 'opens a window' {
+        # The parse test cannot catch a reference that is only undefined at run
+        # time. Nothing opening at all is what that looks like from outside.
+        $script:PreviewWin | Should -Not -BeNullOrEmpty
+    }
+
+    It 'runs its JavaScript without a script error' {
+        $script:PreviewKids | Should -Not -Contain 'Script Error'
+    }
+
+    It 'renders the trademark characters instead of question marks' {
+        # The whole 0.4.3 fix, end to end and through the real HTML engine
+        # rather than through cscript: the label is escaped to &#8482; on the way
+        # into an ASCII file and has to come back out as the character itself.
+        $script:PreviewTitle | Should -Be $script:FancyLabel
+    }
+
+    It 'does not leave the app stuck behind its own preview' {
+        # The preview is launched, not shown modally. A build has to still be
+        # reachable with the menu standing open.
+        Test-CtlEnabled $script:Win '*BUILD ISO' | Should -BeTrue
+    }
+}
 Describe 'Choosing the disc you are going to burn' -Tag 'UI' -Skip:(-not $script:HaveDesktop) {
 
     BeforeAll {
@@ -747,5 +865,93 @@ Describe 'Reopening a project that named a target disc' -Tag 'UI' -Skip:(-not $s
         Start-Sleep -Seconds 2
         Get-MediaTargetText $script:Win | Should -BeLike 'Recommend a disc*'
         Get-StatusText $script:Win | Should -Match 'Disc: '
+    }
+}
+
+
+Describe 'The form while a real build runs' -Tag 'UI' -Skip:(-not $script:HaveDesktop) {
+
+    # 0.4.3 locked the form for the duration of a build. It shipped without ever
+    # having run one from the window, because a build of these sparse fixtures
+    # finishes faster than UI Automation can sample it.
+    #
+    # It does not have to be sampled. The "Build complete" box is shown from
+    # inside the try, and Set-FormBusy $false runs in the finally after it - so
+    # while that box stands, the form is still frozen and can be read at leisure.
+    # That is also the case that matters: a form left disabled behind a dialog is
+    # an app that looks hung.
+
+    BeforeAll {
+        $script:App = Start-DiscWright -AppPath $script:AppPath
+        $script:Win = $script:App.Window
+
+        Set-CtlText -Ctl (Get-BoxAfter $script:Win '6)  Output folder*') -Text $script:ProjOut
+        Invoke-CtlNamed $script:Win 'Open existing disc*' | Out-Null
+        Complete-FolderDialog -Win $script:Win | Out-Null
+        Start-Sleep -Seconds 2
+        # Somewhere empty, so this is a build rather than an overwrite.
+        Set-CtlText -Ctl (Get-BoxAfter $script:Win '6)  Output folder*') -Text $script:LockOut
+        Start-Sleep -Seconds 1
+
+        $script:BeforeChange = Test-CtlEnabled $script:Win 'Change*'
+        Invoke-CtlNamed $script:Win '*BUILD ISO' | Out-Null
+
+        # The completion box, while it is still up. Found rather than waited out:
+        # a fixed sleep would be a guess in both directions.
+        $script:DoneBox = Find-Ctl -Root $script:Win -NameLike 'DiscWright' -TimeoutSec 120
+        $script:DoneText = ''
+        if ($script:DoneBox) {
+            $kids = $script:DoneBox.FindAll(
+                [System.Windows.Automation.TreeScope]::Descendants,
+                [System.Windows.Automation.Condition]::TrueCondition)
+            for ($i = 0; $i -lt $kids.Count; $i++) {
+                try {
+                    $n = $kids.Item($i).Current.Name
+                    if ($n -and $n -notin @('OK','Cancel') -and $n.Length -gt $script:DoneText.Length) {
+                        $script:DoneText = $n
+                    }
+                } catch {}
+            }
+            $ok = Find-Ctl -Root $script:DoneBox -NameLike 'OK' -TimeoutSec 5
+            if ($ok) { Invoke-Ctl -Ctl $ok -SettleMs 800 }
+        }
+        Start-Sleep -Seconds 1
+        $script:ThawedAdd    = Test-CtlEnabled $script:Win 'Add game*'
+        $script:ThawedOpen   = Test-CtlEnabled $script:Win 'Open existing disc*'
+        $script:ThawedChange = Test-CtlEnabled $script:Win 'Change*'
+        Save-WindowShot $script:Win (Join-Path $script:ShotDir 'after-build.png')
+    }
+    AfterAll { Stop-DiscWright $script:App; $script:App = $null }
+
+    It 'finishes the build and says so' {
+        $script:DoneBox  | Should -Not -BeNullOrEmpty
+        $script:DoneText | Should -Match 'Build complete'
+    }
+
+    It 'writes the ISO where step 6 pointed' {
+        @(Get-ChildItem -Path $script:LockOut -Filter '*.iso').Count | Should -BeGreaterThan 0
+    }
+
+    It 'leaves a disc folder beside it' {
+        Test-Path (Join-Path $script:LockOut 'disc') | Should -BeTrue
+    }
+
+    # There used to be a test here asserting the form was disabled while the
+    # completion box stood. It passed with the lock removed entirely: a modal
+    # box makes UI Automation report every control on its owner as disabled,
+    # so it measured modality and not the lock. The lock is covered in
+    # tests/DiscWright.Tests.ps1 instead, on real controls.
+
+    It 'gives the form back once the box is dismissed' {
+        $script:ThawedAdd  | Should -BeTrue
+        $script:ThawedOpen | Should -BeTrue
+    }
+
+    It 'restores what was enabled rather than enabling everything' {
+        # Set-FormBusy remembers each control's state instead of switching the
+        # form back on wholesale. Change... is greyed with no row selected, and a
+        # build must not be a way to wake it.
+        $script:BeforeChange | Should -BeFalse
+        $script:ThawedChange | Should -BeFalse
     }
 }

--- a/tests/ui/UiDriver.psm1
+++ b/tests/ui/UiDriver.psm1
@@ -114,6 +114,27 @@ function Wait-WinForProcess {
     return $null
 }
 
+function Wait-AnyWinForProcess {
+    <#
+    .SYNOPSIS
+        First top-level window belonging to a process, whatever it is called.
+
+    .DESCRIPTION
+        Wait-WinForProcess only matches DiscWright's own title. The menu preview
+        is an HTA whose window is named after the disc, so it needs a search that
+        does not assume what the window will be called.
+    #>
+    param([int]$ProcessId, [int]$TimeoutSec = 20)
+    $deadline = (Get-Date).AddSeconds($TimeoutSec)
+    while ((Get-Date) -lt $deadline) {
+        foreach ($k in $script:UiEl::RootElement.FindAll($script:UiScope::Children, $script:UiAny)) {
+            try { if ($k.Current.ProcessId -eq $ProcessId) { return $k } } catch {}
+        }
+        Start-Sleep -Milliseconds 300
+    }
+    return $null
+}
+
 function Stop-DiscWright {
     param($App)
     if (-not $App) { return }
@@ -569,7 +590,7 @@ function Clear-AllEntries {
     }
 }
 
-Export-ModuleMember -Function Test-UiAvailable, Start-DiscWright, Stop-DiscWright, Wait-Win, Wait-WinForProcess,
+Export-ModuleMember -Function Test-UiAvailable, Start-DiscWright, Stop-DiscWright, Wait-Win, Wait-WinForProcess, Wait-AnyWinForProcess,
     Find-Ctl, Set-WindowFocus, Invoke-Ctl, Invoke-CtlNamed, Test-CtlEnabled, Set-CtlText,
     Send-Keys, Get-BoxAfter, Get-StatusText, Get-EntryCount, Select-ListRow, Clear-AllEntries,
     Complete-FolderDialog, Complete-FileDialog, Read-MessageBox, Save-WindowShot, ConvertTo-SendKeys, Set-DrivenWindow, Test-DrivingOurWindow,


### PR DESCRIPTION
> Stacked on #36 — the volume label fix. Review that first; this targets it as
> its base and GitHub will retarget to `main` once it merges.

`docs/MANUAL-CHECKS.md` listed four checks on the grounds that the suite
structurally could not reach them. Three of the four turned out to be missing
tests rather than impossible ones, and writing them found a defect on the first
attempt — that is #36.

**348 tests to 394.** The manual list is down to five things a machine cannot do.

## The finished ISO, through Windows instead of 7-Zip

Mounting needs no elevation — measured, not assumed — so a test can build an
image, mount it, and read back what a person actually looks at: the drive letter,
the filesystem, the volume label Windows reports against the one the app
computed, no truncation artefact, the full label in `autorun.inf`, and that the
icon, the menu and the installer named on the disc are really on it.

Skips with the reason if a machine refuses to mount, since that is not a defect
in DiscWright.

## Old project files

Contexts for schema v2 and v3, plus a real `discproject.json` written by 0.4.2
kept in `tests/fixtures/` — so "does an old project still open" stops depending
on what happens to be left on somebody's machine.

`ExtrasEveryDisc`, left behind by the removed disc-sets feature, had **no**
coverage. I said earlier in review that it did; it does not. `Save-Project`
writes a fixed set of keys, so passing `ExtrasEveryDisc` in a settings hashtable
never reached the JSON, and the UI fixture that does so proves nothing. It is now
injected into the file after saving, which is the only way to test it.

## The menu preview

Clicking **Preview menu** and reading the HTA back proves the JavaScript *ran*,
not merely that it parses — an undefined reference throws only when the menu is
opened, and `new Function(src)` never executes.

The detector was derived rather than guessed: a menu deliberately broken with an
undefined reference inside `capFor` puts a `Script Error` child in the HTA window,
and a healthy one does not. The window itself appears either way, so its presence
alone would have proved nothing.

The window title also comes back as `Star Wars™: Empire at War®` — 0.4.3's fix
end to end through the real HTML engine rather than through cscript.

## The form lock

A window test was written first and thrown away. It asserted the form was
disabled while the "Build complete" box stood, **and it passed with
`Set-FormBusy $true` deleted from the app** — a modal box makes UI Automation
report every control on its owner as disabled, so it measured modality, not the
lock. There is a comment where it used to be saying so.

The lock is tested on real WinForms controls instead: the freeze, the log and
progress bar staying live, and the restore giving back what was enabled rather
than switching everything on. The wiring is checked in the syntax tree, including
that the unlock sits inside a `finally` so a failed build cannot leave the form
dead.

## Mutation-checked, not assumed

| Mutation | Fails |
| --- | --- |
| `TrimEnd('_')` reverted | the unit test, and the mounted-volume test reading `THE_WITCHER_ENH_` off the real drive |
| `Set-FormBusy $true` deleted | *locks the form when a build starts* |
| unlock moved out of the `finally` | *unlocks it in a finally* |
| restore switched to enabling everything | *gives back exactly what was enabled before* |

## What stays manual

Menu layout and legibility, Explorer actually drawing the icon and label,
AutoRun firing on a double-click, a real GOG installer installing and Play
finding it, and a burned disc. The rewritten doc ends with a table of what is
covered and where, so nobody re-adds a manual check for something that has one.

Locally: 328 logic, 66 window, 0 failed. PSScriptAnalyzer 0 errors and no new
warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
