### PR TITLE
chore(release): 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Whil
 version stays below 1.0.0, the project file format and the on-disc layout may change
 between minor versions.
 
-## [Unreleased]
+## [0.5.1] — 2026-09-03
 
 ### Added
 
@@ -524,7 +524,8 @@ First public release.
 - `extras/DiscLabel.ps1`, a parked printable disc-face generator, kept out of the app to
   keep the tool to one job.
 
-[Unreleased]: https://github.com/lazardjokovic/discwright/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/lazardjokovic/discwright/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/lazardjokovic/discwright/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/lazardjokovic/discwright/compare/v0.4.4...v0.5.0
 [0.4.4]: https://github.com/lazardjokovic/discwright/compare/v0.4.3...v0.4.4
 [0.4.3]: https://github.com/lazardjokovic/discwright/compare/v0.4.2...v0.4.3

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -61,7 +61,7 @@ $PROJECT_FILE = 'discproject.json'
 # this cannot quietly drift a release behind. Shown in the title bar and the log,
 # and written into every project file - a bug report that comes with a project
 # file then says for itself which version built the disc.
-$APP_VERSION  = '0.5.0'
+$APP_VERSION  = '0.5.1'
 
 # =================== SMALL HELPERS ===================
 


### PR DESCRIPTION
Cuts **0.5.1** — the rename fix from `#45`, which is a bug fix in its own right: on a one-game disc the name on the menu could not be reached at all, and the disc label seeds from that same name.

**Patch, not minor.** The changelog preamble reserves minor bumps below 1.0.0 for the project file format and the on-disc layout changing — 0.5.0 was one because add-ons moved into their game's folder. Nothing here touches either: no schema change, no layout change, nothing to migrate, and a 0.5.0 project opens unchanged.

Two files, the same shape as every release commit before it: the `[Unreleased]` heading stamped as `## [0.5.1] — 2026-09-03` with its link refs chained `v0.5.0...v0.5.1`, and `$APP_VERSION`.

**Tested: 374 logic, 76 window, 0 failed**, run on this commit rather than on `main` — a version bump is exactly the change that can break the window test reading `$APP_VERSION` back out of the running title bar, and that test only exists in the suite that needs a desktop. It passed here; it will report "skipping" on CI, which has no desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)