### PR TITLE
chore(release): 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Whil
 version stays below 1.0.0, the project file format and the on-disc layout may change
 between minor versions.
 
-## [Unreleased]
+## [0.5.0] — 2026-09-01
 
 ### Changed
 
@@ -495,7 +495,8 @@ First public release.
 - `extras/DiscLabel.ps1`, a parked printable disc-face generator, kept out of the app to
   keep the tool to one job.
 
-[Unreleased]: https://github.com/lazardjokovic/discwright/compare/v0.4.4...HEAD
+[Unreleased]: https://github.com/lazardjokovic/discwright/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/lazardjokovic/discwright/compare/v0.4.4...v0.5.0
 [0.4.4]: https://github.com/lazardjokovic/discwright/compare/v0.4.3...v0.4.4
 [0.4.3]: https://github.com/lazardjokovic/discwright/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/lazardjokovic/discwright/compare/v0.4.1...v0.4.2

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -61,7 +61,7 @@ $PROJECT_FILE = 'discproject.json'
 # this cannot quietly drift a release behind. Shown in the title bar and the log,
 # and written into every project file - a bug report that comes with a project
 # file then says for itself which version built the disc.
-$APP_VERSION  = '0.4.4'
+$APP_VERSION  = '0.5.0'
 
 # =================== SMALL HELPERS ===================
 


### PR DESCRIPTION
A minor rather than a patch bump. The on-disc layout changes, and the changelog
preamble has said since the first release that the layout may change between
minor versions while the tool is below 1.0.0.

Two changes since 0.4.4, both already merged and reviewed:

- **#40** — a game's add-ons are filed under the game on the disc, not beside it.
- **#41** — rebuilding a disc opened with *Open existing disc...* no longer
  deletes the installers it is about to copy.

This PR is the release bookkeeping only: the changelog heading and its link
refs, and `$APP_VERSION`. Same two files the 0.4.4 release commit touched.

Full suite run locally against this tree: **374 logic, 66 window, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)