### PR TITLE
fix: a rebuild no longer deletes the installers it is about to copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Whil
 version stays below 1.0.0, the project file format and the on-disc layout may change
 between minor versions.
 
+## [Unreleased]
+
+### Fixed
+
+- **Rebuilding a disc you opened no longer deletes the installers.** *Open existing
+  disc...* leaves a game's folder pointing at `disc\`, which is also where the next
+  build stages. With only that one game on the disc the build knew to leave the
+  files alone - but add anything else, a patch or a second game, and it took the
+  other path: wipe the staging folder, then copy everything in. The wipe went
+  straight through the installers it was about to copy. The build then failed on
+  files that no longer existed, and the download it had been opened on was gone
+  from the disk. The staging folder is now renamed aside rather than deleted, and
+  everything that pointed into it is repointed at the new name - so the files are
+  still there to copy, and the copy is the same instant hardlink pass as always.
+  What is left of the old folder goes only once the ISO has been written: if a
+  build fails now, nothing has been lost, and the log says where it is.
+
 ## [0.4.4] — 2026-08-30
 
 ### Fixed

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -79,6 +79,17 @@ function Test-SubPath([string]$child,[string]$parent) {
     } catch { return $false }
 }
 
+# One path, translated from a folder that has just been renamed into its new
+# name. Returns the path untouched when it never pointed inside that folder, so
+# it can be run over every path a build holds without asking which is which.
+function Get-PathMovedAside([string]$path,[string]$from,[string]$to) {
+    if (-not (Test-SubPath $path $from)) { return $path }
+    $c = [IO.Path]::GetFullPath($path).TrimEnd('\\')
+    $p = [IO.Path]::GetFullPath($from).TrimEnd('\\')
+    if ($c.Length -eq $p.Length) { return $to }
+    return (Join-Path $to $c.Substring($p.Length + 1))
+}
+
 # Files copied off a mounted ISO or any read-only media keep the ReadOnly attribute.
 # Overwriting one later fails - and GDI+ reports that as "a generic error occurred
 # in GDI+" rather than access denied, which is impossible to diagnose from the message.
@@ -1719,48 +1730,63 @@ function Invoke-Build([hashtable]$s, [scriptblock]$log, [scriptblock]$progress=$
         & $log "Rebuilding in place - installer files left untouched."
         New-Item -ItemType Directory -Force -Path $stage,"$stage\AUTORUN" | Out-Null
     } else {
-        # Any asset the user picked from inside the old stage would be destroyed
-        # by the wipe - copy it out to temp first and repoint at the copy.
+        # Everything in the old staging folder is about to go, and the build reads
+        # out of it. An icon or a manual picked from inside it - and, after Open
+        # existing disc..., the game installers themselves, whose folder IS the
+        # stage. Wiping first and copying afterwards was a build that ate its own
+        # source: the installers went, the copy then failed on files that were no
+        # longer there, and what the user had opened was gone from the disk.
+        #
+        # So the folder is renamed rather than removed, and every path pointing
+        # inside it is repointed at the new name. A rename within one volume is
+        # instant however many gigabytes it holds, and the copy back is the same
+        # hardlink pass every other build uses, so nothing is written twice. The
+        # renamed folder goes at the very end, once the ISO exists - if the build
+        # fails, everything that was in it is still on the disk, under a name the
+        # log has already given.
         if (Test-Path $stage) {
-            foreach ($k in @('IconPath','BgPath','MusicFile','ManualPath')) {
-                $p = $s[$k]
-                if ($p -and (Test-Path $p) -and (Test-SubPath $p $stage)) {
-                    if (-not $tmpKeep) { $tmpKeep = Join-Path ([IO.Path]::GetTempPath()) ('discwright_'+[Guid]::NewGuid().ToString('N').Substring(0,8)); New-Item -ItemType Directory -Force -Path $tmpKeep | Out-Null }
-                    $n = Join-Path $tmpKeep ([IO.Path]::GetFileName($p)); Copy-Item -LiteralPath $p -Destination $n -Force
-                    $s[$k] = $n; & $log "  preserved $([IO.Path]::GetFileName($p))"
-                }
-            }
-            if ($s.ExtrasPath -and (Test-Path $s.ExtrasPath) -and (Test-SubPath $s.ExtrasPath $stage)) {
-                if (-not $tmpKeep) { $tmpKeep = Join-Path ([IO.Path]::GetTempPath()) ('discwright_'+[Guid]::NewGuid().ToString('N').Substring(0,8)); New-Item -ItemType Directory -Force -Path $tmpKeep | Out-Null }
-                $ne = Join-Path $tmpKeep 'Extras'; New-Item -ItemType Directory -Force -Path $ne | Out-Null
-                Copy-Item "$($s.ExtrasPath)\*" $ne -Recurse -Force -EA SilentlyContinue
-                $s.ExtrasPath = $ne; & $log "  preserved Extras folder"
-            }
-            $kept = @()
-            foreach ($it in @($s.ExtraItems)) {
-                if ($it -and (Test-Path $it) -and (Test-SubPath $it $stage)) {
-                    if (-not $tmpKeep) { $tmpKeep = Join-Path ([IO.Path]::GetTempPath()) ('discwright_'+[Guid]::NewGuid().ToString('N').Substring(0,8)); New-Item -ItemType Directory -Force -Path $tmpKeep | Out-Null }
-                    $nm = [IO.Path]::GetFileName($it.TrimEnd('\')); $np = Join-Path $tmpKeep $nm
-                    if (Test-Path $it -PathType Container) { New-Item -ItemType Directory -Force -Path $np | Out-Null; Copy-Item "$it\*" $np -Recurse -Force -EA SilentlyContinue }
-                    else { Copy-Item -LiteralPath $it -Destination $np -Force }
-                    $kept += $np; & $log "  preserved $nm"
-                } else { $kept += $it }
-            }
-            $s.ExtraItems = $kept
-        }
-        & $log "Preparing staging folder..."
-        # Mounting the ISO to check it and then rebuilding is the obvious workflow,
-        # and it leaves a handle on the folder. Raw exception text here reads as a
-        # crash; say which folder and what to do about it.
-        if (Test-Path $stage) {
-            try { Remove-Item $stage -Recurse -Force -ErrorAction Stop }
+            $aside = Join-Path $s.OutDir ('disc.previous-' + [Guid]::NewGuid().ToString('N').Substring(0,8))
+            # Mounting the ISO to check it and then rebuilding is the obvious
+            # workflow, and it leaves a handle on the folder. Raw exception text
+            # here reads as a crash; say which folder and what to do about it.
+            try { Rename-Item -LiteralPath $stage -NewName (Split-Path $aside -Leaf) -ErrorAction Stop }
             catch {
                 throw ("The old disc folder cannot be replaced - something is still using it:" +
                        "`r`n`r`n$stage`r`n`r`n" +
                        "Close any Explorer window showing that folder, eject the ISO if you have it mounted, " +
                        "then build again.`r`n`r`nWindows said: $($_.Exception.Message)")
             }
+            $tmpKeep = $aside
+            & $log "Set the old disc folder aside as $(Split-Path $aside -Leaf) - it goes once the ISO is written."
+
+            # Tested before rewriting rather than after: Get-PathMovedAside takes
+            # a [string], so an unset asset arrives as '' and would come back as
+            # '' rather than as the $null it went in as.
+            foreach ($k in @('IconPath','BgPath','MusicFile','ManualPath','ExtrasPath')) {
+                if (-not (Test-SubPath $s[$k] $stage)) { continue }
+                $s[$k] = Get-PathMovedAside $s[$k] $stage $aside
+                & $log "  kept $([IO.Path]::GetFileName($s[$k]))"
+            }
+            $s.ExtraItems = @(@($s.ExtraItems) | ForEach-Object {
+                if ($_) { Get-PathMovedAside $_ $stage $aside } else { $_ } })
+
+            # An entry whose own files were in there is repointed too, and marked
+            # so the copy below can put the interface's record straight once they
+            # have a new home. Without that the game list still names a path in a
+            # folder that is about to be deleted, and the NEXT build fails on a
+            # file nobody moved.
+            foreach ($g in $games) {
+                if (-not (Test-SubPath $g.Folder $stage)) { continue }
+                $g.Folder     = Get-PathMovedAside $g.Folder     $stage $aside
+                $g.ManualPath = Get-PathMovedAside $g.ManualPath $stage $aside
+                $g.ExtrasPath = Get-PathMovedAside $g.ExtrasPath $stage $aside
+                $g.SetupExe   = New-Object System.IO.FileInfo (Get-PathMovedAside $g.SetupExe.FullName $stage $aside)
+                $g.Files      = @(@($g.Files) | ForEach-Object { New-Object System.IO.FileInfo (Get-PathMovedAside $_.FullName $stage $aside) })
+                $g.Restaged   = $true
+                & $log "  kept the installer for $($g.GameName)"
+            }
         }
+        & $log "Preparing staging folder..."
         New-Item -ItemType Directory -Force -Path $stage,"$stage\AUTORUN" | Out-Null
 
         # Where each entry goes is Get-DiscEntryFolder's decision, not this loop's -
@@ -1804,6 +1830,22 @@ function Invoke-Build([hashtable]$s, [scriptblock]$log, [scriptblock]$progress=$
                     Clear-ReadOnly $md; Copy-Item -LiteralPath $g.ManualPath -Destination $md -Force; Clear-ReadOnly $md
                     & $log "    manual for $($g.GameName): $([IO.Path]::GetFileName($g.ManualPath))"
                 }
+            }
+
+            # This entry came out of the folder that was set aside, so the copy
+            # just made is the only one that survives the cleanup at the end.
+            # Point the interface's own record at it, or the list still names a
+            # file that is about to stop existing.
+            if ($g.Restaged) {
+                $g.Folder   = $destDir
+                $g.SetupExe = New-Object System.IO.FileInfo (Join-Path $destDir $g.SetupExe.Name)
+                $g.Files    = @(@($g.Files) | ForEach-Object { New-Object System.IO.FileInfo (Join-Path $destDir $_.Name) })
+                if ($g.ManualPath -or $g.ExtrasPath) {
+                    $gx2 = Join-Path $stage (Get-DiscEntryExtras $games $gi)
+                    if ($g.ManualPath) { $g.ManualPath = Join-Path $gx2 ([IO.Path]::GetFileName($g.ManualPath)) }
+                    if ($g.ExtrasPath) { $g.ExtrasPath = $gx2 }
+                }
+                $g.Remove('Restaged')
             }
         }
     }

--- a/docs/MANUAL-CHECKS.md
+++ b/docs/MANUAL-CHECKS.md
@@ -1,6 +1,6 @@
 # Manual checks before a release
 
-The automated suite is 344 logic tests and 66 window tests, and it runs in about
+The automated suite is 356 logic tests and 66 window tests, and it runs in about
 four minutes:
 
 ```
@@ -175,6 +175,9 @@ Do not re-add any of these as a manual check.
 | A pre-schema-6 project recovers its match name on open | same |
 | `ExtrasEveryDisc` from the removed disc-sets feature | same |
 | Target disc saved and restored | same, and *Reopening a project that named a target disc* |
+| Rebuilding a disc whose own folder holds the installers | *Rebuilding a disc folder that the installers themselves live in* |
+| Assets and extra content picked from inside that folder | same, and *Rebuilding over a disc that is already there* |
+| A second build straight after the first still works | same |
 | A build driven from the window, start to ISO on disk | *The form while a real build runs* |
 | The form locks during a build and restores what was enabled | *Locking the form while a build runs* |
 

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -2250,6 +2250,139 @@ Describe 'A real game with its real patches' -Tag 'Real' -Skip:($script:GogFolde
     }
 }
 
+Describe 'Get-PathMovedAside' -Tag 'Unit' {
+
+    It 'moves the folder itself' {
+        Get-PathMovedAside 'C:\out\disc' 'C:\out\disc' 'C:\out\disc.previous-a1' |
+            Should -Be 'C:\out\disc.previous-a1'
+    }
+
+    It 'moves something inside it and keeps the rest of the path' {
+        Get-PathMovedAside 'C:\out\disc\Games\01 - Game\setup.exe' 'C:\out\disc' 'C:\out\disc.previous-a1' |
+            Should -Be 'C:\out\disc.previous-a1\Games\01 - Game\setup.exe'
+    }
+
+    It 'leaves a path that was never in there alone' {
+        Get-PathMovedAside 'D:\GOG\Hollow Knight\setup.exe' 'C:\out\disc' 'C:\out\disc.previous-a1' |
+            Should -Be 'D:\GOG\Hollow Knight\setup.exe'
+    }
+
+    It 'is not fooled by a folder whose name merely starts the same' {
+        # disc2 is not inside disc, and a prefix test without the separator says
+        # it is - which would repoint a path at a folder that does not exist.
+        Get-PathMovedAside 'C:\out\disc2\setup.exe' 'C:\out\disc' 'C:\out\disc.previous-a1' |
+            Should -Be 'C:\out\disc2\setup.exe'
+    }
+}
+
+Describe 'Rebuilding a disc folder that the installers themselves live in' {
+
+    BeforeAll {
+        # Open existing disc... leaves a game's folder pointing at disc\, which is
+        # also where the next build stages. Add anything else to that disc and the
+        # build takes the wipe-and-restage path - and the wipe used to go straight
+        # through the installers it was about to copy. The game was deleted, the
+        # copy then failed on files that were no longer there, and what the user
+        # had opened was gone.
+        $script:EatOut  = Join-Path $script:Sandbox 'out-opened'
+        $script:EatDisc = Join-Path $script:EatOut 'disc'
+        New-Item -ItemType Directory -Force -Path $script:EatDisc | Out-Null
+
+        $stem = 'setup_theopened_1.0_(90210)'
+        foreach ($n in @("$stem.exe", "$stem-1.bin")) {
+            $fs = [IO.File]::Create((Join-Path $script:EatDisc $n)); $fs.SetLength(2MB); $fs.Close()
+        }
+        # An asset and an extra item picked from inside the folder as well: the
+        # code this replaces rescued those by copying them to temp, and they have
+        # to keep arriving on the disc.
+        $script:EatIcon  = New-FixturePng (Join-Path $script:EatDisc 'cover.png') 256 256
+        $script:EatExtra = Join-Path $script:EatDisc 'readme.txt'
+        Set-Content -LiteralPath $script:EatExtra -Value 'kept' -Encoding Ascii
+
+        $script:EatOpened = Get-GameInfo $script:EatDisc
+        $script:EatSecond = Get-GameInfo (New-FixtureGame -Slug 'opened_second')
+        $script:EatAddOn  = Get-GameInfo (New-FixtureGame -Slug 'opened_patch')
+        $script:EatAddOn.Kind = 'AddOn'; $script:EatAddOn.ParentIndex = 0
+        $script:EatGames = @($script:EatOpened, $script:EatSecond, $script:EatAddOn)
+
+        # What the installer files were called before any of this ran, so a test
+        # can look for them by name wherever they ended up.
+        $script:EatNames = @($script:EatOpened.Files | ForEach-Object { $_.Name })
+
+        $script:EatIso = Invoke-Build @{
+            Games=$script:EatGames; Label='Opened Disc'
+            IconPath=$script:EatIcon; IconIsIco=$false; Menu=$true
+            BgPath=$script:Bg; BgAsIs=$false; PanelSide='Right'
+            Divider=$false; ShowTitle=$false; TitleText=''
+            WindowBorder=$true; ButtonStyle='Minimal'; MusicFile=$null
+            Buttons=@('Install','Exit'); ManualPath=$null; ExtrasPath=$null
+            ExtraItems=@($script:EatExtra); OutDir=$script:EatOut } $script:LogSink
+
+        # And again, the way the window does it: a fresh settings hashtable each
+        # time, holding the same entry objects the list still holds.
+        $script:EatErr2 = $null
+        try {
+            $script:EatIso2 = Invoke-Build @{
+                Games=$script:EatGames; Label='Opened Disc'
+                IconPath=$script:Art; IconIsIco=$false; Menu=$true
+                BgPath=$script:Bg; BgAsIs=$false; PanelSide='Right'
+                Divider=$false; ShowTitle=$false; TitleText=''
+                WindowBorder=$true; ButtonStyle='Minimal'; MusicFile=$null
+                Buttons=@('Install','Exit'); ManualPath=$null; ExtrasPath=$null
+                ExtraItems=@($script:EatExtra); OutDir=$script:EatOut } $script:LogSink
+        } catch { $script:EatErr2 = $_ }
+    }
+
+    It 'does not destroy the installers it is about to copy' {
+        # The one that matters. Before this, the exe and its .bin part were gone
+        # from the disk entirely and the build threw on the way to noticing.
+        foreach ($n in $script:EatNames) {
+            Test-Path (Join-Path $script:EatDisc (Join-Path (Get-DiscEntryFolder $script:EatGames 0) $n)) |
+                Should -BeTrue -Because "$n has to survive the rebuild"
+        }
+    }
+
+    It 'writes the ISO it was asked for' {
+        $script:EatIso | Should -Not -BeNullOrEmpty
+        Test-Path $script:EatIso | Should -BeTrue
+    }
+
+    It 'points the games list at where the files ended up' {
+        # The entry object belongs to the window's own list, so leaving it naming
+        # a path inside a folder that has just been deleted breaks the NEXT build
+        # rather than this one - the worst kind of delay between cause and effect.
+        Test-Path $script:EatOpened.SetupExe.FullName | Should -BeTrue
+        Test-SubPath $script:EatOpened.SetupExe.FullName $script:EatDisc | Should -BeTrue
+        foreach ($f in $script:EatOpened.Files) { Test-Path $f.FullName | Should -BeTrue }
+    }
+
+    It 'builds a second time, straight after the first' {
+        $script:EatErr2 | Should -BeNullOrEmpty
+        Test-Path $script:EatIso2 | Should -BeTrue
+    }
+
+    It 'clears the folder it set aside once the ISO is written' {
+        @(Get-ChildItem $script:EatOut -Directory -Filter 'disc.previous-*').Count | Should -Be 0
+    }
+
+    It 'still lands the icon that was picked from inside the folder' {
+        Test-Path (Join-Path $script:EatDisc (Get-DiscIconName 'Opened Disc')) | Should -BeTrue
+    }
+
+    It 'still lands the extra content that was picked from inside the folder' {
+        # Renaming the folder aside has to preserve everything the copy-to-temp
+        # rescue used to preserve, or this fix trades one kind of loss for another.
+        Test-Path (Join-Path $script:EatDisc 'readme.txt') | Should -BeTrue
+    }
+
+    It 'leaves the other two entries where they always went' {
+        foreach ($i in 1, 2) {
+            Test-Path (Join-Path $script:EatDisc (Get-DiscEntrySetup $script:EatGames $i)) |
+                Should -BeTrue
+        }
+    }
+}
+
 Describe 'The comma-return convention is not undone at the call sites' -Tag 'Unit' {
 
     # Several functions return ,@(...) so that a one-element result survives


### PR DESCRIPTION
**Open existing disc…** leaves a game's folder pointing at `disc\`, which is also where
the next build stages. With only that game on the disc, the build knew to leave the files
alone — the in-place branch. Add anything else, a patch or a second game, and it took the
other path: wipe the staging folder, then copy everything into it. **The wipe went straight
through the installers it was about to copy.**

Measured before the fix, not reasoned about:

```
BEFORE : 2 files in the disc folder
build THREW: ... The path is not of a legal form.
AFTER  : source exe still on disk? False
```

The build failed on files that no longer existed, and the download it had been opened on
was gone from the disk. Three clicks — open a disc, add an add-on, press **BUILD** — and
present on every version that has had more than one installer per disc.

## The fix

The staging folder is **renamed aside instead of deleted**, and every path pointing into
it is repointed at the new name. A rename within one volume is instant however many
gigabytes it holds, and the copy back is the same hardlink pass every build already uses.
Nothing is written twice; the fix costs a rename.

That also **replaces** the copy-to-temp rescue this code did for the icon, background,
music, manual and extra content picked from inside the old folder — one rename covers all
of those and the installers besides, and it covers a 40 GB game, which copying to temp
never could. The existing test for that rescue passes unchanged.

An entry whose files were in there is repointed twice: once at the renamed folder so the
copy can find them, and once at their new home on the disc afterwards. Without the second,
the window's own list still names a path in a folder that is about to be deleted, and it
is the **next** build that fails — the worst possible distance between cause and effect.

The renamed folder is removed only once the ISO has been written. A build that fails now
leaves everything on disk under a name the log has already printed, where it used to leave
nothing at all.

## Mutation-checked

Twelve tests. Every mutation below fails the test that claims to cover it:

| Mutation | Tests that fail |
| --- | --- |
| deleting the old folder again instead of renaming it | 9 |
| not repointing an entry's own files | 8 |
| not putting the games list straight after the copy | 7 |
| not repointing a disc asset picked from inside the folder | 9 |
| not repointing extra content picked from inside the folder | 1 |
| deciding what moved with a prefix test and no separator | 9 |
| leaving the renamed folder on disk after a successful build | 1 |

Four are `Get-PathMovedAside` on its own — including the `disc2` case, where a prefix test
without the separator repoints a path that was never inside the folder. The rest stage two
games and an add-on **for real**, with the first game's folder being the staging folder,
and build the whole thing twice.

## Checked

- 356 logic tests, 0 failed (was 344)
- PSScriptAnalyzer: 0 errors, no new warnings
- Pure ASCII, CRLF, no BOM

The window suite has not been run — it refuses while the desktop is in use.

## Note on ordering

This branches from `main`, not from #40, so the two can merge in either order. They touch
different parts of `Invoke-Build` and different regions of the test file; whichever goes
second wants a trivial rebase (the test-count line in `MANUAL-CHECKS.md` is the one real
overlap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
