### PR TITLE
chore(release): 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Whil
 version stays below 1.0.0, the project file format and the on-disc layout may change
 between minor versions.
 
-## [Unreleased]
+## [0.6.0] — 2026-09-10
 
 ### Added
 
@@ -565,7 +565,8 @@ First public release.
 - `extras/DiscLabel.ps1`, a parked printable disc-face generator, kept out of the app to
   keep the tool to one job.
 
-[Unreleased]: https://github.com/lazardjokovic/discwright/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/lazardjokovic/discwright/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/lazardjokovic/discwright/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/lazardjokovic/discwright/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/lazardjokovic/discwright/compare/v0.4.4...v0.5.0
 [0.4.4]: https://github.com/lazardjokovic/discwright/compare/v0.4.3...v0.4.4

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -61,7 +61,7 @@ $PROJECT_FILE = 'discproject.json'
 # this cannot quietly drift a release behind. Shown in the title bar and the log,
 # and written into every project file - a bug report that comes with a project
 # file then says for itself which version built the disc.
-$APP_VERSION  = '0.5.1'
+$APP_VERSION  = '0.6.0'
 
 # =================== SMALL HELPERS ===================
 

--- a/docs/MANUAL-CHECKS.md
+++ b/docs/MANUAL-CHECKS.md
@@ -1,6 +1,6 @@
 # Manual checks before a release
 
-The automated suite is 385 logic tests and 76 window tests, and it runs in about
+The automated suite is 394 logic tests and 76 window tests, and it runs in about
 four minutes:
 
 ```


### PR DESCRIPTION
Stamps 0.6.0.

**Minor, not patch.** The changelog preamble reserves a minor bump below 1.0.0 for a change to the project file format or the on-disc layout. This release changes **both** — the disc can now carry `.xdg-volume-info` and a `.png` icon, and the project file moves to schema 7 to remember whether it should.

| | |
| --- | --- |
| `$APP_VERSION` | `0.5.1` → `0.6.0` |
| `CHANGELOG.md` | `[Unreleased]` stamped `[0.6.0] — 2026-09-10`, link refs updated |
| `docs/MANUAL-CHECKS.md` | test counter 385 → 394 |

No test hardcodes a version, so the bump could not break one — checked before committing rather than after.

**Local run on this branch: 394 logic, 76 window, 0 failures.**

Once this merges and `v0.6.0` is tagged, the `package` job attaches `DiscWright-0.6.0.zip` and `DiscWright-0.6.0-setup.exe` to the release and prints the installer's SHA256 — the value `packaging/winget/New-WingetManifest.ps1` needs, and the reason the winget submission has been waiting on a tag.

Still to do after the tag: bump `site/index.html` on discwright.com, and pull the second checkout at `C:\Users\lazar\DiscWright` that the taskbar pin launches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)