### PR TITLE
docs: the roadmap catches up with 0.5.0, and the README names the site

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ No installation. No dependencies. It is a single PowerShell script.
 
 There is nothing to install. DiscWright is a folder of scripts that runs from wherever you put it.
 
+[**discwright.com**](https://discwright.com) is the same thing with pictures, if you would rather send someone a page than a repo.
+
 1. **Download it.** [Releases](../../releases) for a fixed version, or **Code → Download ZIP** for the latest.
 2. **Unblock the ZIP *before* extracting.** Right-click it → **Properties** → tick **Unblock** → OK. Windows tags everything that came from the internet, and its built-in extractor copies that tag onto every file inside. Clearing it on the ZIP clears the whole folder in one go; skip this and you get a security prompt on every launch, and some setups will refuse to run the script at all.
 3. **Extract it anywhere.** Desktop, Documents, a USB stick. The launchers use relative paths, so there is no fixed install location and nothing to add to PATH.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,11 +38,11 @@ put a name back to what the installer said.
 
 ## Delivered
 
-**A game's add-ons filed under the game** — asked for by someone building a
-multi-game disc; merged, and in the next release. Every entry used to take its own
-numbered folder, so a game and its DLC sat as siblings and eight top-level folders
-said nothing about what belonged to what. An add-on now lives in `Add-ons\` inside
-its game's folder, beside the manual and extras that were already filed there.
+**A game's add-ons filed under the game** — shipped in 0.5.0, asked for by someone
+building a multi-game disc. Every entry used to take its own numbered folder, so a
+game and its DLC sat as siblings and eight top-level folders said nothing about what
+belonged to what. An add-on now lives in `Add-ons\` inside its game's folder, beside
+the manual and extras that were already filed there.
 
 The two things this entry said had to be settled first were settled. Add-ons keep
 numbers of their own inside the folder, because the number is the menu order and
@@ -61,6 +61,11 @@ than with the disc.
 The one thing it does not cover is a mod or an installer from somewhere other than GOG
 being the *game* on a disc. Add-ons accept any `.exe`, but detecting a game still means
 finding a `setup_*.exe` — see *Installers that are not from GOG* under Considering.
+
+**A presentation site** — live at [discwright.com](https://discwright.com). Somewhere
+plainer than a README to read before deciding to run an unsigned script: what a disc
+does when you put it in, what the menu looks like, and where to get it. The README
+stays the technical one.
 
 ## Later
 
@@ -92,8 +97,6 @@ of the installer itself, may be the better trade.
   might justify the complexity. A music player will not.
 - **Menu themes.** The menu is one layout with configurable artwork. Named presets would
   let a disc look like its own era instead of looking like DiscWright.
-- **A presentation site.** Mainly to give people something plainer than a README to read
-  before deciding to run an unsigned script.
 - **PowerShell 7.** The one known blocker is gone: the ISO builder no longer compiles
   with `/unsafe`, so it no longer needs `Add-Type -CompilerParameters`. Whether anything
   else stops it — WinForms, the COM interop, apartment state — has not been tested, and


### PR DESCRIPTION
Three things went stale the moment 0.5.0 shipped.

**The add-ons entry under Delivered still said "merged, and in the next release."** It *is* the release now — `## [0.5.0]` — so it says `shipped in 0.5.0`, matching how the multi-game entry below it reads. The paragraph is reflowed because the first two lines changed length; no wording changed beyond the first sentence.

**"A presentation site" was still under *Considering*,** described as something that might be worth doing. It has been live for days, with a link preview card, canonical URL, robots and a sitemap. Moved to *Delivered* with what it actually turned out to be, and the line about the README staying the technical one, since that is the split that ended up happening.

**Nothing in the repo linked to discwright.com.** The sidebar Website field points there, but no prose did — and the prose is the half people read, the half that gets copied into forum posts, and the half that survives being viewed as a raw file. One line in **Download and run**, where "where do I get this" already lives.

Docs only. No code, no version change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)