### PR TITLE
fix: a renamed game keeps matching on the name GOG registered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ between minor versions.
 
 ### Fixed
 
+- **Renaming a game no longer stops Play finding it.** The entry dialog's *Name on
+  the menu* box has always been free to type in, and the menu searched the GOG
+  registry for whatever was typed - but the registry holds the name GOG registered.
+  Rename *The Witcher: Enhanced Edition* to *The Witcher 1* and Install still
+  worked while Play stayed grey, with nothing on screen saying why. Shortening a
+  title happened to keep working, because the match is a substring test, so the
+  failure only appeared once somebody reworded one. An entry now carries the
+  registered name separately from the name it shows, and only the shown name is
+  editable: the new name still reaches the menu, the disc folder and the label,
+  while the search stays on GOG's. Project files gain a `MatchName` per entry
+  (schema 6); an older file has none and re-detection on open reads it back off
+  the installer, so a project renamed under the previous build repairs itself the
+  first time it is opened.
+
 - **A long disc label no longer ends in a stray underscore in This PC.** The
   ISO9660 volume identifier is 16 characters and everything that is not
   alphanumeric folds to an underscore. The fold was trimmed before truncating

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -197,7 +197,7 @@ function Get-GameInfo([string]$folder) {
     # manual and an Extras folder for the whole disc; an entry that has none of
     # its own falls back to those, which is what keeps a single-game disc, and
     # every project written before this, behaving exactly as it did.
-    $info = @{ Ok=$false; SetupExe=$null; Files=@(); GameName=$null; Msg=''; TotalBytes=0; Folder=$null
+    $info = @{ Ok=$false; SetupExe=$null; Files=@(); GameName=$null; MatchName=$null; Msg=''; TotalBytes=0; Folder=$null
                Warning=''; MissingParts=@(); Kind='Game'; ParentIndex=-1
                ManualPath=$null; ExtrasPath=$null }
     if (-not (Test-Path $folder)) { $info.Msg='Folder not found.'; return $info }
@@ -272,6 +272,14 @@ function Set-InstallerFacts([hashtable]$info,[System.IO.FileInfo]$exe) {
         $name = $name.Trim()
     }
     $info.Ok=$true; $info.SetupExe=$exe; $info.Files=@($exe)+@($bins); $info.GameName=$name
+    # MatchName is the string the menu hands findGame to look for an installed
+    # copy, and it is a second field rather than a reuse of GameName on purpose.
+    # GameName is editable - the entry dialog offers it as 'Name on the menu' -
+    # while the registry holds whatever GOG registered. Sharing one field meant a
+    # rename changed what the menu searched for: rename 'The Witcher: Enhanced
+    # Edition' to 'The Witcher 1' and Install still worked while Play went dead,
+    # with nothing on screen saying why. Set here and never written again.
+    $info.MatchName=$name
     $info.Folder = $exe.DirectoryName
     $info.TotalBytes = ($info.Files | Measure-Object Length -Sum).Sum
     $plural = if ($info.Files.Count -eq 1) { 'file' } else { 'files' }
@@ -306,7 +314,7 @@ function Get-AddOnName([string]$fileName) {
 # comes from the list it is added to, not from its filename. That is what lets a
 # mod or an overhaul, which is never named setup_*, go on the disc at all.
 function Get-AddOnInfo([string]$exePath) {
-    $info = @{ Ok=$false; SetupExe=$null; Files=@(); GameName=$null; Msg=''; TotalBytes=0; Folder=$null
+    $info = @{ Ok=$false; SetupExe=$null; Files=@(); GameName=$null; MatchName=$null; Msg=''; TotalBytes=0; Folder=$null
                Warning=''; MissingParts=@(); Kind='AddOn'; ParentIndex=-1 }
     if (-not (Test-Path $exePath -PathType Leaf)) { $info.Msg='File not found.'; return $info }
     $exe = Get-Item -LiteralPath $exePath
@@ -594,7 +602,12 @@ function Get-MenuGames([array]$entries) {
             $ext = Get-DiscEntryExtras $entries $i
             if ($e.ManualPath) { $man = Join-Path $ext ([IO.Path]::GetFileName([string]$e.ManualPath)) }
         }
-        $out += @{ Name=$e.GameName; MatchName=$e.GameName
+        # The fallback is for an entry out of a project written before version 6,
+        # which had no MatchName. Re-detection from the folder fills it in, so the
+        # fallback only fires when the folder has gone - and then GameName is the
+        # best guess left.
+        $mn = if ($e.MatchName) { [string]$e.MatchName } else { [string]$e.GameName }
+        $out += @{ Name=$e.GameName; MatchName=$mn
                    Setup=(Get-DiscEntrySetup $entries $i); AddOns=@($addOns)
                    Manual=$man; Extras=$ext }
     }
@@ -1506,7 +1519,9 @@ function Save-Project([hashtable]$s,[string]$outDir) {
         # Version 5 adds MediaKey - which disc the set was planned for. Absent in
         # anything older, which reads back as the automatic setting and so builds
         # the single disc those projects always described.
-        Version      = 5
+        # Version 6 adds MatchName per entry. Absent in anything older, where the
+        # name re-detected from the folder on open supplies it.
+        Version      = 6
         AppVersion   = $APP_VERSION
         SavedUtc     = (Get-Date).ToUniversalTime().ToString('s')
         # Version 1 knew about exactly one game and stored it here. Both keys are
@@ -1526,6 +1541,7 @@ function Save-Project([hashtable]$s,[string]$outDir) {
         # GameName is stored because it can be edited, and the edit has to survive.
         Games        = @($games | ForEach-Object {
                             [ordered]@{ Folder=$_.Folder; GameName=$_.GameName
+                                        MatchName=$_.MatchName
                                         Setup=$(if($_.SetupExe){$_.SetupExe.FullName}else{$null})
                                         Kind=$(if($_.Kind -eq 'AddOn'){'AddOn'}else{'Game'})
                                         Parent=[int]$_.ParentIndex
@@ -1564,17 +1580,22 @@ function Import-Project([string]$jsonPath) {
         if ($j.PSObject.Properties.Name -contains 'Games' -and $j.Games) {
             foreach ($g in @($j.Games)) {
                 if (-not $g -or -not $g.Folder) { continue }
-                $kind = 'Game'; $parent = -1; $setup = $null; $nm = $null; $man = $null; $ext = $null
+                $kind = 'Game'; $parent = -1; $setup = $null; $nm = $null; $man = $null; $ext = $null; $mt = $null
                 if ($g.PSObject.Properties.Name -contains 'Kind' -and $g.Kind -eq 'AddOn') { $kind = 'AddOn' }
                 if ($g.PSObject.Properties.Name -contains 'Parent') { $parent = [int]$g.Parent }
                 if ($g.PSObject.Properties.Name -contains 'Setup')  { $setup = [string]$g.Setup }
                 if ($g.PSObject.Properties.Name -contains 'GameName') { $nm = [string]$g.GameName }
+                # Version 6. An older file has none, and $mt stays null - which
+                # leaves the freshly detected name in place, and that name is the
+                # registered one. So an old project renamed under the old code
+                # repairs itself on open, as long as its folder is still there.
+                if ($g.PSObject.Properties.Name -contains 'MatchName') { $mt = [string]$g.MatchName }
                 # Version 4. Absent in anything older, which reads back as an entry
                 # with none of its own - and the menu then falls back to the
                 # disc-wide manual and Extras, exactly as those discs behaved.
                 if ($g.PSObject.Properties.Name -contains 'Manual') { $man = [string]$g.Manual }
                 if ($g.PSObject.Properties.Name -contains 'Extras') { $ext = [string]$g.Extras }
-                $entries += ,@{ Folder=[string]$g.Folder; Kind=$kind; ParentIndex=$parent; Setup=$setup; Name=$nm
+                $entries += ,@{ Folder=[string]$g.Folder; Kind=$kind; ParentIndex=$parent; Setup=$setup; Name=$nm; Match=$mt
                                 Manual=$man; Extras=$ext }
             }
         }
@@ -2594,6 +2615,10 @@ function Set-GameEntries([array]$entries) {
         if ($e.Kind -eq 'AddOn') { $g.Kind = 'AddOn'; $g.ParentIndex = [int]$e.ParentIndex }
         # A name the user edited is theirs, not something to re-derive on open.
         if (-not [string]::IsNullOrWhiteSpace($e.Name)) { $g.GameName = [string]$e.Name }
+        # The match name is NOT taken from the edited name. It is only restored
+        # from the file when the file carried one; otherwise what Get-GameInfo
+        # just read off the installer stands.
+        if (-not [string]::IsNullOrWhiteSpace($e.Match)) { $g.MatchName = [string]$e.Match }
         # Only carried forward if the file is still where it was. A manual that
         # has been moved or deleted since the disc was built must not silently
         # become a menu button pointing at nothing.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,17 +55,20 @@ reading. The name today is the installer's own `ProductName`, which is what GOG 
 in the file rather than what anyone would choose - full of trademark symbols,
 subtitles and edition suffixes, and sometimes just wrong.
 
-The groundwork is already there. An entry carries a display name and a match name
-separately, because the menu needs the registered name to find an installed game and
-should never have been using the caption for that. So a rename can change what is
-shown without touching what is matched - which is the part that would otherwise make
-this risky.
+This turned out to be half built and half broken, so what is left is smaller and
+sharper than the entry above.
 
-What still has to be decided is how far the new name reaches. The disc's folder names
-are built from it (`Games\01 - Hollow Knight`), and so is the volume label on a
-single-game disc. Renaming the menu but not the folders would leave a disc whose two
-halves disagree; renaming both means a rename after a build produces a different disc
-layout from the same games. Neither is obviously right yet.
+The renaming itself has shipped since multi-game discs arrived: the entry dialog's
+**Name on the menu** box edits the name, the project file keeps it, and it already
+reaches the folder on the disc. What was missing is the separation this entry used to
+claim was already there. The menu matched on whatever was typed, so rewording a title
+stopped Play finding the installed copy - `Install` still worked, `Play` stayed grey,
+and nothing on screen said why. A match name that stays GOG's, fixed in 0.4.4, is what
+made the rest of this entry true.
+
+What is genuinely still open is smaller: the rename is only reachable through the entry
+dialog, which is two clicks away and named for something else, and there is no way to
+put a name back to what the installer said.
 
 ## Delivered
 

--- a/docs/MANUAL-CHECKS.md
+++ b/docs/MANUAL-CHECKS.md
@@ -1,6 +1,6 @@
 # Manual checks before a release
 
-The automated suite is 328 logic tests and 66 window tests, and it runs in about
+The automated suite is 344 logic tests and 66 window tests, and it runs in about
 four minutes:
 
 ```
@@ -111,8 +111,11 @@ one run.
 - [ ] If the game registers itself, reopen the menu and click **Play**.
 
 **Should see:** the game launches. Play finds an installed copy through the
-registry keys GOG's installer writes, matched on the game's registered name —
-which is why a game renamed for the menu must still match on its original name.
+registry keys GOG's installer writes, matched on the game's registered name.
+
+> A renamed game matching on its original name is covered by tests now, against
+> the menu's own matcher - so what is left for you here is whether a real
+> install registers itself at all, which no test can arrange.
 
 **Failure looks like:** Install doing nothing (the path on the disc and the path
 in the menu disagree), or Play saying it cannot find the game after a successful
@@ -144,6 +147,8 @@ Do not re-add any of these as a manual check.
 | Menu opens without a runtime script error | *Previewing the menu* |
 | `™` and `®` reach the screen intact | same, and *A game name with characters outside plain ASCII* |
 | Project files from v1, v2, v3 and a real 0.4.2 file | *Project file* |
+| A renamed game still matches on the name GOG registered | *Renaming a game for the menu* |
+| A pre-schema-6 project recovers its match name on open | same |
 | `ExtrasEveryDisc` from the removed disc-sets feature | same |
 | Target disc saved and restored | same, and *Reopening a project that named a target disc* |
 | A build driven from the window, start to ISO on disk | *The form while a real build runs* |

--- a/docs/MANUAL-CHECKS.md
+++ b/docs/MANUAL-CHECKS.md
@@ -104,9 +104,21 @@ Every fixture in the suite is a sparse stub with a GOG-shaped filename. Nothing
 in the repo has ever been a real installer, so nothing automated has ever watched
 one run.
 
+- [ ] Before you install anything, note what is already registered:
+
+```powershell
+.\extras\Show-RegisteredGames.ps1
+```
+
 - [ ] From the mounted disc's menu, click **Install**.
 
 **Should see:** GOG's installer starts and completes against a real download.
+
+- [ ] Run it again.
+
+**Should see:** the game you just installed is now in the list, with `ExeThere`
+true. **That is the whole of this check** - everything the menu does with those
+keys afterwards has a test.
 
 - [ ] If the game registers itself, reopen the menu and click **Play**.
 
@@ -116,6 +128,18 @@ registry keys GOG's installer writes, matched on the game's registered name.
 > A renamed game matching on its original name is covered by tests now, against
 > the menu's own matcher - so what is left for you here is whether a real
 > install registers itself at all, which no test can arrange.
+
+To ask the question the menu asks - would Play find this? - give the helper the
+name the entry matches on:
+
+```powershell
+.\extras\Show-RegisteredGames.ps1 -Match 'Alan Wake'
+```
+
+It runs the menu's own `nameHit`, lifted out of `DiscWright.ps1` and executed
+under cscript, so its answer cannot drift from the menu's. Useful for the rename
+case: rename a game to something **reworded** rather than shortened and the two
+names still have to agree.
 
 **Failure looks like:** Install doing nothing (the path on the disc and the path
 in the menu disagree), or Play saying it cannot find the game after a successful

--- a/extras/Show-RegisteredGames.ps1
+++ b/extras/Show-RegisteredGames.ps1
@@ -1,0 +1,140 @@
+<#
+.SYNOPSIS
+    Lists the games GOG has registered on this machine, and optionally answers
+    whether the disc menu's Play button would find one of them.
+
+.DESCRIPTION
+    A helper for check 4 in docs/MANUAL-CHECKS.md - the one thing no test can
+    arrange, which is a real GOG installer registering itself.
+
+    Run it before installing and again afterwards: the game you just installed
+    should appear, with ExeThere true. That is the whole check. Everything the
+    menu does with these keys afterwards is covered by the suite.
+
+    The menu finds an installed copy by reading gameName out of each key under
+    HKLM\SOFTWARE\GOG.com\Games and comparing it to the name the entry carries -
+    the registered name, not the one shown, which is why renaming a game for the
+    menu does not break Play.
+
+    -Match answers that comparison for a name you type. It does not reimplement
+    the comparison: norm and nameHit are lifted out of DiscWright.ps1 and run
+    under cscript, the same engine the .hta uses, so this cannot drift away from
+    what the menu actually does. A copy pasted in here would agree with itself
+    forever and tell you nothing.
+
+    Reads the registry only. Installs nothing, changes nothing, needs no
+    elevation.
+
+.PARAMETER Match
+    A name to test, as the menu would search for it. Adds a Play column saying
+    whether that name finds an installed copy.
+
+.EXAMPLE
+    .\extras\Show-RegisteredGames.ps1
+
+    Everything GOG has registered.
+
+.EXAMPLE
+    .\extras\Show-RegisteredGames.ps1 -Match 'Alan Wake'
+
+    Whether a disc whose entry matches on 'Alan Wake' would light up Play.
+#>
+[CmdletBinding()]
+param([string]$Match)
+
+$ErrorActionPreference = 'Stop'
+
+# Both hives, because a 32-bit installer on a 64-bit machine writes under
+# WOW6432Node and a 64-bit one does not. The menu reads both, in this order.
+$bases = @(
+    'HKLM:\SOFTWARE\WOW6432Node\GOG.com\Games'
+    'HKLM:\SOFTWARE\GOG.com\Games'
+)
+
+$games = @()
+foreach ($base in $bases) {
+    if (-not (Test-Path $base)) { continue }
+    foreach ($key in Get-ChildItem $base -ErrorAction SilentlyContinue) {
+        $p = Get-ItemProperty $key.PSPath -ErrorAction SilentlyContinue
+        if (-not $p -or -not $p.gameName) { continue }
+        # exe is what the menu launches; exeFile beside path is the older shape,
+        # and findGame accepts either. A key whose exe has gone is a game that was
+        # uninstalled without tidying up, and Play would fail on it.
+        $exe = $p.exe
+        if (-not $exe -and $p.path -and $p.exeFile) { $exe = Join-Path $p.path $p.exeFile }
+        $games += [pscustomobject]@{
+            Id        = $key.PSChildName
+            GameName  = [string]$p.gameName
+            ExeThere  = [bool]($exe -and (Test-Path $exe))
+            Path      = [string]$p.path
+        }
+    }
+}
+
+# Sorted once, before anything is emitted or sent to cscript, so the plain
+# listing and the -Match listing come back in the same order.
+$games = @($games | Sort-Object GameName)
+
+if (-not $games) {
+    Write-Warning 'Nothing is registered under HKLM\SOFTWARE\GOG.com\Games. No GOG game is installed on this machine.'
+    return
+}
+
+if (-not $Match) {
+    $games
+    return
+}
+
+# The menu's own matcher, taken out of the app rather than rewritten here.
+$appScript = Join-Path (Split-Path $PSScriptRoot -Parent) 'DiscWright.ps1'
+if (-not (Test-Path $appScript)) { throw "Cannot find DiscWright.ps1 beside this script." }
+
+function Get-JsFunction([string]$text, [string]$name) {
+    $start = $text.IndexOf("function $name(")
+    if ($start -lt 0) { throw "DiscWright.ps1 has no JScript function called $name" }
+    $i = $text.IndexOf('{', $start); $depth = 0
+    for ($j = $i; $j -lt $text.Length; $j++) {
+        if ($text[$j] -eq '{') { $depth++ }
+        elseif ($text[$j] -eq '}') { $depth--; if ($depth -eq 0) { return $text.Substring($start, $j - $start + 1) } }
+    }
+    throw "unbalanced braces in $name"
+}
+
+$cscript = @(
+    "$env:SystemRoot\System32\cscript.exe"
+    (Get-Command cscript.exe -ErrorAction SilentlyContinue | ForEach-Object { $_.Source })
+) | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
+if (-not $cscript) { throw 'cscript.exe not found, so the menu matcher cannot be run.' }
+
+$appText = Get-Content -Raw -LiteralPath $appScript
+
+# One cscript run for the whole list rather than one per game: the names go in on
+# stdin as a JSON array so nothing has to be escaped onto a command line.
+$js = (Get-JsFunction $appText 'norm') + "`r`n" + (Get-JsFunction $appText 'nameHit') + "`r`n" +
+      # Parenthesised: an object literal at the start of a statement is a BLOCK to
+      # this engine, and "match": inside one is a label rather than a key.
+      'var IN = eval("(" + WScript.StdIn.ReadAll() + ")");' + "`r`n" +
+      'for (var i = 0; i < IN.names.length; i++)' + "`r`n" +
+      '  WScript.Echo(nameHit(IN.names[i], IN.match) ? "1" : "0");' + "`r`n"
+
+$tmp   = Join-Path ([IO.Path]::GetTempPath()) ('dwmatch_' + [Guid]::NewGuid().ToString('N').Substring(0,8))
+$jsF   = "$tmp.js"
+$dataF = "$tmp.json"
+try {
+    $payload = @{ match = $Match; names = @($games | ForEach-Object { $_.GameName }) } | ConvertTo-Json -Compress
+    Set-Content -LiteralPath $jsF   -Value $js      -Encoding Ascii
+    # Ascii, so no BOM reaches eval. ConvertTo-Json escapes anything above 7-bit
+    # as \uXXXX, so a name full of trademark symbols survives it intact.
+    Set-Content -LiteralPath $dataF -Value $payload -Encoding Ascii
+    $hits = @(cmd /c "`"$cscript`" //Nologo //E:JScript `"$jsF`" < `"$dataF`"" 2>&1)
+} finally {
+    foreach ($f in @($jsF, $dataF)) { if (Test-Path $f) { Remove-Item $f -Force -ErrorAction SilentlyContinue } }
+}
+
+for ($i = 0; $i -lt $games.Count; $i++) {
+    $hit = ($i -lt $hits.Count) -and ("$($hits[$i])".Trim() -eq '1')
+    $games[$i] | Add-Member -NotePropertyName 'Play' -NotePropertyValue $(
+        if ($hit -and $games[$i].ExeThere) { 'lights up' }
+        elseif ($hit) { 'matches, but its exe has gone' }
+        else { 'stays grey' }) -PassThru
+}

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -658,8 +658,8 @@ Describe 'Project file' -Tag 'Unit' {
 
     Context 'writing' {
 
-        It 'declares schema version 5' {
-            $script:PJson.Version | Should -Be 5
+        It 'declares schema version 6' {
+            $script:PJson.Version | Should -Be 6
         }
 
         It 'records which disc the set was planned for' {
@@ -2952,5 +2952,273 @@ WScript.Echo(out.join(","));
         $out = (cmd /c "`"$script:CScriptFancy`" //Nologo //E:JScript `"$pf`" < `"$bf`"" 2>&1) -join ' '
         $want = ($script:Fancy.ToCharArray() | ForEach-Object { [int]$_ }) -join ','
         $out.Trim() | Should -Be $want
+    }
+}
+
+Describe 'Renaming a game for the menu' -Tag 'Unit' {
+
+    # Show-EntryKindDialog has offered "Name on the menu" since multi-game discs
+    # arrived, and the menu matched on whatever was typed into it. The GOG
+    # registry holds the name GOG registered, so a rename that reworded a title
+    # stopped Play finding the installed copy: Install still worked, Play stayed
+    # grey, and nothing on screen said why.
+    #
+    # Worth writing down because both ROADMAP.md and docs/MANUAL-CHECKS.md
+    # already described the split as though it existed - "a game renamed for the
+    # menu must still match on its original name". It did not. The name shown and
+    # the name matched are two fields now, and these tests are what makes those
+    # documents true.
+
+    BeforeAll {
+        # What GOG's own installer registers for The Witcher, and the string
+        # findGame reads back out of HKLM.
+        $script:RegName = 'The Witcher: Enhanced Edition'
+
+        # Omitting -Match leaves the key off the hashtable entirely, which is how
+        # an entry out of a pre-version-6 project arrives.
+        function New-RenameEntry {
+            param([string]$Shown, [string]$Match, [string]$Setup = 'setup_the_witcher_1.0.exe')
+            $e = @{ GameName=$Shown; Kind='Game'; ParentIndex=-1
+                    ManualPath=$null; ExtrasPath=$null
+                    SetupExe=[pscustomobject]@{ Name=$Setup } }
+            if ($PSBoundParameters.ContainsKey('Match')) { $e.MatchName = $Match }
+            return $e
+        }
+    }
+
+    It 'starts a freshly detected game with both names the same' {
+        $g = Get-GameInfo (New-FixtureGame -Slug 'rename_fresh')
+        $g.Ok        | Should -BeTrue
+        $g.MatchName | Should -Not -BeNullOrEmpty
+        $g.MatchName | Should -Be $g.GameName
+    }
+
+    It 'shows the chosen name and matches the registered one' {
+        $m = (Get-MenuGames @((New-RenameEntry -Shown 'The Witcher 1' -Match $script:RegName)))[0]
+        $m.Name      | Should -Be 'The Witcher 1'
+        $m.MatchName | Should -Be $script:RegName
+    }
+
+    It 'lets the folder on the disc follow the chosen name' {
+        # Deliberate, and the whole point of splitting the fields: the new name is
+        # the user's everywhere a person reads it - menu, folder, label - and only
+        # the string handed to the registry stays GOG's.
+        $entries = @(
+            (New-RenameEntry -Shown 'The Witcher 1' -Match $script:RegName),
+            (New-RenameEntry -Shown 'Hollow Knight' -Match 'Hollow Knight' -Setup 'setup_hk.exe'))
+        Get-DiscEntryFolder $entries 0 | Should -Be 'Games\01 - The Witcher 1'
+    }
+
+    It 'falls back to the shown name when an entry carries no match name' {
+        # A version 5 project whose source folder has since gone: there is no
+        # registered name left anywhere to recover, and the shown name is the best
+        # guess available. This is the old behaviour, kept for exactly that case
+        # and no other.
+        (Get-MenuGames @((New-RenameEntry -Shown 'The Witcher 1')))[0].MatchName |
+            Should -Be 'The Witcher 1'
+    }
+
+    It 'writes the two names into the menu as separate strings' {
+        $hta = Join-Path $script:Sandbox 'rename-menu.hta'
+        New-MenuHta @{
+            GameName = 'The Witcher 1'
+            Games    = @(Get-MenuGames @((New-RenameEntry -Shown 'The Witcher 1' -Match $script:RegName)))
+            Buttons  = @('Play','Install','Exit')
+            MusicFile = ''; ManualFile = ''; PanelSide = 'Right'; IconName = 'disc.ico'
+            WindowBorder = $true; ButtonStyle = 'Minimal'
+        } $hta
+        # The GAMES line only, not the whole file: a failure here should print
+        # one line of JavaScript rather than the entire menu.
+        $games = [regex]::Match((Get-Content -LiteralPath $hta -Raw), '(?m)^\s*var GAMES=(.+?);\s').Groups[1].Value
+        $games | Should -Match 'n:"The Witcher 1"'
+        $games | Should -Match 'm:"The Witcher: Enhanced Edition"'
+    }
+
+    Context 'against the matcher that ships in the menu' {
+
+        # norm and nameHit are lifted out of DiscWright.ps1 and run under cscript,
+        # so what is exercised is the code that reaches the disc rather than a
+        # transcription of it here. A transcription agrees with itself forever.
+
+        BeforeDiscovery {
+            $script:HaveCScriptRename = @(
+                "$env:SystemRoot\System32\cscript.exe"
+                (Get-Command cscript.exe -ErrorAction SilentlyContinue | ForEach-Object { $_.Source })
+            ) | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
+        }
+
+        BeforeAll {
+            $script:CScriptRename = @(
+                "$env:SystemRoot\System32\cscript.exe"
+                (Get-Command cscript.exe -ErrorAction SilentlyContinue | ForEach-Object { $_.Source })
+            ) | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
+
+            function Get-JsFn([string]$text, [string]$name) {
+                $start = $text.IndexOf("function $name(")
+                if ($start -lt 0) { throw "DiscWright.ps1 has no JScript function called $name" }
+                $i = $text.IndexOf('{', $start); $depth = 0
+                for ($j = $i; $j -lt $text.Length; $j++) {
+                    if ($text[$j] -eq '{') { $depth++ }
+                    elseif ($text[$j] -eq '}') { $depth--; if ($depth -eq 0) { return $text.Substring($start, $j - $start + 1) } }
+                }
+                throw "unbalanced braces in $name"
+            }
+            $appText = Get-Content $appScript -Raw
+            $script:MatcherJs = (Get-JsFn $appText 'norm') + "`r`n" + (Get-JsFn $appText 'nameHit') + "`r`n"
+        }
+
+        It 'finds the installed copy by the registered name and not by the new one' -Skip:(-not $script:HaveCScriptRename) {
+            # 1,0 is the whole bug in two numbers. The first is what the menu asks
+            # now; the second is what it used to ask after a rename.
+            $probe = $script:MatcherJs +
+                'var reg = "The Witcher: Enhanced Edition";' + "`r`n" +
+                'WScript.Echo([nameHit(reg, "The Witcher: Enhanced Edition") ? 1 : 0,' + "`r`n" +
+                '              nameHit(reg, "The Witcher 1") ? 1 : 0].join(","));' + "`r`n"
+            $pf = Join-Path $script:Sandbox 'matcher.js'
+            Set-Content -LiteralPath $pf -Value $probe -Encoding Ascii
+            $out = (cmd /c "`"$script:CScriptRename`" //Nologo //E:JScript `"$pf`"" 2>&1) -join ' '
+            $out.Trim() | Should -Be '1,0'
+        }
+
+        It 'still finds a copy when the name was only trimmed' -Skip:(-not $script:HaveCScriptRename) {
+            # nameHit is a substring test in both directions, so shortening a title
+            # always worked and the bug only bit on a reword. Recorded so the
+            # fallback above is not mistaken for the thing that made trimming safe.
+            $probe = $script:MatcherJs +
+                'WScript.Echo(nameHit("The Witcher: Enhanced Edition", "The Witcher") ? 1 : 0);' + "`r`n"
+            $pf = Join-Path $script:Sandbox 'matcher-trim.js'
+            Set-Content -LiteralPath $pf -Value $probe -Encoding Ascii
+            $out = (cmd /c "`"$script:CScriptRename`" //Nologo //E:JScript `"$pf`"" 2>&1) -join ' '
+            $out.Trim() | Should -Be '1'
+        }
+    }
+
+    Context 'through the project file' {
+
+        BeforeAll {
+            $script:RenameOut = Join-Path $script:Sandbox 'renameproj'
+            New-Item -ItemType Directory -Force -Path $script:RenameOut | Out-Null
+            $script:RenameSrc = New-FixtureGame -Slug 'witcher_ee'
+            $g = Get-GameInfo $script:RenameSrc
+            $script:DetectedName = $g.GameName
+            # What Show-EntryKindDialog does when somebody types a new name: it
+            # writes GameName, and nothing else.
+            $g.GameName = 'The Witcher 1'
+            Save-Project (New-BuildSettings -Games @($g) -Label 'The Witcher 1' -OutDir $script:RenameOut) $script:RenameOut
+            $script:RenameJson = Join-Path $script:RenameOut 'discproject.json'
+            $script:RenameRaw  = Get-Content -Raw -LiteralPath $script:RenameJson | ConvertFrom-Json
+        }
+
+        It 'writes schema version 6' {
+            $script:RenameRaw.Version | Should -Be 6
+        }
+
+        It 'stores the registered name beside the chosen one' {
+            $script:RenameRaw.Games[0].GameName  | Should -Be 'The Witcher 1'
+            $script:RenameRaw.Games[0].MatchName | Should -Be $script:DetectedName
+            $script:DetectedName | Should -Not -Be 'The Witcher 1'
+        }
+
+        It 'gives both names back when the project is reopened' {
+            $e = @((Import-Project $script:RenameJson).GameEntries)[0]
+            $e.Name  | Should -Be 'The Witcher 1'
+            $e.Match | Should -Be $script:DetectedName
+        }
+
+        It 'reads a version 5 file as carrying no match name at all' {
+            # Not as carrying the edited one. That difference is what lets the
+            # reopen below tell "never had one" from "has one, use it".
+            $old = Join-Path $script:RenameOut 'v5.json'
+            ((Get-Content -Raw -LiteralPath $script:RenameJson) -replace
+                '"MatchName":\s*"[^"]*",?\s*', '') | Set-Content -LiteralPath $old -Encoding UTF8
+            $e = @((Import-Project $old).GameEntries)[0]
+            $e.Name  | Should -Be 'The Witcher 1'
+            $e.Match | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'a version 5 project that was renamed under the old code' {
+
+        # The repair. A file written before this fix carries no match name, but it
+        # still names the source folder - so re-detection on open reads the
+        # registered name straight off the installer again while the edited name
+        # stays the user's. Nobody has to know the file was ever wrong.
+        #
+        # Set-GameEntries writes to the list and the labels, so those are here as
+        # real controls and stand-ins, the same way 'Recovering from a bad folder
+        # choice' does it further up.
+
+        BeforeAll {
+            Add-Type -AssemblyName System.Windows.Forms
+            $script:lvGames = New-Object System.Windows.Forms.ListView
+            $script:lvGames.View = 'Details'
+            foreach ($c in @('#','Name','Type','Belongs to')) { [void]$script:lvGames.Columns.Add($c,80) }
+            $script:btnGameDel  = New-Object System.Windows.Forms.Button
+            $script:btnAddOn    = New-Object System.Windows.Forms.Button
+            $script:btnGameEdit = New-Object System.Windows.Forms.Button
+            $script:cmbMedia    = New-Object System.Windows.Forms.ComboBox
+            $script:chkXAll     = [pscustomobject]@{ Checked = $false }
+            $script:lblMan      = [pscustomobject]@{ Text = 'Manual file:' }
+            $script:lblEx       = [pscustomobject]@{ Text = 'Extras folder:' }
+            $script:grpX        = [pscustomobject]@{ Text = '5)  Extra content' }
+            $script:lblGame     = [pscustomobject]@{ Text = ''; ForeColor = $null }
+            $script:cbMan       = [pscustomobject]@{ Checked = $false }
+            $script:cbExtra     = [pscustomobject]@{ Checked = $false }
+            $script:chkMusic    = [pscustomobject]@{ Checked = $false }
+            $script:state       = @{ Games=@(); ExtraItems=@(); ManualPath=$null; ExtrasPath=$null; MusicFile=$null }
+
+            $src = New-FixtureGame -Slug 'witcher_v5'
+            $script:V5Detected = (Get-GameInfo $src).GameName
+            # Exactly what Import-Project hands back for a version 5 file: a name
+            # the user edited, and no Match key at all.
+            Set-GameEntries @(@{ Folder=$src; Kind='Game'; ParentIndex=-1; Setup=$null
+                                 Name='The Witcher 1'; Manual=$null; Extras=$null }) | Out-Null
+            $script:V5Entry = @($script:state.Games)[0]
+        }
+
+        It 'keeps the name the user chose' {
+            $script:V5Entry.GameName | Should -Be 'The Witcher 1'
+        }
+
+        It 'recovers the registered name off the installer' {
+            $script:V5Entry.MatchName | Should -Be $script:V5Detected
+            $script:V5Entry.MatchName | Should -Not -Be 'The Witcher 1'
+        }
+
+        It 'hands the menu the recovered name' {
+            (Get-MenuGames @($script:V5Entry))[0].MatchName | Should -Be $script:V5Detected
+        }
+    }
+
+    Context 'wired so a rename cannot reach the match name' {
+
+        BeforeAll {
+            $tree = [System.Management.Automation.Language.Parser]::ParseFile($appScript, [ref]$null, [ref]$null)
+            $assigns = @($tree.FindAll({ param($n)
+                $n -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+                $n.Left -is [System.Management.Automation.Language.MemberExpressionAst] -and
+                "$($n.Left.Member)" -eq 'MatchName' }, $true))
+
+            function Get-EnclosingFunction($node) {
+                $n = $node.Parent
+                while ($n) {
+                    if ($n -is [System.Management.Automation.Language.FunctionDefinitionAst]) { return $n.Name }
+                    $n = $n.Parent
+                }
+                return '<top level>'
+            }
+            $script:MatchWriters = @($assigns | ForEach-Object { Get-EnclosingFunction $_ } | Sort-Object -Unique)
+        }
+
+        It 'is written in exactly the two places that are allowed to write it' {
+            # Set-InstallerFacts reads it off the installer; Set-GameEntries
+            # restores one a project file carried. Anywhere else - and
+            # Show-EntryKindDialog above all - is the bug coming back.
+            $script:MatchWriters | Should -Be @('Set-GameEntries', 'Set-InstallerFacts')
+        }
+
+        It 'is never written by the dialog that renames a game' {
+            $script:MatchWriters | Should -Not -Contain 'Show-EntryKindDialog'
+        }
     }
 }


### PR DESCRIPTION
The entry dialog has offered **Name on the menu** since multi-game discs arrived,
and the menu searched the GOG registry for whatever was typed into it. The registry
holds the name GOG's installer registered — so a rename that reworded a title stopped
Play finding the installed copy. Install still worked, Play stayed grey, and nothing
on screen said why.

## Why it survived this long

`nameHit` is a substring test in both directions, so **trimming** a title always worked
and only a **reword** breaks it. Measured against the matcher itself:

```
registry gameName : The Witcher: Enhanced Edition
  'The Witcher'    -> FOUND
  'The Witcher 1'  -> NOT FOUND -> Play greys out
```

Renaming to something shorter is the common case, which is why nobody hit this.

## What the documents already claimed

Both `ROADMAP.md` and `docs/MANUAL-CHECKS.md` described the split as though it existed:

> …matched on the game's registered name — **which is why a game renamed for the menu
> must still match on its original name.**

It did not. `Get-MenuGames` set `Name` and `MatchName` from the same field and
`Save-Project` stored no match name at all. Both documents are updated, and true now.

## The change

An entry carries `MatchName` beside `GameName`. `Set-InstallerFacts` reads it off the
installer once, `Set-GameEntries` restores one a project file carried, and nothing else
writes it — `Show-EntryKindDialog` least of all, which is the point and has a test of
its own.

The chosen name still reaches the menu, the folder on the disc and the seeded label.
Only the string handed to `findGame` stays GOG's.

## Old projects repair themselves

Project files gain `MatchName` per entry, schema 6. A version 5 file has none, and
`Import-Project` reads that back as **absent** rather than as the edited name — which
is what lets `Set-GameEntries` tell "never had one" from "has one, use it". Absent
means the name just re-detected from the folder stands, and that name is the registered
one. So a project renamed under the old build fixes itself the first time it is opened,
as long as its source folder is still there.

Covered by a test that drives `Set-GameEntries` with exactly what `Import-Project`
hands back for a v5 file.

## Mutation-checked

Sixteen new tests. Every mutation below fails the test that claims to cover it:

| Mutation | Tests that fail |
| --- | --- |
| the menu matching on the shown name again | 3 |
| detection not recording the registered name | 6 |
| `Save-Project` dropping the key | 2 |
| reopening overwriting the match with the edited name | 2 |
| the rename dialog writing `MatchName` | 2 |

Two of the tests run `norm` and `nameHit` under cscript, **lifted out of
`DiscWright.ps1` rather than transcribed**, so what is exercised is the matcher that
reaches the disc. A transcription would agree with itself forever.

## Checked

- 344 logic tests, 0 failed (was 328)
- 66 window tests, 0 failed — CI cannot run these, so they were run locally against
  this commit
- PSScriptAnalyzer: 0 errors, no new warnings
- `DiscWright.ps1` and the test file stay pure ASCII, CRLF, no BOM

What stays manual is unchanged and now smaller: whether a real GOG installer registers
itself at all, which no test can arrange.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
