### PR TITLE
feat: file a game's add-ons under the game, not beside it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ between minor versions.
 
 ## [Unreleased]
 
+### Changed
+
+- **A game's add-ons are filed under the game on the disc, not beside it.** Every
+  entry used to get its own numbered folder, so two games carrying three patches
+  each came out as eight top-level folders with nothing saying what belonged to
+  what - while the menu, which has always shown an add-on as a second Install
+  button on its game's screen, knew perfectly well. An add-on now lives in
+  `Add-ons\` inside its game's folder, the way that game's manual and extras
+  already do. Two consequences worth knowing before you build: the folder numbers
+  count games rather than entries, so they no longer skip every time a game
+  carries a patch; and a game with add-ons but no second game is still one game,
+  so it keeps the flat disc a single-game build has always produced, with
+  `Add-ons\` beside the installer instead of a `Games\` tree wrapped around one
+  folder. An add-on whose game is removed is still promoted to a game of its own,
+  and moves back out to the top level with it.
+
 ### Fixed
 
 - **Rebuilding a disc you opened no longer deletes the installers.** *Open existing

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -534,7 +534,7 @@ function Get-DiscIconName([string]$label) {
 # discs built before the icon was named after the game.
 function Test-ReservedDiscName([string]$name,[string]$iconName='disc.ico') {
     if ($name -like 'setup_*') { return $true }
-    return (@('autorun.inf','disc.ico',$iconName,'AUTORUN','Extras','Games',$PROJECT_FILE) -contains $name)
+    return (@('autorun.inf','disc.ico',$iconName,'AUTORUN','Extras','Games','Add-ons',$PROJECT_FILE) -contains $name)
 }
 
 # Folder name for one game on a multi-game disc. Numbered, so the order in the
@@ -549,6 +549,37 @@ function Get-GameFolderName([int]$index,[string]$name) {
     return ('{0:D2} - {1}' -f $index, $n)
 }
 
+# The parent of an add-on, as an index into the same list, or -1 for an entry
+# the menu treats as a game in its own right.
+#
+# An entry marked AddOn whose parent is missing, points at itself, or points at
+# another add-on is promoted rather than dropped: a disc that shows an
+# unexpected entry is recoverable, one that silently omits an installer the
+# user paid for and burned is not.
+#
+# The menu and the disc layout both ask this, and they MUST get the same
+# answer. A promoted add-on takes a top-level folder AND a top-level place in
+# the chooser, or it takes neither. The rule was written out twice before, once
+# in each, which is exactly the arrangement that drifts.
+function Get-EntryParentIndex([array]$entries,[int]$index) {
+    $e = $entries[$index]
+    if ($e.Kind -ne 'AddOn') { return -1 }
+    $p = [int]$e.ParentIndex
+    if ($p -lt 0 -or $p -ge $entries.Count -or $p -eq $index) { return -1 }
+    if ($entries[$p].Kind -eq 'AddOn') { return -1 }
+    return $p
+}
+
+# The entries the menu shows as games, in menu order, as indices into the list.
+# This is what the folder numbering counts - see Get-DiscEntryFolder.
+function Get-DiscGameIndexes([array]$entries) {
+    $out = @()
+    for ($i = 0; $i -lt @($entries).Count; $i++) {
+        if ((Get-EntryParentIndex $entries $i) -lt 0) { $out += $i }
+    }
+    return ,@($out)
+}
+
 # Where an entry's installer sits on the finished disc, relative to the disc root.
 # Empty string means the disc root itself.
 #
@@ -558,14 +589,52 @@ function Get-GameFolderName([int]$index,[string]$name) {
 # points at another, and the disc burns with an Install button greyed out for a
 # reason nothing on screen explains. One function now, called by both.
 #
-# A disc with a single entry keeps the original flat layout, installer at the
-# root, exactly as every disc built before multi-game existed. Two or more and
-# every entry moves into Games\, add-ons included: their .bin parts are named
-# after their own installer, but a flat root full of a dozen setup files is
-# unreadable, and the numbering is what makes the disc browsable by hand.
+# A disc with a single game keeps the original flat layout, installer at the
+# root, exactly as every disc built before multi-game existed. Two or more games
+# and each one moves into a numbered folder under Games\: a flat root holding a
+# dozen setup files is unreadable, and the numbering is what makes the disc
+# browsable by hand.
+#
+# An add-on goes inside the folder of the game it belongs to, the way that
+# game's manual and extras already do. It used to take a top-level number of its
+# own, so two games carrying three patches each came out as eight sibling
+# folders with nothing saying what belonged to what - while the menu, which has
+# always shown an add-on as a second Install button on its game's screen, knew
+# perfectly well. The disc layout was the last place they still looked
+# unrelated.
+#
+# Two consequences, both chosen rather than fallen into. The numbers count GAMES
+# now, not entries, so they no longer skip every time a game carries a patch.
+# And a game with add-ons but no second game is still one game, so it keeps the
+# flat root that a single-game build has always produced - Add-ons\ beside the
+# installer, rather than a Games\ tree wrapped around one folder.
 function Get-DiscEntryFolder([array]$entries,[int]$index) {
-    if ($entries.Count -le 1) { return '' }
-    return (Join-Path 'Games' (Get-GameFolderName ($index+1) $entries[$index].GameName))
+    $parent = Get-EntryParentIndex $entries $index
+
+    if ($parent -lt 0) {
+        $games = Get-DiscGameIndexes $entries
+        if ($games.Count -le 1) { return '' }
+        $n = [array]::IndexOf($games, $index) + 1
+        return (Join-Path 'Games' (Get-GameFolderName $n $entries[$index].GameName))
+    }
+
+    # Numbered within the game that owns it, by the same rule the games use, so
+    # a stack of patches reads in the order the menu lists them for anyone
+    # working through the disc by hand. Counted here rather than taken from
+    # Get-EntryAddOns, which answers a different question - what Remove would
+    # take along with the parent - and counts entries the menu has promoted away.
+    $n = 0
+    for ($j = 0; $j -lt $entries.Count; $j++) {
+        if ((Get-EntryParentIndex $entries $j) -ne $parent) { continue }
+        $n++
+        if ($j -eq $index) { break }
+    }
+
+    # Join-Path refuses an empty first argument, and empty is exactly what the
+    # parent returns on a one-game disc.
+    $base  = Get-DiscEntryFolder $entries $parent
+    $under = if ($base) { Join-Path $base 'Add-ons' } else { 'Add-ons' }
+    return (Join-Path $under (Get-GameFolderName $n $entries[$index].GameName))
 }
 
 function Get-DiscEntrySetup([array]$entries,[int]$index) {
@@ -577,8 +646,9 @@ function Get-DiscEntrySetup([array]$entries,[int]$index) {
 
 # Where an entry's own manual and extras live on the disc. Beside its installer,
 # so a game and everything belonging to it sit together and can be found by hand
-# without the menu. A disc holding one entry keeps the flat Extras\ at the root,
-# which is where every disc built before this put them.
+# without the menu - which for an add-on now means inside the add-on's own
+# folder, under the game. A disc holding one game keeps the flat Extras\ at the
+# root, which is where every disc built before this put them.
 function Get-DiscEntryExtras([array]$entries,[int]$index) {
     $rel = Get-DiscEntryFolder $entries $index
     if ([string]::IsNullOrEmpty($rel)) { return 'Extras' }
@@ -586,24 +656,18 @@ function Get-DiscEntryExtras([array]$entries,[int]$index) {
 }
 
 # The menu's view of the disc: games in order, each carrying the add-ons that
-# point at it. An add-on whose parent is missing, or which points at another
-# add-on, is promoted to a game of its own rather than dropped - a disc that
-# shows an unexpected entry is recoverable, one that silently omits an installer
-# the user paid for and burned is not.
+# point at it. Which is which is Get-EntryParentIndex's decision rather than
+# this loop's, because Get-DiscEntryFolder asks it the same question when it
+# decides where on the disc the files land.
 function Get-MenuGames([array]$entries) {
     $out = @()
     for ($i = 0; $i -lt $entries.Count; $i++) {
         $e = $entries[$i]
-        $p = [int]$e.ParentIndex
-        $isAddOn = ($e.Kind -eq 'AddOn') -and $p -ge 0 -and $p -lt $entries.Count -and
-                   $p -ne $i -and $entries[$p].Kind -ne 'AddOn'
-        if ($isAddOn) { continue }
+        if ((Get-EntryParentIndex $entries $i) -ge 0) { continue }
         $addOns = @()
         for ($j = 0; $j -lt $entries.Count; $j++) {
-            $a = $entries[$j]
-            if ($j -eq $i -or $a.Kind -ne 'AddOn') { continue }
-            if ([int]$a.ParentIndex -ne $i) { continue }
-            $addOns += @{ Name=$a.GameName; Setup=(Get-DiscEntrySetup $entries $j) }
+            if ((Get-EntryParentIndex $entries $j) -ne $i) { continue }
+            $addOns += @{ Name=$entries[$j].GameName; Setup=(Get-DiscEntrySetup $entries $j) }
         }
         # An entry's own manual and extras, as paths on the finished disc. Empty
         # means it has none of its own and the menu should fall back to the
@@ -1722,8 +1786,9 @@ function Invoke-Build([hashtable]$s, [scriptblock]$log, [scriptblock]$progress=$
 
     $games = @($s.Games)
     # Rebuilding a disc folder in place: the payload already lives in the stage,
-    # so do NOT wipe it. Only ever true for a single game - several games live in
-    # Games\ subfolders, so their source folder is never the stage itself.
+    # so do NOT wipe it. One ENTRY, deliberately, not one game: a game carrying
+    # add-ons keeps the disc root for itself, but its add-ons still have to be
+    # copied into Add-ons\ and this branch is the one that copies nothing.
     $inPlace = ($games.Count -eq 1) -and (Test-SamePath $games[0].Folder $stage)
 
     if ($inPlace) {
@@ -3577,8 +3642,9 @@ $btnBuild.Add_Click({
     # named by THIS label, and the staging folder. A differently named ISO sitting
     # in the same folder is not touched and must not be described as if it were.
     if ($isoExists -or $stageExists) {
-        # Rebuilding in place only applies to a single game whose folder IS the
-        # stage. Several games always live in Games\ subfolders, never at the root.
+        # Rebuilding in place only applies to a disc of ONE entry whose folder IS
+        # the stage - the same test Invoke-Build makes, and for the same reason:
+        # anything else has files to copy in.
         $bGames  = Get-Games
         $inPlace = ($bGames.Count -eq 1) -and (Test-SamePath $bGames[0].Folder $stage)
         $isoName = if ($isoPath) { Split-Path $isoPath -Leaf } else { 'the ISO' }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,40 +15,6 @@ feature only creates pressure to cram things in to justify it.
 
 ## Next
 
-**File a game's add-ons under the game, not beside it.** Requested by someone building a
-multi-game disc. On the disc today every entry gets its own numbered folder, so a game
-and its DLC sit as siblings:
-
-```
-Games\01 - Hollow Knight\
-Games\02 - Update 1.5.12459\
-Games\03 - Update 1.5.12618\
-Games\04 - Ori and the Blind Forest\
-```
-
-With two games carrying three patches each that is eight top-level folders and nothing
-saying what belongs to what. The menu already knows - an add-on shows as a second Install
-button on its game's screen, never in the chooser - so the disc layout is the only place
-they still look unrelated.
-
-The shape would be the game's own folder holding them, the way its manual and extras
-already are:
-
-```
-Games\01 - Hollow Knight\
-Games\01 - Hollow Knight\Add-ons\Update 1.5.12459\
-Games\02 - Ori and the Blind Forest\
-```
-
-Two things to settle first. **An orphan needs somewhere to go** - remove a game and its
-add-ons become entries in their own right, in the menu and so on the disc, which means
-moving back out to the top level. And **the numbering is the menu order**, so grouping
-changes what the numbers count; whether add-ons keep numbers of their own inside the
-folder or just use their names is a real choice rather than a detail.
-
-Small, and worth doing. It changes where files land on a disc, so it wants its own
-release note rather than riding along with something else.
-
 **Let a game be renamed for the menu.** Asked for by the same person who found the
 question marks, once the characters were arriving intact and the name was worth
 reading. The name today is the installer's own `ProductName`, which is what GOG put
@@ -56,7 +22,7 @@ in the file rather than what anyone would choose - full of trademark symbols,
 subtitles and edition suffixes, and sometimes just wrong.
 
 This turned out to be half built and half broken, so what is left is smaller and
-sharper than the entry above.
+sharper than it first looked.
 
 The renaming itself has shipped since multi-game discs arrived: the entry dialog's
 **Name on the menu** box edits the name, the project file keeps it, and it already
@@ -71,6 +37,20 @@ dialog, which is two clicks away and named for something else, and there is no w
 put a name back to what the installer said.
 
 ## Delivered
+
+**A game's add-ons filed under the game** — asked for by someone building a
+multi-game disc; merged, and in the next release. Every entry used to take its own
+numbered folder, so a game and its DLC sat as siblings and eight top-level folders
+said nothing about what belonged to what. An add-on now lives in `Add-ons\` inside
+its game's folder, beside the manual and extras that were already filed there.
+
+The two things this entry said had to be settled first were settled. Add-ons keep
+numbers of their own inside the folder, because the number is the menu order and
+that is the install order for a stack of patches. And an orphan — an add-on whose
+game was removed — was already promoted to a game of its own by the menu; the disc
+layout now asks the menu's own function which entries are games, so a promoted
+add-on moves back out to the top level in both at once rather than in one and not
+the other.
 
 **More than one installer on a disc** — shipped in 0.3.0, and the most-asked-for thing
 on this page: three separate requests, more than anything else. Several games on one disc

--- a/docs/MANUAL-CHECKS.md
+++ b/docs/MANUAL-CHECKS.md
@@ -1,6 +1,6 @@
 # Manual checks before a release
 
-The automated suite is 356 logic tests and 66 window tests, and it runs in about
+The automated suite is 374 logic tests and 66 window tests, and it runs in about
 four minutes:
 
 ```
@@ -178,6 +178,10 @@ Do not re-add any of these as a manual check.
 | Rebuilding a disc whose own folder holds the installers | *Rebuilding a disc folder that the installers themselves live in* |
 | Assets and extra content picked from inside that folder | same, and *Rebuilding over a disc that is already there* |
 | A second build straight after the first still works | same |
+| Add-ons land inside their game's folder on a real staged disc | *Building a two-game disc that has add-ons on it* |
+| Folder numbers count games, and add-ons renumber inside each | *Filing an add-on under the game it belongs to* |
+| A single game keeps the flat disc root, add-ons beside it | same |
+| A promoted orphan moves back out to the top level | same |
 | A build driven from the window, start to ISO on disk | *The form while a real build runs* |
 | The form locks during a build and restores what was enabled | *Locking the form while a build runs* |
 

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -1328,6 +1328,67 @@ Describe 'The finished ISO as Windows itself reads it' -Tag 'Build' -Skip:(-not 
     }
 }
 
+Describe 'Building a two-game disc that has add-ons on it' {
+
+    BeforeAll {
+        # Two games, two patches on the first and one on the second - the shape
+        # from the roadmap, staged for real so the assertions are about folders
+        # that exist rather than about strings a function returned.
+        $script:GrpA  = Get-GameInfo (New-FixtureGame -Slug 'grp_a' -Parts 1)
+        $script:GrpA1 = Get-GameInfo (New-FixtureGame -Slug 'grp_a_patch1')
+        $script:GrpA2 = Get-GameInfo (New-FixtureGame -Slug 'grp_a_patch2')
+        $script:GrpB  = Get-GameInfo (New-FixtureGame -Slug 'grp_b')
+        $script:GrpB1 = Get-GameInfo (New-FixtureGame -Slug 'grp_b_patch1')
+        $script:GrpA1.Kind = 'AddOn'; $script:GrpA1.ParentIndex = 0
+        $script:GrpA2.Kind = 'AddOn'; $script:GrpA2.ParentIndex = 0
+        $script:GrpB1.Kind = 'AddOn'; $script:GrpB1.ParentIndex = 3
+
+        $script:GrpAll = @($script:GrpA, $script:GrpA1, $script:GrpA2, $script:GrpB, $script:GrpB1)
+
+        $script:GrpOut = Join-Path $script:Sandbox 'out-grouped'
+        New-Item -ItemType Directory -Force -Path $script:GrpOut | Out-Null
+        $null = Invoke-Build (New-BuildSettings -Games $script:GrpAll `
+                    -Label 'Grouped Disc' -OutDir $script:GrpOut) $script:LogSink
+        $script:GrpStage = Join-Path $script:GrpOut 'disc'
+    }
+
+    It 'puts one folder under Games for each game, and nothing else' {
+        # Five installers, two games. Before grouping this folder held five.
+        @(Get-ChildItem (Join-Path $script:GrpStage 'Games') -Directory).Count | Should -Be 2
+    }
+
+    It 'nests each game''s add-ons inside that game, numbered from 01' {
+        $gameA = Join-Path $script:GrpStage (Get-DiscEntryFolder $script:GrpAll 0)
+        $gameB = Join-Path $script:GrpStage (Get-DiscEntryFolder $script:GrpAll 3)
+        @(Get-ChildItem (Join-Path $gameA 'Add-ons') -Directory).Count | Should -Be 2
+        @(Get-ChildItem (Join-Path $gameB 'Add-ons') -Directory).Count | Should -Be 1
+        @(Get-ChildItem (Join-Path $gameA 'Add-ons') -Directory | ForEach-Object { $_.Name }) |
+            ForEach-Object { $_ | Should -Match '^0[12] - ' }
+        (Get-ChildItem (Join-Path $gameB 'Add-ons') -Directory)[0].Name | Should -BeLike '01 - *'
+    }
+
+    It 'writes every installer to the path the menu was given' {
+        # The one that matters on a burned disc. The menu's Install hands the
+        # shell this path; if the staging loop wrote anywhere else, the button
+        # fails and nothing on screen says why.
+        foreach ($g in (Get-MenuGames $script:GrpAll)) {
+            Test-Path (Join-Path $script:GrpStage $g.Setup) | Should -BeTrue -Because "the game's installer must be at $($g.Setup)"
+            foreach ($a in $g.AddOns) {
+                Test-Path (Join-Path $script:GrpStage $a.Setup) | Should -BeTrue -Because "the add-on's installer must be at $($a.Setup)"
+            }
+        }
+    }
+
+    It 'brings a game''s .bin parts along into its own folder' {
+        $gameA = Join-Path $script:GrpStage (Get-DiscEntryFolder $script:GrpAll 0)
+        @(Get-ChildItem $gameA -File -Filter '*.bin').Count | Should -Be 1
+    }
+
+    It 'leaves no installer at the disc root' {
+        @(Get-ChildItem $script:GrpStage -File -Filter 'setup_*').Count | Should -Be 0
+    }
+}
+
 Describe 'Where an entry lands on the disc' {
 
     BeforeAll {
@@ -1353,6 +1414,142 @@ Describe 'Where an entry lands on the disc' {
     It 'builds the setup path from that same folder' {
         $rel = Get-DiscEntrySetup $script:LayoutMany 1
         $rel | Should -Be (Join-Path (Get-DiscEntryFolder $script:LayoutMany 1) $script:LayoutMany[1].SetupExe.Name)
+    }
+}
+
+Describe 'Filing an add-on under the game it belongs to' -Tag 'Unit' {
+
+    BeforeAll {
+        function New-Ent {
+            param([string]$Name, [string]$Kind = 'Game', [int]$Parent = -1)
+            return @{ Ok=$true; GameName=$Name; Kind=$Kind; ParentIndex=$Parent
+                      SetupExe=@{ Name = "setup_$($Name -replace '\W','').exe" } }
+        }
+
+        # The example from the roadmap: two games, patches on each. Under the old
+        # layout this came out as five sibling folders numbered 01 to 05.
+        $script:Grp = @(
+            (New-Ent 'Hollow Knight')
+            (New-Ent 'Update 1.5.12459' 'AddOn' 0)
+            (New-Ent 'Update 1.5.12618' 'AddOn' 0)
+            (New-Ent 'Ori and the Blind Forest')
+            (New-Ent 'Definitive Edition Upgrade' 'AddOn' 3)
+        )
+
+        # One game carrying patches. Still one game, so still a flat disc.
+        $script:GrpOne = @(
+            (New-Ent 'Hollow Knight')
+            (New-Ent 'Update 1.5.12459' 'AddOn' 0)
+            (New-Ent 'Update 1.5.12618' 'AddOn' 0)
+        )
+    }
+
+    It 'puts an add-on inside its game''s folder rather than beside it' {
+        $game  = Get-DiscEntryFolder $script:Grp 0
+        $addOn = Get-DiscEntryFolder $script:Grp 1
+        $game  | Should -Be 'Games\01 - Hollow Knight'
+        $addOn | Should -Be 'Games\01 - Hollow Knight\Add-ons\01 - Update 1.5.12459'
+        # Stated twice on purpose: the string above is what a person reads on the
+        # disc, and this is the property that has to hold for any name at all.
+        $addOn.StartsWith($game + '\Add-ons\') | Should -BeTrue
+    }
+
+    It 'numbers the games by games, so the numbers stop skipping' {
+        # The second game is the fourth entry. Numbering by entry made it 04 and
+        # left 02 and 03 belonging to patches that no longer have a top-level
+        # folder at all - a listing that counts to five and shows two things.
+        Get-DiscEntryFolder $script:Grp 3 | Should -Be 'Games\02 - Ori and the Blind Forest'
+    }
+
+    It 'numbers add-ons within their own game, starting again at 01' {
+        Get-DiscEntryFolder $script:Grp 2 |
+            Should -Be 'Games\01 - Hollow Knight\Add-ons\02 - Update 1.5.12618'
+        Get-DiscEntryFolder $script:Grp 4 |
+            Should -Be 'Games\02 - Ori and the Blind Forest\Add-ons\01 - Definitive Edition Upgrade'
+    }
+
+    It 'keeps the flat root when the disc holds one game and its patches' {
+        # A game with add-ons but no second game is one game. Wrapping a Games\
+        # tree around a single folder buys nothing, and this is the disc every
+        # single-game build has produced since before add-ons existed.
+        Get-DiscEntryFolder $script:GrpOne 0 | Should -Be ''
+        Get-DiscEntryFolder $script:GrpOne 1 | Should -Be 'Add-ons\01 - Update 1.5.12459'
+        Get-DiscEntryFolder $script:GrpOne 2 | Should -Be 'Add-ons\02 - Update 1.5.12618'
+    }
+
+    It 'builds the installer path from wherever the folder turned out to be' {
+        Get-DiscEntrySetup $script:GrpOne 1 |
+            Should -Be 'Add-ons\01 - Update 1.5.12459\setup_Update1512459.exe'
+        Get-DiscEntrySetup $script:Grp 4 | Should -Be (Join-Path (Get-DiscEntryFolder $script:Grp 4) `
+                                                                $script:Grp[4].SetupExe.Name)
+    }
+
+    It 'files an add-on''s own manual and extras inside the add-on''s folder' {
+        Get-DiscEntryExtras $script:Grp 1 |
+            Should -Be 'Games\01 - Hollow Knight\Add-ons\01 - Update 1.5.12459\Extras'
+    }
+
+    It 'leaves a lone game and a pair of plain games exactly where they were' {
+        # The rule that changed is which entries count. For a disc with no add-ons
+        # on it, nothing may move - those discs have been burned already.
+        Get-DiscEntryFolder @( (New-Ent 'Solo') ) 0 | Should -Be ''
+        $two = @( (New-Ent 'One'), (New-Ent 'Two') )
+        Get-DiscEntryFolder $two 0 | Should -Be 'Games\01 - One'
+        Get-DiscEntryFolder $two 1 | Should -Be 'Games\02 - Two'
+    }
+
+    It 'gives an add-on whose game is missing a top-level folder of its own' {
+        # Promotion is the menu's rule for an orphan, and the disc has to follow
+        # it: an entry the chooser lists as a game cannot be buried inside one.
+        $e = @( (New-Ent 'Hollow Knight'), (New-Ent 'Stray Patch' 'AddOn' 7) )
+        Get-DiscEntryFolder $e 1 | Should -Be 'Games\02 - Stray Patch'
+        (Get-MenuGames $e).Count | Should -Be 2
+    }
+
+    It 'promotes an add-on hanging off another add-on, on the disc as in the menu' {
+        $e = @( (New-Ent 'Hollow Knight'), (New-Ent 'Update 1' 'AddOn' 0),
+                (New-Ent 'Patch of a patch' 'AddOn' 1) )
+        Get-DiscEntryFolder $e 2 | Should -Be 'Games\02 - Patch of a patch'
+        Get-DiscEntryFolder $e 1 | Should -Be 'Games\01 - Hollow Knight\Add-ons\01 - Update 1'
+    }
+
+    It 'hands the menu the same paths the layout decided' {
+        # The failure this guards against is silent and only visible on a burned
+        # disc: the files land in one place and the menu's Install points at
+        # another. Every path the menu emits, game and add-on alike, has to be
+        # the one Get-DiscEntrySetup gave for that entry.
+        $fromMenu = @()
+        foreach ($g in (Get-MenuGames $script:Grp)) {
+            $fromMenu += $g.Setup
+            foreach ($a in $g.AddOns) { $fromMenu += $a.Setup }
+        }
+        $fromLayout = @(0..($script:Grp.Count-1) | ForEach-Object { Get-DiscEntrySetup $script:Grp $_ })
+        @($fromMenu | Sort-Object) | Should -Be @($fromLayout | Sort-Object)
+    }
+
+    It 'never lands two entries in the same folder' {
+        $mixed = @(
+            (New-Ent 'A'), (New-Ent 'B' 'AddOn' 0), (New-Ent 'C' 'AddOn' 7)
+            (New-Ent 'D'), (New-Ent 'E' 'AddOn' 3), (New-Ent 'F' 'AddOn' 1) )
+        $folders = @(0..($mixed.Count-1) | ForEach-Object { Get-DiscEntryFolder $mixed $_ })
+        @($folders | Sort-Object -Unique).Count | Should -Be $mixed.Count
+    }
+
+    It 'counts the same entries as games that the menu does' {
+        $mixed = @(
+            (New-Ent 'A'), (New-Ent 'B' 'AddOn' 0), (New-Ent 'C' 'AddOn' 7)
+            (New-Ent 'D'), (New-Ent 'E' 'AddOn' 3), (New-Ent 'F' 'AddOn' 1) )
+        # No @() around the call: Get-DiscGameIndexes returns ,@(...) and
+        # wrapping it rebuilds the single-element array the comma prevents.
+        (Get-DiscGameIndexes $mixed).Count | Should -Be (Get-MenuGames $mixed).Count
+    }
+
+    It 'treats Add-ons as a folder the pipeline made, not as content someone added' {
+        # Reopening a built disc folder lists everything at the root that the
+        # pipeline does not generate as the user's own extra content. Without
+        # this, Add-ons\ on a single-game disc comes back as extra content and
+        # the next build copies the disc into itself.
+        Test-ReservedDiscName 'Add-ons' | Should -BeTrue
     }
 }
 
@@ -1438,8 +1635,13 @@ Describe 'Building a disc that has an add-on on it' {
         $script:AoHta   = Get-Content -Raw (Join-Path $script:AoStage 'AUTORUN\menu.hta')
     }
 
-    It 'stages both installers under Games' {
-        @(Get-ChildItem (Join-Path $script:AoStage 'Games') -Directory).Count | Should -Be 2
+    It 'keeps a single game flat and files its add-on underneath it' {
+        # One game, so the disc keeps the flat root it has always had - there is
+        # no Games\ tree to wrap around one folder. The add-on goes into Add-ons\
+        # beside the installer rather than becoming a second top-level entry.
+        Test-Path (Join-Path $script:AoStage 'Games') | Should -BeFalse
+        Test-Path (Join-Path $script:AoStage $script:AoGame.SetupExe.Name) | Should -BeTrue
+        @(Get-ChildItem (Join-Path $script:AoStage 'Add-ons') -Directory).Count | Should -Be 1
     }
 
     It 'copies the add-on installer too' {
@@ -2217,7 +2419,7 @@ Describe 'A real game with its real patches' -Tag 'Real' -Skip:($script:GogFolde
         }
     }
 
-    It 'finds the game and its patches side by side' -Skip:(-not (@($script:GogFolders | Where-Object { $_ -like '*hollow_knight*' }).Count)) {
+    It 'finds the game and its patches, and files them underneath it' -Skip:(-not (@($script:GogFolders | Where-Object { $_ -like '*hollow_knight*' }).Count)) {
         $game = Get-GameInfo $script:HkDir
         $game.GameName | Should -Be 'Hollow Knight'
 
@@ -2244,9 +2446,15 @@ Describe 'A real game with its real patches' -Tag 'Real' -Skip:($script:GogFolde
         @($names | Sort-Object -Unique).Count | Should -Be $patches.Count
         $names | ForEach-Object { $_ | Should -Not -Be 'Hollow Knight' }
 
-        # And every installer gets its own folder on the disc.
+        # And every installer gets its own folder on the disc, with the patches
+        # filed inside the game instead of beside it. One game, so the game
+        # itself keeps the disc root - real names, real patch count, real
+        # version info, which is the whole reason this block runs off a folder
+        # that GOG wrote rather than off a fixture.
         $folders = @(0..($entries.Count-1) | ForEach-Object { Get-DiscEntryFolder $entries $_ })
         @($folders | Sort-Object -Unique).Count | Should -Be $entries.Count
+        $folders[0] | Should -Be ''
+        $folders[1..($folders.Count-1)] | ForEach-Object { $_ | Should -BeLike 'Add-ons\*' }
     }
 }
 


### PR DESCRIPTION
Every entry took its own numbered folder on the disc, so a game and its DLC sat as
siblings. The menu has always known better — an add-on shows as a second **Install**
button on its game's screen and never in the chooser — so the disc layout was the last
place they still looked unrelated.

## Before and after

```
Games\01 - Hollow Knight\              Games\01 - Hollow Knight\
Games\02 - Update 1.5.12459\             Add-ons\01 - Update 1.5.12459\
Games\03 - Update 1.5.12618\             Add-ons\02 - Update 1.5.12618\
Games\04 - Ori and the Blind Forest\   Games\02 - Ori and the Blind Forest\
Games\05 - Definitive Edition\           Add-ons\01 - Definitive Edition\
```

## The two things the roadmap parked

**Numbering.** The numbers count *games* now rather than entries, so they stop skipping
every time a game carries a patch — the second game above is the fourth entry and is
numbered `02`. Add-ons keep numbers of their own inside the folder, because that number
is the menu order, which is the install order for a stack of patches, and someone
working through the disc by hand has nothing else to go on.

**Where an orphan goes.** It already had an answer that only half the code knew about.
The menu promotes an add-on whose game is missing, or which points at another add-on, to
a game of its own rather than dropping it. That rule lived in `Get-MenuGames`; the layout
used the raw entry index and knew nothing about it. It is now one function, `Get-EntryParentIndex`,
and both ask it — so a promoted add-on takes a top-level folder **and** a top-level place
in the chooser, or it takes neither.

## One rule genuinely changed

The flat disc is decided by one *game* now, not one *entry*. A game with add-ons and no
second game is still one game, so it keeps the flat disc that single-game builds have
always produced — `Add-ons\` beside the installer instead of a `Games\` tree wrapped
around a single folder. **A disc with no add-ons on it does not move at all.**

`Add-ons` also joins the reserved disc names. Without that, reopening a built single-game
disc reads the folder back as content the user added by hand, and the next build copies
the disc into itself.

## Mutation-checked

Eighteen tests. Every mutation below fails the test that claims to cover it:

| Mutation | Tests that fail |
| --- | --- |
| add-ons back to being siblings of their game | 10 |
| game numbers counting entries again | 3 |
| add-on numbering not restarting inside each game | 2 |
| the flat rule counting entries rather than games | 3 |
| an add-on allowed to hang off another add-on | 3 |
| `Add-ons\` at the root reading as content someone added | 1 |

Five of them **stage a real two-game disc and look at the folders that came out**, not at
what a function returned. The Hollow Knight block that runs off a real GOG download
asserts the nesting too.

## Checked

- 362 logic tests, 0 failed (was 344)
- PSScriptAnalyzer: 0 errors, no new warnings
- `DiscWright.ps1` and the test file stay pure ASCII, CRLF, no BOM

The window suite has **not** been run against this — it refuses to start while the
desktop is in use, and it was in use. Worth a run before release, since this touches the
build pipeline the window drives.

## Not in this PR

Probing the in-place rebuild guard next door turned up a separate, pre-existing data-loss
bug, reachable from *Open existing disc…* → add an add-on → **BUILD**. Reported rather
than folded in here; it predates this change and wants its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
