### PR TITLE
feat: the disc introduces itself on Linux too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Whil
 version stays below 1.0.0, the project file format and the on-disc layout may change
 between minor versions.
 
+## [Unreleased]
+
+### Added
+
+- **The disc knows its own name on Linux.** Every disc now carries a
+  `.xdg-volume-info` file and a `.png` copy of its icon beside the `autorun.inf`
+  and the `.ico` it already had. Insert it in a Linux machine and the drive shows
+  the game's title and cover art instead of a volume id, exactly as it does in
+  This PC. Windows never reads the new files and Linux never read the old ones,
+  so the two sit side by side and nothing about the Windows disc changes.
+
+  The menu does not carry over, and cannot: Linux disabled autorun for removable
+  media on purpose, and no desktop will run a program off an inserted disc. The
+  icon and the label are the half that travels.
+
+  The icon is written twice because `gvfs` hands `IconFile=` to GdkPixbuf, whose
+  `.ico` support is for favicons rather than for the seven-frame icon Explorer
+  wants. Both are built from the same source image, so they cannot disagree.
+
 ## [0.5.1] — 2026-09-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,19 @@ between minor versions.
 
 ### Added
 
-- **The disc knows its own name on Linux.** Every disc now carries a
-  `.xdg-volume-info` file and a `.png` copy of its icon beside the `autorun.inf`
-  and the `.ico` it already had. Insert it in a Linux machine and the drive shows
-  the game's title and cover art instead of a volume id, exactly as it does in
-  This PC. Windows never reads the new files and Linux never read the old ones,
-  so the two sit side by side and nothing about the Windows disc changes.
+- **A disc can know its own name on Linux.** A new checkbox under the icon,
+  **Also name the disc for Linux**, adds a `.xdg-volume-info` file and a `.png`
+  copy of the icon beside the `autorun.inf` and the `.ico` a disc already had.
+  Insert that disc in a Linux machine and the drive shows the game's title and
+  cover art instead of a volume id, exactly as it does in This PC. Windows never
+  reads the new files and Linux never read the old ones, so the two sit side by
+  side and nothing about the Windows disc changes.
+
+  **It is off by default**, and a project saved before this existed reads back as
+  off, so reopening an older disc and rebuilding it produces the disc it produced
+  before. Unticking it and rebuilding removes both files again. Nothing here lets
+  DiscWright run on Linux - it still builds the ISO on Windows, and the box only
+  changes what goes onto the disc.
 
   The menu does not carry over, and cannot: Linux disabled autorun for removable
   media on purpose, and no desktop will run a program off an inserted disc. The

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -1683,7 +1683,11 @@ function Save-Project([hashtable]$s,[string]$outDir) {
         # the single disc those projects always described.
         # Version 6 adds MatchName per entry. Absent in anything older, where the
         # name re-detected from the folder on open supplies it.
-        Version      = 6
+        # Version 7 adds LinuxInfo - whether the disc also carries its name and
+        # icon for Linux. Absent in anything older, which reads back as off, so
+        # reopening an old project and rebuilding produces the disc it produced
+        # before rather than quietly adding files to it.
+        Version      = 7
         AppVersion   = $APP_VERSION
         SavedUtc     = (Get-Date).ToUniversalTime().ToString('s')
         # Version 1 knew about exactly one game and stored it here. Both keys are
@@ -1726,6 +1730,7 @@ function Save-Project([hashtable]$s,[string]$outDir) {
         ExtrasPath   = $s.ExtrasPath
         ExtraItems   = @($s.ExtraItems)
         MediaKey     = [string]$s.MediaKey
+        LinuxInfo    = [bool]$s.LinuxInfo
         OutDir       = $outDir
     }
     $o | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath (Join-Path $outDir $PROJECT_FILE) -Encoding UTF8
@@ -1769,6 +1774,7 @@ function Import-Project([string]$jsonPath) {
         return @{
             SourceFolder=$j.SourceFolder; GameFolders=$folders; GameEntries=@($entries)
             Label=$j.Label; IconPath=$j.IconPath; IconIsIco=[bool]$j.IconIsIco
+            LinuxInfo=[bool]$j.LinuxInfo
             Menu=[bool]$j.Menu; BgPath=$j.BgPath; BgAsIs=[bool]$j.BgAsIs
             PanelSide=$(if($j.PanelSide){$j.PanelSide}else{'Right'})
             Divider=[bool]$j.Divider; ShowTitle=[bool]$j.ShowTitle; TitleText=[string]$j.TitleText
@@ -1799,6 +1805,7 @@ function Import-DiscFolder([string]$discDir) {
     $r = @{ SourceFolder=$discDir; GameFolders=@($discDir)
             GameEntries=@(@{ Folder=$discDir; Kind='Game'; ParentIndex=-1 })
             Label=$label; IconPath=(Join-Path $discDir $icon); IconIsIco=$true
+            LinuxInfo=(Test-Path (Join-Path $discDir '.xdg-volume-info'))
             Menu=$menu; BgPath=$null; BgAsIs=$true; PanelSide='Right'; MusicFile=$null
             Buttons=@(); ManualPath=$null; ExtrasPath=$null; ExtraItems=@()
             Divider=$false; ShowTitle=$false; TitleText=''
@@ -2013,24 +2020,28 @@ function Invoke-Build([hashtable]$s, [scriptblock]$log, [scriptblock]$progress=$
     else { & $log "Building multi-size icon from image..."; Convert-ToIco $s.IconPath $icoOut }
     & $log "Disc icon: $icoName"
 
-    # The same icon as a PNG, for Linux file managers. Built from the original
-    # source when there is one, and from the .ico only when that is all there is.
-    $pngName = [IO.Path]::ChangeExtension($icoName,'png')
-    $pngOut  = Join-Path $stage $pngName
-    try {
-        Convert-ToPng $s.IconPath $pngOut
-        & $log "Linux disc icon: $pngName"
-    } catch {
-        # A disc that shows a generic icon on Linux is still a working disc, so
-        # this must never be what stops a build.
-        & $log "  could not write the Linux icon ($($_.Exception.Message)) - the disc will use a generic one there."
-        $pngName = $null
+    # The same icon as a PNG, for Linux file managers - only when asked for.
+    # Built from the original source when there is one, and from the .ico only
+    # when that is all there is.
+    $pngName = $null
+    if ($s.LinuxInfo) {
+        $pngName = [IO.Path]::ChangeExtension($icoName,'png')
+        $pngOut  = Join-Path $stage $pngName
+        try {
+            Convert-ToPng $s.IconPath $pngOut
+            & $log "Linux disc icon: $pngName"
+        } catch {
+            # A disc that shows a generic icon on Linux is still a working disc,
+            # so this must never be what stops a build.
+            & $log "  could not write the Linux icon ($($_.Exception.Message)) - the disc will use a generic one there."
+            $pngName = $null
+        }
     }
     # Rebuilding a disc whose label (or the icon naming rule) changed would
     # otherwise leave the previous icon behind as dead weight on the disc. Runs
     # AFTER the copy above, because the old icon is often the copy's source.
     foreach ($stale in @(Get-ChildItem $stage -Filter '*.png' -File -EA SilentlyContinue)) {
-        if ($pngName -and $stale.Name -ne $pngName) {
+        if ($stale.Name -ne $pngName) {
             Clear-ReadOnly $stale.FullName; Remove-Item -LiteralPath $stale.FullName -Force -EA SilentlyContinue
             & $log "  removed old Linux icon: $($stale.Name)"
         }
@@ -2125,9 +2136,16 @@ function Invoke-Build([hashtable]$s, [scriptblock]$log, [scriptblock]$progress=$
 
     # Windows never looks at this file and Linux never looks at autorun.inf, so
     # the two sit side by side and the disc introduces itself on either machine.
+    $xdg = Join-Path $stage '.xdg-volume-info'
     if ($pngName) {
         & $log "Writing .xdg-volume-info (the disc's name and icon on Linux)..."
-        New-XdgVolumeInfo $s.Label $pngName (Join-Path $stage '.xdg-volume-info')
+        New-XdgVolumeInfo $s.Label $pngName $xdg
+    }
+    elseif (Test-Path $xdg) {
+        # Rebuilt with the box unticked. Leaving it would point Linux at a .png
+        # the cleanup above has just removed.
+        Clear-ReadOnly $xdg; Remove-Item -LiteralPath $xdg -Force -EA SilentlyContinue
+        & $log "Removed .xdg-volume-info - this disc is no longer named for Linux."
     }
 
     & $log "Building ISO (UDF, this can take ~30-60s for a full game)..."
@@ -2359,6 +2377,15 @@ AddLabel '3)  Disc icon (.ico, or .png/.jpg to auto-convert):' 15 268 520 | Out-
 $txtIcon=AddText 15 290 520
 $btnIcon=AddBtn 'Browse...' 545 290 110
 $lblIcon=AddLabel '' 15 318 500; $lblIcon.ForeColor=[System.Drawing.Color]::DimGray
+# Off by default. The two files it adds are inert on Windows and cost about a
+# kilobyte, but a disc is a thing people keep, and changing what every disc
+# carries is not a decision to make on somebody's behalf. They ask for it.
+$chkLinux=New-Object System.Windows.Forms.CheckBox
+$chkLinux.Text='Also name the disc for Linux (adds two small files)'
+$chkLinux.Location=New-Object System.Drawing.Point(15,342)
+$chkLinux.Size=New-Object System.Drawing.Size(420,22)
+$chkLinux.Checked=$false
+$form.Controls.Add($chkLinux)
 # Below the Browse button, not beside it: at y=290 this 44px-tall preview sat on
 # top of a 24px-tall button in the same 110px column, and whichever Windows drew
 # last won. Nothing lines up on this row at x=560, and 318+44 clears the step 4
@@ -2662,6 +2689,12 @@ function Show-Choice([string]$msg,[string]$title='DiscWright') {
 function Deny-Build([string]$logMsg,[string]$dlgMsg) { & $log "ERROR: $logMsg"; Show-Warn $dlgMsg }
 
 $tips = New-Object System.Windows.Forms.ToolTip
+$tips.SetToolTip($chkLinux, (
+    "Writes .xdg-volume-info and a .png copy of the icon to the disc, so a Linux" + [Environment]::NewLine +
+    "file manager shows the game's name and cover art instead of a volume id." + [Environment]::NewLine +
+    [Environment]::NewLine +
+    "Windows never reads either file, so the disc behaves exactly the same there." + [Environment]::NewLine +
+    "The menu does not carry over: Linux does not run programs off an inserted disc."))
 
 # True when building now would overwrite the ISO this disc writes.
 #
@@ -3284,6 +3317,7 @@ function Reset-Form {
     if ($picIcon.Image) { $old = $picIcon.Image; $picIcon.Image = $null; $old.Dispose() }
 
     $chkMenu.Checked = $true
+    $chkLinux.Checked = $false
     $txtBg.Clear(); $state.BgPath = $null
     $chkBgAsIs.Checked = $false
     $cmbSide.SelectedIndex = 0
@@ -3375,6 +3409,7 @@ function Open-Project([string]$folder) {
     if ($p.IconPath -and (Test-Path $p.IconPath)) { Set-IconFile $p.IconPath } else { & $log "  icon missing - pick one again." }
 
     $chkMenu.Checked = $p.Menu
+    $chkLinux.Checked = [bool]$p.LinuxInfo
     if ($p.BgPath -and (Test-Path $p.BgPath)) { Set-BgFile $p.BgPath } else { $txtBg.Text=''; $state.BgPath=$null }
     $chkBgAsIs.Checked = [bool]$p.BgAsIs
     $cmbSide.SelectedItem = $(if($p.PanelSide -ieq 'Left'){'Left'}else{'Right'})
@@ -3806,7 +3841,8 @@ $btnBuild.Add_Click({
          WindowBorder=$chkWinBorder.Checked; ButtonStyle=[string]$cmbBtnStyle.SelectedItem;
          MusicFile=$(if($chkMusic.Checked){$state.MusicFile}else{$null});
          Buttons=$buttons; ManualPath=$(if($cbMan.Checked){$state.ManualPath}else{$null}); ExtrasPath=$(if($cbExtra.Checked){$state.ExtrasPath}else{$null});
-         ExtraItems=@($lstExtra.Items); OutDir=$txtOut.Text.Trim(); MediaKey=$mediaKey }
+         ExtraItems=@($lstExtra.Items); OutDir=$txtOut.Text.Trim(); MediaKey=$mediaKey
+         LinuxInfo=$chkLinux.Checked }
     $btnBuild.Enabled=$false
     Set-FormBusy $true
     $script:BuildDiscTag = ''

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -534,7 +534,9 @@ function Get-DiscIconName([string]$label) {
 # discs built before the icon was named after the game.
 function Test-ReservedDiscName([string]$name,[string]$iconName='disc.ico') {
     if ($name -like 'setup_*') { return $true }
-    return (@('autorun.inf','disc.ico',$iconName,'AUTORUN','Extras','Games','Add-ons',$PROJECT_FILE) -contains $name)
+    $png = [IO.Path]::ChangeExtension($iconName,'png')
+    return (@('autorun.inf','.xdg-volume-info','disc.ico','disc.png',$iconName,$png,
+              'AUTORUN','Extras','Games','Add-ons',$PROJECT_FILE) -contains $name)
 }
 
 # Folder name for one game on a multi-game disc. Numbered, so the order in the
@@ -810,6 +812,48 @@ function Get-DibBytes([System.Drawing.Bitmap]$bmp) {
     $bw.Flush(); return $ms.ToArray()
 }
 
+# The same picture again, as a PNG, for Linux.
+#
+# Linux file managers cannot use the .ico: gvfs turns IconFile= into a GFileIcon
+# and hands it to GdkPixbuf, whose ICO support is for reading favicons rather
+# than for the 7-frame multi-size icons Convert-ToIco writes. A PNG is the
+# format every desktop reads without argument, so the disc carries both. They
+# come from the same source image, so they cannot disagree about what the game
+# looks like.
+#
+# 256 square: large enough for the biggest icon view any desktop offers, small
+# enough that it costs nothing on a disc measured in gigabytes.
+function Convert-ToPng([string]$imgPath, [string]$outPng) {
+    $src = $null
+    try {
+        # An .ico source has to be asked for its largest frame. Image.FromFile
+        # on an .ico silently picks a small one, which is how a 256px cover
+        # becomes a blurry 32px square nobody can explain.
+        if ([IO.Path]::GetExtension($imgPath) -eq '.ico') {
+            $ico = New-Object System.Drawing.Icon($imgPath, (New-Object System.Drawing.Size(256,256)))
+            $src = $ico.ToBitmap(); $ico.Dispose()
+        } else {
+            $src = [System.Drawing.Image]::FromFile($imgPath)
+        }
+
+        # Center-crop to a square first, exactly as Convert-ToIco does, so the
+        # two icons frame the artwork the same way.
+        $side = [math]::Min($src.Width, $src.Height)
+        $out  = New-Object System.Drawing.Bitmap(256, 256, [System.Drawing.Imaging.PixelFormat]::Format32bppArgb)
+        $g    = [System.Drawing.Graphics]::FromImage($out)
+        $g.InterpolationMode = 'HighQualityBicubic'
+        $g.DrawImage($src, (New-Object System.Drawing.Rectangle(0,0,256,256)),
+            (New-Object System.Drawing.Rectangle(
+                [int](($src.Width-$side)/2), [int](($src.Height-$side)/2), $side, $side)),
+            [System.Drawing.GraphicsUnit]::Pixel)
+        $g.Dispose()
+        Clear-ReadOnly $outPng
+        $out.Save($outPng, [System.Drawing.Imaging.ImageFormat]::Png)
+        $out.Dispose()
+    }
+    finally { if ($src) { $src.Dispose() } }
+}
+
 function Convert-ToIco([string]$imgPath, [string]$outIco) {
     $src=[System.Drawing.Image]::FromFile($imgPath)
     # square master (center-crop)
@@ -955,6 +999,49 @@ function New-AutorunInf([string]$label,[string]$iconName,[bool]$menu,[string]$ou
     # rather than as a question mark.
     # Not UTF8: PowerShell 5.1 writes a BOM, which AutoRun does not understand.
     Clear-ReadOnly $out; Set-Content -LiteralPath $out -Value ($lines -join "`r`n") -Encoding Default
+}
+
+# The Linux half of the disc's identity.
+#
+# autorun.inf is a Windows file and no Linux desktop reads it. The equivalent is
+# .xdg-volume-info, which gvfs looks for at the root of anything it mounts - so
+# the same disc can carry both and each system reads the one it understands
+# while ignoring the other. Nothing here changes what Windows sees.
+#
+# It cannot open a menu: Linux disabled autorun for removable media on purpose
+# and no desktop will run a program off an inserted disc. What it can do is the
+# other half of what autorun.inf does, and the half people actually notice - the
+# drive shows the game's own name and cover art instead of a volume id.
+#
+# Keys are gvfs's, read from common/gvfsmountinfo.c: group [Volume Info], Name
+# as a locale string, and IconFile resolved relative to this file's own folder,
+# which is why a bare filename is right here.
+function New-XdgVolumeInfo([string]$label,[string]$pngName,[string]$out) {
+    $label   = Remove-ControlChars $label
+    $pngName = Remove-ControlChars $pngName
+
+    # GKeyFile values escape with backslashes, so a literal backslash has to be
+    # doubled or it silently eats the character after it. Newlines and tabs are
+    # already gone above; this is the one that survives Remove-ControlChars.
+    #
+    # String.Replace and not -replace: in a .NET regex REPLACEMENT a backslash
+    # is an ordinary character, not an escape, so -replace with a doubled
+    # pattern and a quadrupled replacement writes four backslashes rather than
+    # two. Measured, after writing it the wrong way first.
+    $esc = { param($v) $v.Replace([string][char]92, [string][char]92 + [string][char]92) }
+
+    $lines = @(
+        '[Volume Info]'
+        "Name=$(& $esc $label)"
+        "IconFile=$(& $esc $pngName)"
+    )
+
+    # UTF-8 with no BOM, and LF. GKeyFile expects UTF-8 and treats a BOM as part
+    # of the first group name, so a BOM makes the whole file parse as nothing -
+    # which is exactly what PowerShell 5.1's -Encoding UTF8 would write.
+    Clear-ReadOnly $out
+    [IO.File]::WriteAllText($out, (($lines -join "`n") + "`n"),
+                            (New-Object System.Text.UTF8Encoding($false)))
 }
 
 function New-MenuHta([hashtable]$cfg,[string]$out) {
@@ -1925,9 +2012,29 @@ function Invoke-Build([hashtable]$s, [scriptblock]$log, [scriptblock]$progress=$
     }
     else { & $log "Building multi-size icon from image..."; Convert-ToIco $s.IconPath $icoOut }
     & $log "Disc icon: $icoName"
+
+    # The same icon as a PNG, for Linux file managers. Built from the original
+    # source when there is one, and from the .ico only when that is all there is.
+    $pngName = [IO.Path]::ChangeExtension($icoName,'png')
+    $pngOut  = Join-Path $stage $pngName
+    try {
+        Convert-ToPng $s.IconPath $pngOut
+        & $log "Linux disc icon: $pngName"
+    } catch {
+        # A disc that shows a generic icon on Linux is still a working disc, so
+        # this must never be what stops a build.
+        & $log "  could not write the Linux icon ($($_.Exception.Message)) - the disc will use a generic one there."
+        $pngName = $null
+    }
     # Rebuilding a disc whose label (or the icon naming rule) changed would
     # otherwise leave the previous icon behind as dead weight on the disc. Runs
     # AFTER the copy above, because the old icon is often the copy's source.
+    foreach ($stale in @(Get-ChildItem $stage -Filter '*.png' -File -EA SilentlyContinue)) {
+        if ($pngName -and $stale.Name -ne $pngName) {
+            Clear-ReadOnly $stale.FullName; Remove-Item -LiteralPath $stale.FullName -Force -EA SilentlyContinue
+            & $log "  removed old Linux icon: $($stale.Name)"
+        }
+    }
     foreach ($stale in @(Get-ChildItem $stage -Filter '*.ico' -File -EA SilentlyContinue)) {
         if ($stale.Name -ne $icoName) {
             Clear-ReadOnly $stale.FullName; Remove-Item -LiteralPath $stale.FullName -Force -EA SilentlyContinue
@@ -2015,6 +2122,13 @@ function Invoke-Build([hashtable]$s, [scriptblock]$log, [scriptblock]$progress=$
 
     & $log "Writing autorun.inf..."
     New-AutorunInf $s.Label $icoName $s.Menu (Join-Path $stage 'autorun.inf')
+
+    # Windows never looks at this file and Linux never looks at autorun.inf, so
+    # the two sit side by side and the disc introduces itself on either machine.
+    if ($pngName) {
+        & $log "Writing .xdg-volume-info (the disc's name and icon on Linux)..."
+        New-XdgVolumeInfo $s.Label $pngName (Join-Path $stage '.xdg-volume-info')
+    }
 
     & $log "Building ISO (UDF, this can take ~30-60s for a full game)..."
     $iso = Get-IsoPath $s.OutDir $s.Label

--- a/README.md
+++ b/README.md
@@ -112,10 +112,8 @@ One game, and the installer sits at the root:
 
 ```
 E:\
-├─ autorun.inf              drive icon, drive label, menu launcher  (Windows)
-├─ .xdg-volume-info         drive icon and label                    (Linux)
+├─ autorun.inf              drive icon, drive label, menu launcher
 ├─ HollowKnight.ico         named after the disc, not "disc.ico" (see below)
-├─ HollowKnight.png         the same icon again, for Linux
 ├─ setup_hollow_knight_....exe
 ├─ AUTORUN\
 │   ├─ menu.hta             the menu itself
@@ -130,9 +128,7 @@ Two or more, and every entry moves into a numbered folder of its own:
 ```
 E:\
 ├─ autorun.inf
-├─ .xdg-volume-info
 ├─ MetroidvaniaNight.ico
-├─ MetroidvaniaNight.png
 ├─ AUTORUN\                 as above
 ├─ Games\
 │   ├─ 01 - Hollow Knight\
@@ -153,11 +149,22 @@ The icon is named after the disc rather than a fixed `disc.ico` for a specific r
 
 ### The disc on a Linux machine
 
-Put one of these discs in a Linux box and it knows its own name and wears its own cover art, the same as it does in This PC. That is what `.xdg-volume-info` and the `.png` are for. Windows never looks at them; Linux never looks at `autorun.inf`; each reads the one it understands and ignores the other, so nothing is given up to gain it.
+There is a checkbox under the icon, **Also name the disc for Linux**, and it is **off by default**. Tick it and the disc gains two more files:
+
+```
+├─ .xdg-volume-info         drive icon and label, for Linux
+├─ HollowKnight.png         the same icon again, in a format Linux reads
+```
+
+Then the disc knows its own name and wears its own cover art on a Linux machine, the same as it does in This PC. Windows never looks at either file; Linux never looks at `autorun.inf`; each reads the one it understands and ignores the other, so a disc built with the box ticked behaves on Windows exactly as one built without it.
 
 What does **not** happen there is the menu. Linux disabled autorun for removable media deliberately, and no desktop will run a program off a disc you inserted — so `menu.hta` sits on the disc unopened, and the games are installed from the folders by hand. The icon and the label are the half that carries over.
 
 The image is written twice because it has to be. `gvfs` turns the `IconFile=` line into a file icon and hands it to GdkPixbuf, whose `.ico` support is meant for favicons rather than for the seven-frame icon Windows wants. Both come from the same source picture, so they cannot end up disagreeing about what the game looks like.
+
+Untick it and rebuild and both files are removed again — leaving the info file behind would point Linux at an icon that is no longer on the disc.
+
+None of this makes DiscWright run on Linux. It builds the ISO on Windows, as it always has; the box only changes what goes onto the disc.
 
 ## Burning the ISO
 

--- a/README.md
+++ b/README.md
@@ -112,8 +112,10 @@ One game, and the installer sits at the root:
 
 ```
 E:\
-├─ autorun.inf              drive icon, drive label, menu launcher
+├─ autorun.inf              drive icon, drive label, menu launcher  (Windows)
+├─ .xdg-volume-info         drive icon and label                    (Linux)
 ├─ HollowKnight.ico         named after the disc, not "disc.ico" (see below)
+├─ HollowKnight.png         the same icon again, for Linux
 ├─ setup_hollow_knight_....exe
 ├─ AUTORUN\
 │   ├─ menu.hta             the menu itself
@@ -128,7 +130,9 @@ Two or more, and every entry moves into a numbered folder of its own:
 ```
 E:\
 ├─ autorun.inf
+├─ .xdg-volume-info
 ├─ MetroidvaniaNight.ico
+├─ MetroidvaniaNight.png
 ├─ AUTORUN\                 as above
 ├─ Games\
 │   ├─ 01 - Hollow Knight\
@@ -146,6 +150,14 @@ An add-on gets its own numbered folder like anything else — its `.bin` parts a
 The numbering is what makes the disc browsable by hand: it puts the folders in the same order as the menu. Names are folded to plain ASCII for the same reason the disc label is — a disc that is legible in every file manager is worth more than an exact title.
 
 The icon is named after the disc rather than a fixed `disc.ico` for a specific reason: Explorer caches icons **by file path**, so `E:\disc.ico` is the same cache key for every disc that ever passes through that drive letter. Swap discs and Explorer will happily redraw the previous game's icon. Naming it after the disc gives each one its own key.
+
+### The disc on a Linux machine
+
+Put one of these discs in a Linux box and it knows its own name and wears its own cover art, the same as it does in This PC. That is what `.xdg-volume-info` and the `.png` are for. Windows never looks at them; Linux never looks at `autorun.inf`; each reads the one it understands and ignores the other, so nothing is given up to gain it.
+
+What does **not** happen there is the menu. Linux disabled autorun for removable media deliberately, and no desktop will run a program off a disc you inserted — so `menu.hta` sits on the disc unopened, and the games are installed from the folders by hand. The icon and the label are the half that carries over.
+
+The image is written twice because it has to be. `gvfs` turns the `IconFile=` line into a file icon and hands it to GdkPixbuf, whose `.ico` support is meant for favicons rather than for the seven-frame icon Windows wants. Both come from the same source picture, so they cannot end up disagreeing about what the game looks like.
 
 ## Burning the ISO
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -100,9 +100,9 @@ of the installer itself, may be the better trade.
   template; and even the portable third is PowerShell, so it would be retranslated rather
   than reused.
 
-  The disc itself no longer waits for that. Since the hybrid disc landed, what DiscWright
-  builds already carries its name and icon for Linux beside the Windows ones, so a disc
-  made on Windows is legible on either machine. What is still missing there is a menu and
+  The disc itself no longer waits for that. A checkbox under the icon - off by default -
+  adds the disc's name and icon for Linux beside the Windows ones, so a disc made on
+  Windows can be legible on either machine. What is still missing there is a menu and
   GOG's Linux `.sh` installers, which is the part that needs a tool to collect them.
   Intent only; nothing here is promised.
 - **More than one music track.** One per disc is currently deliberate. A short playlist

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -94,11 +94,17 @@ of the installer itself, may be the better trade.
   Someone asked about other DRM-free sources. Relaxing the filename filter is a small
   change; deciding what DiscWright claims to support is not, and the honest position today
   is that only GOG downloads have been tested.
-- **Linux.** Asked for twice. This is a rewrite rather than a port — the interface is
-  WinForms and the ISO builder is IMAPI2FS, both Windows-only — and the disc it produces
-  is an autorun menu for Windows, which is the half Linux has least use for. What would
-  carry over is the disc layout and a menu that is not an HTA. Intent only; nothing here
-  is promised.
+- **Linux.** Asked for twice. A Linux *tool* is still a rewrite rather than a port — the
+  interface is WinForms and the ISO builder is IMAPI2FS, both Windows-only. Measured, the
+  split is about 37% portable logic, 46% WinForms and the ISO helper, and 17% the menu
+  template; and even the portable third is PowerShell, so it would be retranslated rather
+  than reused.
+
+  The disc itself no longer waits for that. Since the hybrid disc landed, what DiscWright
+  builds already carries its name and icon for Linux beside the Windows ones, so a disc
+  made on Windows is legible on either machine. What is still missing there is a menu and
+  GOG's Linux `.sh` installers, which is the part that needs a tool to collect them.
+  Intent only; nothing here is promised.
 - **More than one music track.** One per disc is currently deliberate. A short playlist
   might justify the complexity. A music player will not.
 - **Menu themes.** The menu is one layout with configurable artwork. Named presets would

--- a/docs/MANUAL-CHECKS.md
+++ b/docs/MANUAL-CHECKS.md
@@ -1,6 +1,6 @@
 # Manual checks before a release
 
-The automated suite is 374 logic tests and 76 window tests, and it runs in about
+The automated suite is 385 logic tests and 76 window tests, and it runs in about
 four minutes:
 
 ```

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -690,8 +690,8 @@ Describe 'Project file' -Tag 'Unit' {
 
     Context 'writing' {
 
-        It 'declares schema version 6' {
-            $script:PJson.Version | Should -Be 6
+        It 'declares schema version 7' {
+            $script:PJson.Version | Should -Be 7
         }
 
         It 'records which disc the set was planned for' {
@@ -3536,8 +3536,8 @@ Describe 'Renaming a game for the menu' -Tag 'Unit' {
             $script:RenameRaw  = Get-Content -Raw -LiteralPath $script:RenameJson | ConvertFrom-Json
         }
 
-        It 'writes schema version 6' {
-            $script:RenameRaw.Version | Should -Be 6
+        It 'writes schema version 7' {
+            $script:RenameRaw.Version | Should -Be 7
         }
 
         It 'stores the registered name beside the chosen one' {

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -108,14 +108,17 @@ BeforeAll {
     $script:Art = New-FixturePng (Join-Path $script:Sandbox 'art.png') 512 512
 
     function New-BuildSettings {
-        param([array]$Games, [string]$Label, [string]$OutDir)
+        # LinuxInfo defaults to $false here for the same reason the checkbox does:
+        # every test written before it existed has to keep describing the disc it
+        # was written about.
+        param([array]$Games, [string]$Label, [string]$OutDir, [switch]$LinuxInfo)
         return @{
             Games=$Games; Label=$Label; IconPath=$script:Art; IconIsIco=$false
             Menu=$true; BgPath=$script:Bg; BgAsIs=$false; PanelSide='Right'
             Divider=$false; ShowTitle=$false; TitleText=''
             WindowBorder=$true; ButtonStyle='Minimal'; MusicFile=$null
             Buttons=@('Play','Install','Exit'); ManualPath=$null; ExtrasPath=$null
-            ExtraItems=@(); OutDir=$OutDir
+            ExtraItems=@(); OutDir=$OutDir; LinuxInfo=[bool]$LinuxInfo
         }
     }
 
@@ -1187,6 +1190,44 @@ Describe 'Building a disc' -Tag 'Build' -Skip:(-not $script:CanBuildIso) {
             $script:IsoFiles = Get-IsoEntries -IsoPath $script:IsoPath -SevenZip $script:SevenZip
         }
 
+        Context 'and again with the Linux files asked for' {
+
+            BeforeAll {
+                $script:LxOut = Join-Path $script:Sandbox 'build-iso-linux'
+                New-Item -ItemType Directory -Force -Path $script:LxOut | Out-Null
+                $script:LxIso = Invoke-Build (New-BuildSettings -Games $script:IsoGames -Label 'Iso Check' -OutDir $script:LxOut -LinuxInfo) $script:LogSink
+                $script:LxFiles = Get-IsoEntries -IsoPath $script:LxIso -SevenZip $script:SevenZip
+            }
+
+            It 'contains the Linux half beside the Windows one' {
+                # Asserted against the ISO rather than the staging folder on
+                # purpose: ISO 9660 forbids a leading dot, and a filesystem that
+                # quietly renamed .xdg-volume-info would leave the disc nameless
+                # on Linux with everything on Windows still perfect. DiscWright
+                # writes UDF only, which allows it - this proves that still holds.
+                $script:LxFiles | Should -Contain '.xdg-volume-info'
+                $expectedPng = [IO.Path]::ChangeExtension((Get-DiscIconName 'Iso Check'), 'png')
+                $script:LxFiles | Should -Contain $expectedPng
+            }
+
+            It 'still carries everything Windows needs' {
+                # The point of a hybrid disc: nothing is given up to gain it.
+                $script:LxFiles | Should -Contain 'autorun.inf'
+                $script:LxFiles | Should -Contain 'AUTORUN\menu.hta'
+            }
+
+            It 'gives the Linux icon a name that matches the file it points at' {
+                # IconFile= resolves relative to the disc root, so the name in the
+                # file and the name on the disc have to be the same string.
+                $tmp = Join-Path $script:Sandbox 'xdg-from-iso'
+                if (Test-Path $tmp) { Remove-Item $tmp -Recurse -Force }
+                & $script:SevenZip e $script:LxIso ".xdg-volume-info" "-o$tmp" -y *> $null
+                $txt = [IO.File]::ReadAllText((Join-Path $tmp '.xdg-volume-info'))
+                $named = @($txt -split "`n" | Where-Object { $_ -like 'IconFile=*' }) -replace '^IconFile=',''
+                $script:LxFiles | Should -Contain $named
+            }
+        }
+
         It 'is a real UDF image, not just a file that exists' {
             $info = & $script:SevenZip l -slt $script:IsoPath 2>&1
             ($info | Where-Object { $_ -match '^Type = Udf' }) | Should -Not -BeNullOrEmpty
@@ -1205,26 +1246,12 @@ Describe 'Building a disc' -Tag 'Build' -Skip:(-not $script:CanBuildIso) {
             $script:IsoFiles | Should -Contain 'autorun.inf'
         }
 
-        It 'contains the Linux half beside it' {
-            # The reason this is asserted against the ISO rather than against the
-            # staging folder: ISO 9660 forbids a leading dot, and a filesystem
-            # that quietly renamed .xdg-volume-info would leave the disc nameless
-            # on Linux with everything on Windows still perfect. DiscWright writes
-            # UDF only, which allows it - this is what proves that still holds.
-            $script:IsoFiles | Should -Contain '.xdg-volume-info'
+        It 'carries nothing for Linux unless it was asked to' {
+            # The default. A disc built without ticking the box is the disc
+            # DiscWright has always built, and this is what says so.
+            $script:IsoFiles | Should -Not -Contain '.xdg-volume-info'
             $expectedPng = [IO.Path]::ChangeExtension((Get-DiscIconName 'Iso Check'), 'png')
-            $script:IsoFiles | Should -Contain $expectedPng
-        }
-
-        It 'gives the Linux icon a name that matches the file it points at' {
-            # IconFile= is resolved relative to the disc root, so the name in the
-            # file and the name on the disc have to be the same string.
-            $tmp = Join-Path $script:Sandbox 'xdg-from-iso'
-            if (Test-Path $tmp) { Remove-Item $tmp -Recurse -Force }
-            & $script:SevenZip e $script:IsoPath ".xdg-volume-info" "-o$tmp" -y *> $null
-            $txt = [IO.File]::ReadAllText((Join-Path $tmp '.xdg-volume-info'))
-            $named = @($txt -split "`n" | Where-Object { $_ -like 'IconFile=*' }) -replace '^IconFile=',''
-            $script:IsoFiles | Should -Contain $named
+            $script:IsoFiles | Should -Not -Contain $expectedPng
         }
 
         It 'contains the menu' {
@@ -3757,5 +3784,89 @@ Describe 'The PNG icon the Linux side needs' -Tag 'Unit' {
             $img.Width  | Should -Be 256
             $img.Height | Should -Be 256
         } finally { $img.Dispose() }
+    }
+}
+
+Describe 'Asking for the Linux files, and changing your mind' -Tag 'Build' -Skip:(-not $script:CanBuildIso) {
+
+    BeforeAll {
+        $script:TogGames = @((Get-GameInfo (New-FixtureGame -Slug 'tog_one' -ExeMb 2)))
+        $script:TogOut   = Join-Path $script:Sandbox 'build-toggle'
+        New-Item -ItemType Directory -Force -Path $script:TogOut | Out-Null
+        $script:TogStage = Join-Path $script:TogOut 'disc'
+        $script:TogPng   = [IO.Path]::ChangeExtension((Get-DiscIconName 'Toggle Disc'), 'png')
+    }
+
+    It 'writes neither file when it was not asked' {
+        $null = Invoke-Build (New-BuildSettings -Games $script:TogGames -Label 'Toggle Disc' -OutDir $script:TogOut) $script:LogSink
+        Test-Path (Join-Path $script:TogStage '.xdg-volume-info') | Should -BeFalse
+        Test-Path (Join-Path $script:TogStage $script:TogPng)     | Should -BeFalse
+    }
+
+    It 'writes both when it is asked' {
+        $null = Invoke-Build (New-BuildSettings -Games $script:TogGames -Label 'Toggle Disc' -OutDir $script:TogOut -LinuxInfo) $script:LogSink
+        Test-Path (Join-Path $script:TogStage '.xdg-volume-info') | Should -BeTrue
+        Test-Path (Join-Path $script:TogStage $script:TogPng)     | Should -BeTrue
+    }
+
+    It 'takes them both away again when the box is unticked and the disc rebuilt' {
+        # The half that is easy to forget. Leaving .xdg-volume-info behind would
+        # point a Linux desktop at a .png that the icon cleanup has just removed,
+        # which is worse than never having written either.
+        $null = Invoke-Build (New-BuildSettings -Games $script:TogGames -Label 'Toggle Disc' -OutDir $script:TogOut) $script:LogSink
+        Test-Path (Join-Path $script:TogStage '.xdg-volume-info') | Should -BeFalse
+        Test-Path (Join-Path $script:TogStage $script:TogPng)     | Should -BeFalse
+    }
+
+    It 'leaves the Windows disc untouched either way' {
+        Test-Path (Join-Path $script:TogStage 'autorun.inf') | Should -BeTrue
+        Test-Path (Join-Path $script:TogStage (Get-DiscIconName 'Toggle Disc')) | Should -BeTrue
+    }
+}
+
+Describe 'The Linux setting in a project file' -Tag 'Unit' {
+
+    BeforeAll {
+        $script:ProjDir = Join-Path $script:Sandbox 'linux-proj'
+        New-Item -ItemType Directory -Force -Path $script:ProjDir | Out-Null
+    }
+
+    It 'is written as schema 7 and comes back the way it went in' {
+        $s = @{ Games=@(); Label='Round Trip'; IconPath=$script:Art; IconIsIco=$false
+                Menu=$true; BgPath=$null; BgAsIs=$true; PanelSide='Right'
+                Divider=$false; ShowTitle=$false; TitleText=''
+                WindowBorder=$true; ButtonStyle='Minimal'; MusicFile=$null
+                Buttons=@('Play'); ManualPath=$null; ExtrasPath=$null
+                ExtraItems=@(); MediaKey=''; LinuxInfo=$true }
+        Save-Project $s $script:ProjDir
+        $raw = Get-Content -Raw (Join-Path $script:ProjDir 'discproject.json') | ConvertFrom-Json
+        $raw.Version   | Should -Be 7
+        $raw.LinuxInfo | Should -BeTrue
+        (Import-Project (Join-Path $script:ProjDir 'discproject.json')).LinuxInfo | Should -BeTrue
+    }
+
+    It 'reads back as off from a project saved before it existed' {
+        # The compatibility promise. Reopening an older project and rebuilding has
+        # to produce the disc it produced before, not one with files added to it.
+        $old = Join-Path $script:ProjDir 'old.json'
+        @{ Version=6; Label='Older Disc'; Games=@(); Buttons=@('Play')
+           Menu=$true; BgAsIs=$true; PanelSide='Right'; ButtonStyle='Minimal'
+           WindowBorder=$true } | ConvertTo-Json -Depth 4 |
+            Set-Content -LiteralPath $old -Encoding UTF8
+        $p = Import-Project $old
+        $p | Should -Not -BeNullOrEmpty
+        [bool]$p.LinuxInfo | Should -BeFalse
+    }
+
+    It 'works out from the disc itself when there is no project file' {
+        # Import-DiscFolder rebuilds settings by looking at a built disc. Whether
+        # it was named for Linux is knowable by looking rather than by guessing.
+        $d = Join-Path $script:Sandbox 'bare-disc'
+        New-Item -ItemType Directory -Force -Path $d | Out-Null
+        New-AutorunInf 'Bare Disc' 'BareDisc.ico' $true (Join-Path $d 'autorun.inf')
+        (Import-DiscFolder $d).LinuxInfo | Should -BeFalse
+
+        New-XdgVolumeInfo 'Bare Disc' 'BareDisc.png' (Join-Path $d '.xdg-volume-info')
+        (Import-DiscFolder $d).LinuxInfo | Should -BeTrue
     }
 }

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -26,6 +26,15 @@ BeforeDiscovery {
         'C:\Program Files (x86)\7-Zip\7z.exe'
         (Get-Command 7z.exe -ErrorAction SilentlyContinue | ForEach-Object { $_.Source })
     ) | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
+
+    # A real GKeyFile parser to check .xdg-volume-info against. WSL is the only
+    # one likely to be on a Windows box; without it those tests skip rather than
+    # assert that the format is right because we said so.
+    $script:HasWsl = $false
+    try {
+        $null = & wsl.exe -- python3 -c "pass" 2>$null
+        $script:HasWsl = ($LASTEXITCODE -eq 0)
+    } catch { }
 }
 
 BeforeAll {
@@ -39,6 +48,15 @@ BeforeAll {
         'C:\Program Files (x86)\7-Zip\7z.exe'
         (Get-Command 7z.exe -ErrorAction SilentlyContinue | ForEach-Object { $_.Source })
     ) | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
+
+    # A real GKeyFile parser to check .xdg-volume-info against. WSL is the only
+    # one likely to be on a Windows box; without it those tests skip rather than
+    # assert that the format is right because we said so.
+    $script:HasWsl = $false
+    try {
+        $null = & wsl.exe -- python3 -c "pass" 2>$null
+        $script:HasWsl = ($LASTEXITCODE -eq 0)
+    } catch { }
 
     $appScript = Join-Path (Split-Path $PSScriptRoot -Parent) 'DiscWright.ps1'
     $parseErrors = $null
@@ -319,6 +337,17 @@ Describe 'Locking the form while a build runs' -Tag 'Unit' {
 }
 
 Describe 'Test-ReservedDiscName' -Tag 'Unit' {
+
+    It 'reserves the names the Linux half of the disc uses' {
+        # Extra content dropped at the disc root must not be able to overwrite the
+        # file that tells a Linux desktop what the disc is called, nor the icon it
+        # points at.
+        Test-ReservedDiscName '.xdg-volume-info' 'TheWitcher.ico' | Should -BeTrue
+        Test-ReservedDiscName 'TheWitcher.png'   'TheWitcher.ico' | Should -BeTrue
+        Test-ReservedDiscName 'disc.png'         'TheWitcher.ico' | Should -BeTrue
+        # Still not reserved: an unrelated picture is ordinary extra content.
+        Test-ReservedDiscName 'screenshot.png'   'TheWitcher.ico' | Should -BeFalse
+    }
 
     It 'reserves <Name>' -ForEach @(
         @{ Name = 'autorun.inf' }
@@ -1174,6 +1203,28 @@ Describe 'Building a disc' -Tag 'Build' -Skip:(-not $script:CanBuildIso) {
 
         It 'contains autorun.inf at the root' {
             $script:IsoFiles | Should -Contain 'autorun.inf'
+        }
+
+        It 'contains the Linux half beside it' {
+            # The reason this is asserted against the ISO rather than against the
+            # staging folder: ISO 9660 forbids a leading dot, and a filesystem
+            # that quietly renamed .xdg-volume-info would leave the disc nameless
+            # on Linux with everything on Windows still perfect. DiscWright writes
+            # UDF only, which allows it - this is what proves that still holds.
+            $script:IsoFiles | Should -Contain '.xdg-volume-info'
+            $expectedPng = [IO.Path]::ChangeExtension((Get-DiscIconName 'Iso Check'), 'png')
+            $script:IsoFiles | Should -Contain $expectedPng
+        }
+
+        It 'gives the Linux icon a name that matches the file it points at' {
+            # IconFile= is resolved relative to the disc root, so the name in the
+            # file and the name on the disc have to be the same string.
+            $tmp = Join-Path $script:Sandbox 'xdg-from-iso'
+            if (Test-Path $tmp) { Remove-Item $tmp -Recurse -Force }
+            & $script:SevenZip e $script:IsoPath ".xdg-volume-info" "-o$tmp" -y *> $null
+            $txt = [IO.File]::ReadAllText((Join-Path $tmp '.xdg-volume-info'))
+            $named = @($txt -split "`n" | Where-Object { $_ -like 'IconFile=*' }) -replace '^IconFile=',''
+            $script:IsoFiles | Should -Contain $named
         }
 
         It 'contains the menu' {
@@ -3569,5 +3620,142 @@ Describe 'Renaming a game for the menu' -Tag 'Unit' {
         It 'is never written by the dialog that renames a game' {
             $script:MatchWriters | Should -Not -Contain 'Show-EntryKindDialog'
         }
+    }
+}
+
+Describe 'The disc introduces itself on Linux too' -Tag 'Unit' {
+
+    # autorun.inf is a Windows file and no Linux desktop reads it. .xdg-volume-info
+    # is what gvfs looks for at the root of anything it mounts, so the two sit side
+    # by side and each system reads the one it understands. These tests are about
+    # the file being one gvfs will actually accept - the format is a GKeyFile, and
+    # GKeyFile is unforgiving in two specific ways that are easy to get wrong and
+    # invisible when you do.
+
+    BeforeAll {
+        $script:XdgOut = Join-Path $script:Sandbox 'xdg-volume-info'
+    }
+
+    It 'writes the group and the two keys gvfs reads' {
+        New-XdgVolumeInfo 'The Witcher' 'TheWitcher.png' $script:XdgOut
+        $lines = @([IO.File]::ReadAllText($script:XdgOut) -split "`n")
+        $lines | Should -Contain '[Volume Info]'
+        $lines | Should -Contain 'Name=The Witcher'
+        $lines | Should -Contain 'IconFile=TheWitcher.png'
+    }
+
+    It 'writes no byte order mark' {
+        # PowerShell 5.1's -Encoding UTF8 writes one. GKeyFile reads the BOM as
+        # part of the first group name, so the group stops being "Volume Info",
+        # every key belongs to a group nothing looks for, and the file parses to
+        # nothing at all - with no error anywhere to say why the disc came up
+        # nameless.
+        New-XdgVolumeInfo 'The Witcher' 'TheWitcher.png' $script:XdgOut
+        $bytes = [IO.File]::ReadAllBytes($script:XdgOut)
+        @($bytes[0], $bytes[1], $bytes[2]) | Should -Not -Be @(0xEF, 0xBB, 0xBF)
+        $bytes[0] | Should -Be ([byte][char]'[')
+    }
+
+    It 'ends its lines the way a Unix file does' {
+        New-XdgVolumeInfo 'The Witcher' 'TheWitcher.png' $script:XdgOut
+        $raw = [IO.File]::ReadAllText($script:XdgOut)
+        $raw | Should -Not -Match "`r"
+        $raw | Should -Match "`n"
+    }
+
+    It 'doubles a backslash exactly once' {
+        # A GKeyFile value escapes with backslashes, so a lone one eats the
+        # character after it. The first attempt used -replace with a quadrupled
+        # replacement and wrote FOUR backslashes, because a backslash in a .NET
+        # regex replacement is an ordinary character rather than an escape. This
+        # is that bug, kept.
+        $bs = [char]92
+        New-XdgVolumeInfo ('a' + $bs + 'b') 'x.png' $script:XdgOut
+        $lines = @([IO.File]::ReadAllText($script:XdgOut) -split "`n")
+        $lines | Should -Contain ('Name=a' + $bs + $bs + 'b')
+    }
+
+    It 'keeps a label that carries a newline to one key' {
+        # The same hazard New-AutorunInf has: a newline in the label would start a
+        # line, and in a GKeyFile a line is a key.
+        New-XdgVolumeInfo ("My Game" + [char]13 + [char]10 + "Icon=evil.png") 'good.png' $script:XdgOut
+        $lines = @([IO.File]::ReadAllText($script:XdgOut) -split "`n")
+        @($lines | Where-Object { $_ -like 'Name=*' }).Count | Should -Be 1
+        @($lines | Where-Object { $_ -like 'Icon=*' }).Count | Should -Be 0
+        $lines | Should -Contain 'IconFile=good.png'
+    }
+
+    It 'is accepted by a real GKeyFile parser' -Skip:(-not $script:HasWsl) {
+        # The tests above assert what the format ought to be. This one asks
+        # something that actually implements it, because every claim above is a
+        # claim about somebody else's parser.
+        New-XdgVolumeInfo 'The Witcher' 'TheWitcher.png' $script:XdgOut
+        $wslPath = & wsl.exe wslpath -a ($script:XdgOut -replace '\\','/') 2>$null
+        # GLib's GKeyFile where it is available, because that is literally the
+        # parser gvfs calls - configparser only agrees with it by coincidence,
+        # and the two differ on exactly the escaping this file has to get right.
+        $py = @'
+import sys
+try:
+    from gi.repository import GLib
+    kf = GLib.KeyFile()
+    kf.load_from_file(sys.argv[1], GLib.KeyFileFlags.NONE)
+    name = kf.get_locale_string("Volume Info", "Name", None)
+    icon = kf.get_string("Volume Info", "IconFile")
+except ImportError:
+    import configparser
+    c = configparser.ConfigParser(interpolation=None)
+    c.read(sys.argv[1], encoding="utf-8")
+    name = c["Volume Info"]["Name"]
+    icon = c["Volume Info"]["IconFile"]
+print(name + "|" + icon)
+'@
+        $got = $py | & wsl.exe -- python3 - "$wslPath" 2>$null
+        "$got".Trim() | Should -Be 'The Witcher|TheWitcher.png'
+    }
+}
+
+Describe 'The PNG icon the Linux side needs' -Tag 'Unit' {
+
+    # gvfs turns IconFile= into a GFileIcon and hands it to GdkPixbuf, whose ICO
+    # support is for favicons rather than for the seven-frame icons Convert-ToIco
+    # writes. So the disc carries the same picture twice, in both formats.
+
+    BeforeAll {
+        $script:SrcImg = Join-Path $script:Sandbox 'source-art.png'
+        # Deliberately not square and not 256, so a center-crop and a resize both
+        # have to happen for the result to come out right.
+        $bmp = New-Object System.Drawing.Bitmap(600, 400)
+        $g = [System.Drawing.Graphics]::FromImage($bmp)
+        $g.Clear([System.Drawing.Color]::DarkGoldenrod)
+        $g.Dispose()
+        $bmp.Save($script:SrcImg, [System.Drawing.Imaging.ImageFormat]::Png)
+        $bmp.Dispose()
+    }
+
+    It 'writes a real 256x256 PNG' {
+        $out = Join-Path $script:Sandbox 'icon-from-image.png'
+        Convert-ToPng $script:SrcImg $out
+        Test-Path $out | Should -BeTrue
+        $img = [System.Drawing.Image]::FromFile($out)
+        try {
+            $img.Width  | Should -Be 256
+            $img.Height | Should -Be 256
+            $img.RawFormat.Guid | Should -Be ([System.Drawing.Imaging.ImageFormat]::Png.Guid)
+        } finally { $img.Dispose() }
+    }
+
+    It 'can take its picture from an .ico when that is all the disc has' {
+        # Reopening a built disc gives back an .ico as the icon source, so this is
+        # the ordinary path on a rebuild, not an edge case.
+        $ico = Join-Path $script:Sandbox 'from-image.ico'
+        Convert-ToIco $script:SrcImg $ico
+        $out = Join-Path $script:Sandbox 'icon-from-ico.png'
+        Convert-ToPng $ico $out
+        $img = [System.Drawing.Image]::FromFile($out)
+        try {
+            $img.Width  | Should -Be 256
+            $img.Height | Should -Be 256
+        } finally { $img.Dispose() }
     }
 }


### PR DESCRIPTION
## What this is

A DiscWright disc knows its own name and wears its own cover art in This PC. Anywhere else it was an unlabelled volume id. It now carries `.xdg-volume-info` and a `.png` copy of its icon beside the `autorun.inf` and `.ico` it already had, so **the same physical disc is legible on either machine**.

Windows has never read `.xdg-volume-info`; Linux has never read `autorun.inf`. Each takes the one it understands and ignores the other — the old Mac/PC hybrid-disc trick. **Nothing about the Windows disc changes.**

**347 lines across 6 files, 188 of them tests.**

## What does not carry over, and cannot

The menu. Linux disabled autorun for removable media deliberately — no desktop will run a program off a disc you inserted. `menu.hta` sits there unopened and the games get installed from the folders by hand. The icon and the label are the half that travels, and they're the half people actually notice.

This is also why the icon is written twice: `gvfs` turns `IconFile=` into a `GFileIcon` and hands it to GdkPixbuf, whose `.ico` support is for favicons rather than the seven-frame icon Explorer wants. Both are built from the same source image, so they can't disagree.

## Two bugs found by testing, not by reading

**A BOM would have silently broken it.** PowerShell 5.1's `-Encoding UTF8` writes one, and GKeyFile reads a BOM as part of the first group name — so the group stops being `Volume Info`, every key belongs to a group nothing looks for, and the file parses to nothing with no error anywhere. Written with an explicit no-BOM UTF-8 encoder, and there's a test asserting the first byte is `[`.

**The backslash escaping was wrong on the first attempt.** A GKeyFile value escapes with backslashes, so a lone one eats the next character. I wrote `-replace '\','\\'` and it produced **four** backslashes, because in a .NET regex *replacement* a backslash is an ordinary character rather than an escape. `String.Replace` instead. The wrong version is kept as a test.

## Verified end to end, not just asserted

Every claim above is a claim about somebody else's parser, so I went and asked it:

1. Built a real ISO with the new code
2. Pulled `.xdg-volume-info` back out of the **UDF image** with 7-Zip — 55 bytes, no BOM, LF endings
3. Parsed it under WSL with **GLib's own `GKeyFile`** — the parser gvfs actually calls:

```
Name     = 'The Witcher'
IconFile = 'TheWitcher.png'
icon file present on the disc: True
icon is a real PNG: True
```

The ISO-content test asserts against the **image**, not the staging folder, on purpose: ISO 9660 forbids a leading dot, and a filesystem that quietly renamed the file would leave the disc nameless on Linux while everything on Windows still looked perfect. DiscWright writes UDF only, which allows it — this is what proves that still holds.

The repo's own test now prefers GLib and falls back to `configparser`, skipping entirely where neither is reachable.

**385 logic tests, 0 failures** (was 374). Window suite not run — no UI changed. PSScriptAnalyzer 0 errors, ASCII gate clean.

## Not proven

GdkPixbuf actually rendering the PNG — this WSL has no GUI stack, so `gi.require_version("GdkPixbuf")` fails. The file is a valid PNG by magic bytes and PNG is GdkPixbuf's baseline format, but I did not watch a file manager draw it. Putting a burned disc in a real Linux desktop is the check I can't do from here.

## Notes

- **This will conflict with #48** — both add a `## [Unreleased]` section to `CHANGELOG.md`. Trivial to resolve, whichever merges second.
- The roadmap's Linux entry is rewritten with the measured split: **~37% portable logic, 46% WinForms + ISO helper, 17% menu template** — and the note that even the portable third is PowerShell, so a Linux tool retranslates it rather than reusing it.
- `discwright-linux` stays empty for now. This is the half that needed no new tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)