### PR TITLE
chore(release): 0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Whil
 version stays below 1.0.0, the project file format and the on-disc layout may change
 between minor versions.
 
-## [Unreleased]
+## [0.4.4] — 2026-08-30
 
 ### Fixed
 
@@ -462,7 +462,8 @@ First public release.
 - `extras/DiscLabel.ps1`, a parked printable disc-face generator, kept out of the app to
   keep the tool to one job.
 
-[Unreleased]: https://github.com/lazardjokovic/discwright/compare/v0.4.3...HEAD
+[Unreleased]: https://github.com/lazardjokovic/discwright/compare/v0.4.4...HEAD
+[0.4.4]: https://github.com/lazardjokovic/discwright/compare/v0.4.3...v0.4.4
 [0.4.3]: https://github.com/lazardjokovic/discwright/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/lazardjokovic/discwright/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/lazardjokovic/discwright/compare/v0.4.0...v0.4.1

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -61,7 +61,7 @@ $PROJECT_FILE = 'discproject.json'
 # this cannot quietly drift a release behind. Shown in the title bar and the log,
 # and written into every project file - a bug report that comes with a project
 # file then says for itself which version built the disc.
-$APP_VERSION  = '0.4.3'
+$APP_VERSION  = '0.4.4'
 
 # =================== SMALL HELPERS ===================
 


### PR DESCRIPTION
Two fixes since 0.4.3, both patch-level. Neither changed how a disc looks — both
were cases where it came out looking right and something on it quietly did not work.

## What is in it

**A long disc label no longer ends in a stray underscore in This PC** (#36). The
ISO9660 volume identifier is 16 characters and everything not alphanumeric folds to
an underscore. The fold was trimmed before truncating rather than after, so a title
cut mid-word left the separator behind.

**A renamed game keeps matching on the name GOG registered** (#38). The entry
dialog's *Name on the menu* box has been there since multi-game discs, and the menu
searched the GOG registry for whatever was typed into it — but the registry holds the
name GOG's installer registered. Rewording a title left Install working and Play grey
with nothing on screen saying why. Shortening one happened to keep working, the match
being a substring test in both directions, which is why it went unseen this long.
An entry now carries `MatchName` beside `GameName`; project files go to schema 6, and
a project renamed under the previous build repairs itself the first time it is opened.

Also merged since 0.4.3: #37, which automated the parts of the manual checklist a
machine can actually arrange, and `extras/Show-RegisteredGames.ps1` for the part it
cannot.

## The release commit

`$APP_VERSION` to `0.4.4`, `[Unreleased]` stamped as `0.4.4 — 2026-08-30`, and the
compare rows extended. No code changes.

## Checked

- 344 logic tests, 0 failed
- No test hardcodes the version — both the logic suite and the window suite read
  `$APP_VERSION` out of the source
- `DiscWright.ps1` stays pure ASCII, CRLF, no BOM

The window suite was last run green against the fix commit on #38; it refuses to run
while the desktop is in use, and this commit touches only the version string and the
changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
