### PR TITLE
feat(packaging): an installer, so winget has something it will accept

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -177,6 +177,91 @@ jobs:
   #     .\tests\Invoke-Tests.ps1          both suites
   #     Invoke-Pester tests/ui            the window alone
   #
+  # Builds the two things a release is made of: the payload zip, and the Inno
+  # Setup installer that exists so winget has something it will accept.
+  #
+  # It runs on every PR and push, not only on tags, for the same reason
+  # version-matches-tag exists: a packaging file exercised only at release time
+  # is one that breaks at release time, when the tag is already pushed and the
+  # only way out is another tag.
+  #
+  # On a tag it also attaches both files to the release and prints the
+  # installer's SHA256 - the number packaging/winget/New-WingetManifest.ps1
+  # needs, and the one value that cannot be known before the artifact exists.
+  package:
+    runs-on: windows-latest
+    timeout-minutes: 15
+
+    # Read everywhere except the upload, which has to write to the release it is
+    # attaching to. Scoped to this job so the rest of the workflow keeps the
+    # read-only token it has today.
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Inno Setup ships with the windows-latest image (6.7.1 at the time of
+      # writing), so there is nothing to install. If a future image drops it,
+      # this fails loudly here rather than quietly producing a zip alone.
+      - name: Inno Setup must be on the runner
+        shell: powershell
+        run: |
+          $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
+          if (-not (Test-Path $iscc)) {
+              Write-Host "::error::ISCC.exe not found at $iscc - the runner image no longer ships Inno Setup"
+              exit 1
+          }
+          Write-Host "found $iscc"
+
+      - name: Build the zip and the installer
+        id: build
+        shell: powershell
+        run: |
+          $r = .\packaging\Build-Release.ps1 -Installer
+
+          # Step outputs so the upload below does not have to guess at
+          # filenames, and so the hash is readable from the run summary.
+          "version=$($r.Version)"   | Out-File $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "zip=$($r.Zip)"           | Out-File $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "setup=$($r.Setup)"       | Out-File $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "setupsha=$($r.SetupSha)" | Out-File $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+          $tick = [char]0x60
+          $sum  = @(
+              "### DiscWright $($r.Version)"
+              ""
+              "| artifact | sha256 |"
+              "| --- | --- |"
+              "| $tick$(Split-Path $r.Zip -Leaf)$tick | $tick$($r.Sha256)$tick |"
+              "| $tick$(Split-Path $r.Setup -Leaf)$tick | $tick$($r.SetupSha)$tick |"
+          )
+          $sum | Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+
+      # A build nobody can look at proves less than one they can. On a PR this is
+      # how the installer gets tried on a real machine before it ever ships.
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: discwright-package
+          path: build/*.*
+          if-no-files-found: error
+
+      - name: Attach to the release
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: powershell
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ZIP:   ${{ steps.build.outputs.zip }}
+          SETUP: ${{ steps.build.outputs.setup }}
+          SHA:   ${{ steps.build.outputs.setupsha }}
+        run: |
+          # Paths arrive as environment variables rather than being pasted into
+          # the script, for the same reason GITHUB_REF_NAME is read that way in
+          # version-matches-tag below: they stay data instead of becoming code.
+          gh release upload $env:GITHUB_REF_NAME $env:ZIP $env:SETUP --clobber
+          Write-Host "installer sha256: $env:SHA"
+
   # A version constant maintained by hand drifts, because bumping it is a step
   # that gets forgotten. This runs only when a tag is pushed and fails the tag if
   # the app would report a version it is not.

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ discproject.json
 # Pester output
 pester-results.xml
 tests/ui/shots/
+
+# Release artifacts from packaging/Build-Release.ps1 - built on demand and
+# attached to a GitHub release, never committed.
+build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Whil
 version stays below 1.0.0, the project file format and the on-disc layout may change
 between minor versions.
 
+## [Unreleased]
+
+### Added
+
+- **An installer, so DiscWright can be installed with winget.** Releases now carry
+  a `DiscWright-<version>-setup.exe` beside the zip. It installs per-user, so it
+  asks for no administrator and shows no UAC prompt, and it leaves a Start menu
+  entry and a real uninstall behind. The zip is unchanged and is still the way the
+  README tells you to get the app.
+
+  This exists because winget will not accept a folder of scripts: its only route
+  for a plain zip refuses every file type except `.exe` - `.cmd`, `.vbs`, `.ps1`
+  and `.bat` are all rejected by `winget validate` itself, not at run time. What
+  the installer does not do is make DiscWright an executable. The installed app is
+  the same scripts, and its shortcut starts them through `wscript.exe`, so the
+  Microsoft-signed chain that lets the app run under Smart App Control is intact.
+  Only the installer is an `.exe`, run once, and anyone whose machine refuses it
+  still has the zip.
+
 ## [0.5.1] — 2026-09-03
 
 ### Added

--- a/packaging/Build-Release.ps1
+++ b/packaging/Build-Release.ps1
@@ -1,0 +1,122 @@
+<#
+  Build-Release.ps1
+
+  Assembles the files a user actually needs into a folder, then zips it.
+
+  This exists because "Code -> Download ZIP" is not a release artifact. That zip
+  carries tests/, docs/research/ (throwaway harnesses kept as evidence, several
+  megabytes of them) and a versioned root folder, and its URL changes shape
+  between a tag and a branch. winget needs one stable URL whose SHA256 never
+  moves, so the release gets a zip built on purpose instead.
+
+  Output lands in build/ , which .gitignore covers.
+#>
+
+[CmdletBinding()]
+param(
+    # Where to put the staging folder and the zip. Left empty here on purpose:
+    # under Windows PowerShell 5.1 $PSScriptRoot is not populated yet while
+    # parameter defaults are being bound, so a default built from it lands as
+    # an empty string. Resolved in the body instead, where it is set.
+    [string]$OutDir,
+
+    # Also compile the Inno Setup installer. Off by default because ISCC.exe is
+    # not on most machines and the zip is the artifact that matters most; CI
+    # passes this, where Inno Setup ships with the runner image.
+    [switch]$Installer
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repo = Resolve-Path (Join-Path $PSScriptRoot '..')
+if (-not $OutDir) { $OutDir = Join-Path $repo 'build' }
+
+# The version is read out of the app rather than passed in. A number typed on
+# the command line is a number that can disagree with the one the app reports,
+# and CI already fails a tag whose $APP_VERSION does not match it - so the app
+# is the single place this is written down.
+$appPs1 = Join-Path $repo 'DiscWright.ps1'
+$m = [regex]::Match((Get-Content $appPs1 -Raw), '\$APP_VERSION\s*=\s*''([^'']+)''')
+if (-not $m.Success) { throw "No `$APP_VERSION assignment found in $appPs1" }
+$version = $m.Groups[1].Value
+
+# What ships. Deliberately not "everything that is not a test": extras/ and
+# tools/ are standalone helper scripts that the README never mentions and the
+# app never loads, and shipping them invites questions nothing answers.
+$payload = @(
+    'DiscWright.ps1'
+    'DiscWright.ico'
+    'DiscWright.vbs'
+    'Run DiscWright.cmd'
+    'README.md'
+    'LICENSE'
+)
+
+$stage = Join-Path $OutDir "DiscWright-$version"
+$zip   = Join-Path $OutDir "DiscWright-$version.zip"
+
+if (Test-Path $stage) { Remove-Item $stage -Recurse -Force }
+if (Test-Path $zip)   { Remove-Item $zip -Force }
+New-Item -ItemType Directory -Path $stage -Force | Out-Null
+
+foreach ($f in $payload) {
+    $src = Join-Path $repo $f
+    if (-not (Test-Path -LiteralPath $src)) { throw "Missing payload file: $f" }
+    Copy-Item -LiteralPath $src -Destination (Join-Path $stage $f) -Force
+}
+
+# Compress-Archive is in PS 5.1, so this needs nothing installed. The wildcard
+# on the source is what keeps the zip flat-ish: the staging folder's own name
+# becomes the single root folder inside, which is what people expect to extract.
+Compress-Archive -Path $stage -DestinationPath $zip -CompressionLevel Optimal
+
+$sha = (Get-FileHash -Path $zip -Algorithm SHA256).Hash
+
+$setup    = $null
+$setupSha = $null
+
+if ($Installer) {
+    # Inno Setup does not put ISCC.exe on PATH, so look where it installs before
+    # giving up on it.
+    $iscc = Get-Command 'ISCC.exe' -ErrorAction SilentlyContinue |
+            Select-Object -First 1 -ExpandProperty Source
+    if (-not $iscc) {
+        $iscc = @(
+            "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
+            "$env:ProgramFiles\Inno Setup 6\ISCC.exe"
+        ) | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
+    }
+    if (-not $iscc) {
+        throw ("Inno Setup's ISCC.exe was not found. Install Inno Setup 6, or " +
+               "drop -Installer to build the zip alone.")
+    }
+
+    $iss = Join-Path $PSScriptRoot 'DiscWright.iss'
+    # The version is passed in rather than read again inside the .iss, so both
+    # artifacts in one run can only ever carry the same number.
+    & $iscc "/DAppVersion=$version" "/O$OutDir" $iss
+    if ($LASTEXITCODE -ne 0) { throw "ISCC.exe failed with exit code $LASTEXITCODE" }
+
+    $setup = Join-Path $OutDir "DiscWright-$version-setup.exe"
+    if (-not (Test-Path $setup)) { throw "ISCC.exe reported success but $setup is missing" }
+    $setupSha = (Get-FileHash -Path $setup -Algorithm SHA256).Hash
+}
+
+Write-Host "version   $version"
+Write-Host "staged    $stage"
+Write-Host "zip       $zip"
+Write-Host "sha256    $sha"
+if ($setup) {
+    Write-Host "setup     $setup"
+    Write-Host "setupsha  $setupSha"
+}
+
+# Emitted as an object too, so CI can consume it without parsing the text above.
+[pscustomobject]@{
+    Version   = $version
+    Stage     = $stage
+    Zip       = $zip
+    Sha256    = $sha
+    Setup     = $setup
+    SetupSha  = $setupSha
+}

--- a/packaging/DiscWright.iss
+++ b/packaging/DiscWright.iss
@@ -1,0 +1,119 @@
+; DiscWright - Inno Setup script
+;
+; Why there is an installer at all, for an app whose README opens with "there is
+; nothing to install": winget will not take a folder of scripts. Its only route
+; for a plain zip is NestedInstallerType: portable, and that rejects every
+; extension except .exe outright - .cmd, .vbs, .ps1 and .bat are all refused at
+; manifest validation, not at run time. So the choice is an installer or no
+; winget. The zip stays the primary download and nothing about it changes.
+;
+; What this deliberately does NOT do is turn DiscWright into an executable. The
+; installed app is still the same scripts, still started through Microsoft-signed
+; wscript.exe and powershell.exe, which is what lets it run on a Smart App
+; Control machine (see the note at the top of DiscWright.ps1). Only the installer
+; itself is an .exe, run once. Somebody on a locked-down PC who cannot run it
+; still has the zip, working exactly as before.
+;
+; Built by packaging/Build-Release.ps1, which passes the version in:
+;     ISCC.exe /DAppVersion=0.5.1 packaging\DiscWright.iss
+
+#ifndef AppVersion
+  #error AppVersion must be passed in with /DAppVersion=x.y.z
+#endif
+
+#define AppName    "DiscWright"
+#define AppPublisher "Lazar Djokovic"
+#define AppUrl     "https://discwright.com"
+
+[Setup]
+; Never change AppId. It is how Windows and winget recognise an existing
+; install as the same product, so a new one here would leave the old install
+; behind as an orphan that nothing can upgrade or remove.
+AppId={{20F71A81-9D66-445E-BDC3-394B940F190E}
+AppName={#AppName}
+AppVersion={#AppVersion}
+AppVerName={#AppName} {#AppVersion}
+AppPublisher={#AppPublisher}
+AppPublisherURL={#AppUrl}
+AppSupportURL=https://github.com/lazardjokovic/discwright/issues
+AppUpdatesURL=https://github.com/lazardjokovic/discwright/releases
+VersionInfoVersion={#AppVersion}
+
+; Per-user, so installing never shows a UAC prompt and never needs an admin to
+; be standing there. With PrivilegesRequired=lowest, {autopf} resolves to
+; %LOCALAPPDATA%\Programs - a real install location that the user owns.
+;
+; It also sidesteps a question a machine-wide install would raise: DiscWright
+; writes discproject.json into the OUTPUT folder the user picks, never beside
+; itself, so it keeps no state in its install directory either way. Per-user is
+; simply the friendlier of two paths that both work.
+PrivilegesRequired=lowest
+DefaultDirName={autopf}\{#AppName}
+DefaultGroupName={#AppName}
+DisableProgramGroupPage=yes
+; Nothing here needs a decision from the person installing, so the wizard opens
+; on the one page that does: where it goes, and whether they want a desktop icon.
+DisableWelcomePage=yes
+DisableReadyPage=yes
+
+LicenseFile=..\LICENSE
+SetupIconFile=..\DiscWright.ico
+UninstallDisplayIcon={app}\DiscWright.ico
+UninstallDisplayName={#AppName} {#AppVersion}
+
+OutputDir=..\build
+OutputBaseFilename=DiscWright-{#AppVersion}-setup
+Compression=lzma2/max
+SolidCompression=yes
+WizardStyle=modern
+
+; The app is a Windows PowerShell 5.1 WinForms script: no native code, nothing
+; architecture-specific. x64compatible keeps {sys} pointing at the real System32
+; on 64-bit Windows rather than SysWOW64, so the shortcut below starts 64-bit
+; wscript.exe and therefore 64-bit PowerShell.
+ArchitecturesInstallIn64BitMode=x64compatible
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+
+[Files]
+; Source paths are relative to this .iss file, which lives in packaging/.
+Source: "..\DiscWright.ps1";      DestDir: "{app}"; Flags: ignoreversion
+Source: "..\DiscWright.ico";      DestDir: "{app}"; Flags: ignoreversion
+Source: "..\DiscWright.vbs";      DestDir: "{app}"; Flags: ignoreversion
+Source: "..\Run DiscWright.cmd";  DestDir: "{app}"; Flags: ignoreversion
+Source: "..\README.md";           DestDir: "{app}"; Flags: ignoreversion
+Source: "..\LICENSE";             DestDir: "{app}"; Flags: ignoreversion
+
+[Icons]
+; Pointed at the .vbs rather than the .cmd because that is the launcher whose
+; whole job is starting the app without a console window flashing up first, and
+; because wscript.exe -> powershell.exe is the Microsoft-signed chain that keeps
+; this working under Smart App Control. Naming wscript.exe explicitly rather
+; than letting the shell resolve the .vbs association means a machine that has
+; had .vbs re-associated with an editor still launches the app.
+Name: "{group}\{#AppName}"; \
+    Filename: "{sys}\wscript.exe"; \
+    Parameters: """{app}\DiscWright.vbs"""; \
+    WorkingDir: "{app}"; \
+    IconFilename: "{app}\DiscWright.ico"; \
+    Comment: "Turn a GOG installer folder into a burnable game disc"
+
+Name: "{group}\{cm:UninstallProgram,{#AppName}}"; Filename: "{uninstallexe}"
+
+Name: "{autodesktop}\{#AppName}"; \
+    Filename: "{sys}\wscript.exe"; \
+    Parameters: """{app}\DiscWright.vbs"""; \
+    WorkingDir: "{app}"; \
+    IconFilename: "{app}\DiscWright.ico"; \
+    Tasks: desktopicon
+
+[Run]
+Description: "{cm:LaunchProgram,{#AppName}}"; \
+    Filename: "{sys}\wscript.exe"; \
+    Parameters: """{app}\DiscWright.vbs"""; \
+    WorkingDir: "{app}"; \
+    Flags: postinstall nowait skipifsilent

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,83 @@
+# Packaging
+
+DiscWright ships two ways, and the zip is still the main one. Nothing here
+changes how the app runs or how it is downloaded from the README.
+
+| | what it is | who it is for |
+| --- | --- | --- |
+| `DiscWright-<v>.zip` | the six files that matter, in one folder | anyone; unzip and double-click, exactly as before |
+| `DiscWright-<v>-setup.exe` | Inno Setup installer, per-user, no UAC | Start menu entry, clean uninstall, and **winget** |
+
+## Why there is an installer at all
+
+The README opens with "there is nothing to install", and that stays true. The
+installer exists for one reason: **winget will not take a folder of scripts.**
+
+Its only route for a plain zip is `NestedInstallerType: portable`, and that
+rejects every extension except `.exe`. Not at run time - at manifest validation:
+
+```
+> winget validate --manifest .
+Manifest Error: The file type of the referenced file is not allowed.
+                [RelativeFilePath] Value: Run DiscWright.cmd
+```
+
+`.vbs`, `.ps1` and `.bat` are refused the same way
+([winget-cli#3386](https://github.com/microsoft/winget-cli/issues/3386), open).
+So it is an installer or no winget.
+
+What the installer deliberately does **not** do is turn DiscWright into an
+executable. The installed app is still the same scripts, and the Start menu
+shortcut runs `wscript.exe DiscWright.vbs` - the Microsoft-signed chain that
+lets the app work on a Smart App Control machine, as the header of
+`DiscWright.ps1` explains. Only the installer itself is an `.exe`, run once.
+Somebody on a locked-down PC who cannot run it still has the zip.
+
+The install is per-user (`PrivilegesRequired=lowest`), so it never shows a UAC
+prompt and never needs an admin. That is safe because DiscWright keeps no state
+beside itself: `discproject.json` is written into whichever output folder the
+user picks.
+
+## Cutting a release
+
+1. Tag as usual. The `package` job in `.github/workflows/checks.yml` builds both
+   artifacts, attaches them to the release, and prints the installer's SHA256 in
+   the run summary.
+2. Build the manifests with that hash:
+
+   ```powershell
+   .\packaging\winget\New-WingetManifest.ps1 -Version 0.5.2 -Sha256 <hash>
+   ```
+
+3. Check them, on this machine, before they go anywhere:
+
+   ```powershell
+   winget validate --manifest .\build\winget\0.5.2
+   winget install  --manifest .\build\winget\0.5.2   # really installs it
+   winget uninstall DiscWright
+   ```
+
+4. Submit: fork [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs),
+   copy the folder to `manifests\l\LazarDjokovic\DiscWright\<version>\`, open a
+   PR. Their CI runs the install on a clean VM and a human reviews it.
+
+Step 4 is not automated on purpose - it publishes to somebody else's repository,
+and that should be a decision rather than a side effect of pushing a tag.
+
+## First submission
+
+The first PR to `winget-pkgs` claims the publisher folder `LazarDjokovic`, so
+the identifier `LazarDjokovic.DiscWright` is fixed from then on. `AppId` in
+`DiscWright.iss` and `ProductCode` in the generated installer manifest have to
+stay in step with each other forever after, or winget stops recognising an
+installed copy as the same product.
+
+## What is not here
+
+No code signing. An unsigned installer means SmartScreen shows "Windows
+protected your PC" until the download builds reputation, and a Smart App Control
+machine refuses it outright. A certificate is roughly $200-400 a year because OV
+signing now requires a hardware token or cloud HSM. The Microsoft Store is the
+cheaper way out of that - Microsoft signs what it distributes - but the Store
+listing would need screenshots that contain no game artwork, which is a separate
+problem from the one the README disclaimer solves.

--- a/packaging/winget/New-WingetManifest.ps1
+++ b/packaging/winget/New-WingetManifest.ps1
@@ -1,0 +1,145 @@
+<#
+  New-WingetManifest.ps1
+
+  Writes the three YAML files winget wants, filled in for one release.
+
+  They are generated rather than kept in the repo as finished files because two
+  of the values cannot be known until the release exists: the installer's URL and
+  its SHA256. Committing a manifest with a placeholder hash would mean committing
+  one that fails `winget validate`, and a manifest nobody can validate is one
+  nobody checks.
+
+  Usage, after the release is published:
+
+      .\New-WingetManifest.ps1 -Version 0.5.1 -Sha256 <hash of the setup .exe>
+
+  Then, to check it before it goes anywhere near Microsoft's repo:
+
+      winget validate --manifest .\build\winget\0.5.1
+      winget install --manifest .\build\winget\0.5.1   # really installs it
+
+  Submitting is a separate, manual act: fork microsoft/winget-pkgs, copy the
+  folder to manifests\l\LazarDjokovic\DiscWright\<version>\ and open a PR. That
+  is deliberately not automated here - it publishes to somebody else's repo.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$Version,
+
+    # SHA256 of the DiscWright-<version>-setup.exe that is actually attached to
+    # the release. packaging/Build-Release.ps1 -Installer prints it, and so does
+    # the release workflow.
+    [Parameter(Mandatory)][string]$Sha256,
+
+    [string]$OutDir
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $OutDir) {
+    $OutDir = Join-Path (Resolve-Path (Join-Path $PSScriptRoot '..\..')) "build\winget\$Version"
+}
+if (-not (Test-Path $OutDir)) { New-Item -ItemType Directory -Path $OutDir -Force | Out-Null }
+
+$id  = 'LazarDjokovic.DiscWright'
+$url = "https://github.com/lazardjokovic/discwright/releases/download/v$Version/DiscWright-$Version-setup.exe"
+
+# winget wants the hash upper-case and unbracketed.
+$sha = $Sha256.Trim().ToUpper() -replace '[^0-9A-F]',''
+if ($sha.Length -ne 64) { throw "Sha256 does not look like a SHA256: '$Sha256'" }
+
+# ---------------------------------------------------------------- version --
+@"
+# Created for DiscWright $Version - see packaging/winget/New-WingetManifest.ps1
+PackageIdentifier: $id
+PackageVersion: $Version
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0
+"@ | Set-Content -LiteralPath (Join-Path $OutDir "$id.yaml") -Encoding UTF8
+
+# -------------------------------------------------------------- installer --
+#
+# InstallerType is inno, not zip. A zip would have to declare
+# NestedInstallerType: portable, and that refuses every extension except .exe -
+# .cmd, .vbs, .ps1 and .bat are all rejected by `winget validate` itself. The
+# app is scripts, so there is no .exe to point at, and an installer is the only
+# route onto winget that does not mean rewriting the app as a binary.
+#
+# Scope: user matches PrivilegesRequired=lowest in the .iss - it installs under
+# %LOCALAPPDATA%\Programs with no UAC prompt.
+#
+# ProductCode is how winget recognises an existing install for upgrade and
+# uninstall. Inno Setup registers its uninstall entry as "<AppId>_is1", so this
+# has to stay in step with AppId in packaging/DiscWright.iss.
+@"
+# Created for DiscWright $Version - see packaging/winget/New-WingetManifest.ps1
+PackageIdentifier: $id
+PackageVersion: $Version
+InstallerLocale: en-US
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{20F71A81-9D66-445E-BDC3-394B940F190E}_is1'
+Installers:
+- Architecture: neutral
+  InstallerUrl: $url
+  InstallerSha256: $sha
+ManifestType: installer
+ManifestVersion: 1.6.0
+"@ | Set-Content -LiteralPath (Join-Path $OutDir "$id.installer.yaml") -Encoding UTF8
+
+# ----------------------------------------------------------------- locale --
+#
+# ShortDescription is the line the store front and `winget search` show, so it
+# says what the tool does rather than what it is built with.
+@"
+# Created for DiscWright $Version - see packaging/winget/New-WingetManifest.ps1
+PackageIdentifier: $id
+PackageVersion: $Version
+PackageLocale: en-US
+Publisher: Lazar Djokovic
+PublisherUrl: https://github.com/lazardjokovic
+PublisherSupportUrl: https://github.com/lazardjokovic/discwright/issues
+PackageName: DiscWright
+PackageUrl: https://discwright.com
+License: MIT
+LicenseUrl: https://github.com/lazardjokovic/discwright/blob/main/LICENSE
+Copyright: Copyright (c) 2026 lazardjokovic
+ShortDescription: Turn a GOG offline installer into a real game disc, with the game's own icon and title in This PC and a menu when you double-click it.
+Description: |-
+  DiscWright turns a folder of GOG offline installers into a burnable ISO that
+  behaves like a game disc from a box: the drive carries the game's own icon and
+  label in This PC, and double-clicking it opens an autorun menu with Play,
+  Install, Manual and Extras.
+
+  It builds the ISO with the disc imaging support already in Windows, so there
+  is nothing bundled and nothing to trust. More than one game fits on a disc,
+  add-ons live under the game they belong to, and a set too big for one disc can
+  be split across several.
+
+  Burning is out of scope on purpose - DiscWright writes the ISO and leaves
+  burning to the tools that already do it well.
+Moniker: discwright
+Tags:
+- gog
+- iso
+- disc
+- burn
+- games
+- autorun
+- retro
+- backup
+ReleaseNotesUrl: https://github.com/lazardjokovic/discwright/releases/tag/v$Version
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0
+"@ | Set-Content -LiteralPath (Join-Path $OutDir "$id.locale.en-US.yaml") -Encoding UTF8
+
+Write-Host "wrote three manifests to $OutDir"
+Get-ChildItem $OutDir | Select-Object -ExpandProperty Name


### PR DESCRIPTION
## Why

You asked for a winget manifest. Writing one turned up a blocker worth stating plainly: **winget will not accept a folder of scripts.**

Its only route for a plain zip is `NestedInstallerType: portable`, and that refuses every extension except `.exe` — not at run time, at manifest validation:

```
> winget validate --manifest .
Manifest Error: The file type of the referenced file is not allowed.
                [RelativeFilePath] Value: Run DiscWright.cmd
```

I probed the rest: `.exe` accepted; `.vbs`, `.ps1`, `.bat`, `.com`, `.msi` all rejected. ([winget-cli#3386](https://github.com/microsoft/winget-cli/issues/3386), still open.) So it is an installer or no winget.

## What this does not do

It does **not** turn DiscWright into an executable. That would throw away the property the header of `DiscWright.ps1` is proudest of:

> Runs on Smart App Control-locked PCs: launched via signed powershell.exe...

The installed app is still the same scripts, and its Start menu shortcut runs `wscript.exe "DiscWright.vbs"` — the same Microsoft-signed chain. Only the *installer* is an `.exe`, run once. Anyone whose machine refuses it still has the zip, unchanged, and the README still tells everyone to use it.

Per-user install (`PrivilegesRequired=lowest`), so no UAC prompt and no administrator. Safe because the app keeps no state beside itself — `discproject.json` goes to whichever output folder the user picks (`DiscWright.ps1:1644`).

## What is here

| file | what |
| --- | --- |
| `packaging/Build-Release.ps1` | builds the payload zip; `-Installer` also compiles the setup `.exe` |
| `packaging/DiscWright.iss` | Inno Setup script |
| `packaging/winget/New-WingetManifest.ps1` | generates the three manifests |
| `packaging/README.md` | the runbook, and why each choice was made |
| `checks.yml` → `package` job | builds both artifacts on every PR; attaches them on a tag |

The `package` job runs on every PR rather than only on tags, for the same reason `version-matches-tag` exists: a packaging file exercised only at release time breaks at release time, when the tag is already pushed.

## Tested

- Zip builds, contains exactly the six payload files under one root folder
- Generated manifests → **`Manifest validation succeeded`**
- PSScriptAnalyzer: **0 errors** (7 `PSAvoidUsingWriteHost` warnings, already tolerated repo-wide)
- Logic suite: **374/374**
- Window suite: not run — no app code changed

**The `.iss` is not compiled locally** — there is no ISCC on this machine and I would not install one while you were away. The `package` job in this PR is what proves it, and its artifact is a real installer you can download from the run and try.

## Decisions left to you

1. **v0.5.1 has no assets.** The artifacts appear from the *next* tag onward. If you want winget live sooner, the 0.5.1 release can be backfilled — that is a publish, so I have not done it.
2. **Submitting to `microsoft/winget-pkgs` is manual and not automated here** — it publishes to someone else's repo. The first PR also permanently claims the publisher folder `LazarDjokovic`.
3. **README still says "There is nothing to install."** Still true for the zip; worth a sentence once winget actually accepts the package, not before.
4. **No code signing.** SmartScreen will warn until reputation builds, and a Smart App Control machine refuses the installer outright. Roughly $200–400/yr to fix, or the Store, which has its own screenshot problem — noted at the end of `packaging/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)