### PR TITLE
fix(ci): the tag build creates a release when there is not one

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -259,7 +259,27 @@ jobs:
           # Paths arrive as environment variables rather than being pasted into
           # the script, for the same reason GITHUB_REF_NAME is read that way in
           # version-matches-tag below: they stay data instead of becoming code.
-          gh release upload $env:GITHUB_REF_NAME $env:ZIP $env:SETUP --clobber
+          $tag = $env:GITHUB_REF_NAME
+
+          # Pushing a tag does not create a release, and `gh release upload` on a
+          # tag with no release fails with "release not found" - which is how
+          # 0.6.0 came out with both artifacts built and neither attached. So the
+          # release is created here when it is missing.
+          #
+          # As a DRAFT, deliberately. These notes are written by hand after
+          # looking at what actually shipped, and a tag push should not publish
+          # a release with no notes on it. The draft gives the artifacts
+          # somewhere to go; a person writes the notes and presses publish.
+          gh release view $tag --json tagName *> $null
+          if ($LASTEXITCODE -ne 0) {
+              Write-Host "No release for $tag yet - creating a draft to attach to."
+              gh release create $tag --draft --verify-tag --title $tag --notes "Draft - release notes not written yet."
+              if ($LASTEXITCODE -ne 0) { Write-Host "::error::could not create a draft release for $tag"; exit 1 }
+          }
+
+          gh release upload $tag $env:ZIP $env:SETUP --clobber
+          if ($LASTEXITCODE -ne 0) { Write-Host "::error::could not attach the artifacts to $tag"; exit 1 }
+
           Write-Host "installer sha256: $env:SHA"
 
   # A version constant maintained by hand drifts, because bumping it is a step

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -42,7 +42,10 @@ user picks.
 
 1. Tag as usual. The `package` job in `.github/workflows/checks.yml` builds both
    artifacts, attaches them to the release, and prints the installer's SHA256 in
-   the run summary.
+   the run summary. If no release exists for the tag yet it creates one as a
+   **draft** first - pushing a tag does not create a release, and 0.6.0 shipped
+   with both artifacts built and neither attached because of it. Write the notes
+   on the draft and publish it.
 2. Build the manifests with that hash:
 
    ```powershell


### PR DESCRIPTION
## What went wrong on 0.6.0

Pushing `v0.6.0` ran the tag build. `powershell` passed, `version-matches-tag` passed, both artifacts built correctly — and then:

```
release not found
installer sha256: BD23E16DC8F04FD78659787596823692C61E9D63F7BF4568B8A451FA8FC750A8
##[error]Process completed with exit code 1.
```

**Pushing a tag does not create a release.** `gh release upload` needs one to exist. So 0.6.0 was tagged with both artifacts built and neither attached — I created the release by hand and uploaded the exact bytes CI produced, verifying the installer's SHA256 matched what the run reported.

Two separate faults, both fixed here.

## 1. No release to attach to

The step now creates one when it is missing, **as a draft**. Release notes here are written by hand after looking at what shipped, and a tag push should not publish a release with nothing on it. The draft gives the artifacts somewhere to go; a person writes the notes and presses publish.

## 2. A failed upload looked like a successful one

Note the order in the log above — `release not found`, then the hash printed anyway. The step ran on past the failure and only failed at the end because PowerShell propagated the last exit code. Both `gh` calls now check `$LASTEXITCODE` and emit `::error::` with what they were trying to do.

## Testing

This cannot be exercised on a PR — the whole step is behind `if: startsWith(github.ref, 'refs/tags/v')`. What this run proves is that the workflow still parses and the non-tag path is unaffected; the tag path gets proven at v0.6.1 or v0.7.0, whichever comes first.

I checked the YAML parses and the `Attach to the release` step is still guarded by the tag condition, so it stays inert on PRs and pushes to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)