### PR TITLE
docs: name the game publishers in the README, not just GOG

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,3 +192,5 @@ MIT. See [LICENSE](LICENSE).
 DiscWright is an independent hobby project. It is **not affiliated with, endorsed by, or connected to GOG.com, GOG sp. z o.o., or CD PROJEKT**. "GOG" is their trademark and is used here only to describe what the tool reads.
 
 It works with GOG offline installers because those installers are DRM-free by design — that is GOG's whole proposition, and it is the only reason a tool like this can exist. DiscWright circumvents nothing. Use it with games you own, to make copies for yourself.
+
+Game names, logos and artwork shown in this README are the property of their respective owners, and appear only to demonstrate what the tool does.


### PR DESCRIPTION
The README ends with **Not affiliated with GOG**, which covers GOG and nothing else. But the publishers whose work is actually on the page are never mentioned: the three demo GIFs are Witcher and Hollow Knight artwork, and Alan Wake, Ori and Hollow Knight are named in the prose and in the example disc layouts.

One sentence, the same one the site footer has carried since `3f594dd` on discwright.com:

> Game names, logos and artwork shown in this README are the property of their respective owners, and appear only to demonstrate what the tool does.

Two lines added at the end of the existing disclaimer section. No other change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)