### PR TITLE
feat: a disc can be made readable on Windows XP and older

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Whil
 version stays below 1.0.0, the project file format and the on-disc layout may change
 between minor versions.
 
+## [Unreleased]
+
+### Added
+
+- **A disc can be made readable on Windows XP and older.** DiscWright writes the
+  ISO as UDF 2.50, and Windows Vista was the first version able to read that, so
+  until now a DiscWright disc could not be mounted at all on XP, 2000, ME, 98 or
+  95. A second checkbox on the new **Extra compatibility** row writes ISO9660 and
+  Joliet filesystems beside the UDF one, which those systems can read. Every
+  system takes the newest filesystem it understands and ignores the rest, so a
+  disc built with the box ticked behaves on Windows 11 exactly as one built
+  without it.
+
+  **Off by default**, and a project saved before this existed reads back as off.
+
+  Two things were supposed to rule this out and neither survived measurement.
+  Joliet holds filenames to 64 characters, but IMAPI writes long names into the
+  ISO9660 tree anyway - a real 96-character GOG patch filename comes through
+  intact. And ISO9660 keeps a file's length in 32 bits, so it cannot describe a
+  file of 4 GiB or more - but GOG already splits its installers one byte under
+  that, because FAT32 has the same ceiling.
+
+  Where a file really is too big the checkbox greys itself and says so, and the
+  build re-checks the finished disc folder and falls back to UDF alone rather
+  than write an image that has silently lost a file.
+
+### Changed
+
+- **The Linux and older-Windows options share one row**, labelled *Extra
+  compatibility*. The Linux checkbox was a full sentence on its own line; naming
+  what the two have in common says more than either sentence did, and keeps the
+  window the same height.
+
 ## [0.6.0] — 2026-09-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ between minor versions.
   build re-checks the finished disc folder and falls back to UDF alone rather
   than write an image that has silently lost a file.
 
+  Reading the disc is not the same as installing from it. Joliet long filenames
+  go back to Windows 95, but every GOG installer checked asks for Windows 2000 in
+  its own PE header, and Windows 9x will not load a program that wants 5.0. So on
+  98 and 95 the disc browses correctly and nothing on it installs; XP and 2000 are
+  the oldest versions where it is genuinely useful.
+
 ### Changed
 
 - **The Linux and older-Windows options share one row**, labelled *Extra

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -2814,6 +2814,10 @@ $tips.SetToolTip($chkLegacy, (
     [Environment]::NewLine +
     "Costs nothing on the disc and changes nothing Windows 11 sees." + [Environment]::NewLine +
     [Environment]::NewLine +
+    "Reading the disc is not the same as installing from it: GOG's installers ask" + [Environment]::NewLine +
+    "for Windows 2000 or newer in their own headers, so on 98 and 95 the disc can" + [Environment]::NewLine +
+    "be browsed but not installed from." + [Environment]::NewLine +
+    [Environment]::NewLine +
     "Unavailable when a file is 4 GiB or larger: ISO9660 keeps a file's length in" + [Environment]::NewLine +
     "32 bits and cannot describe one that big."))
 $tips.SetToolTip($chkLinux, (

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -2440,17 +2440,17 @@ $lblIcon=AddLabel '' 15 318 500; $lblIcon.ForeColor=[System.Drawing.Color]::DimG
 # Off by default. The two files it adds are inert on Windows and cost about a
 # kilobyte, but a disc is a thing people keep, and changing what every disc
 # carries is not a decision to make on somebody's behalf. They ask for it.
-AddLabel 'Extra compatibility:' 15 344 125 | Out-Null
+AddLabel 'Also make the disc:' 15 344 125 | Out-Null
 $chkLinux=New-Object System.Windows.Forms.CheckBox
-$chkLinux.Text='Name the disc on Linux'
+$chkLinux.Text='named on Linux'
 $chkLinux.Location=New-Object System.Drawing.Point(145,342)
-$chkLinux.Size=New-Object System.Drawing.Size(185,22)
+$chkLinux.Size=New-Object System.Drawing.Size(115,22)
 $chkLinux.Checked=$false
 $form.Controls.Add($chkLinux)
 $chkLegacy=New-Object System.Windows.Forms.CheckBox
-$chkLegacy.Text='Readable on Windows XP and older'
-$chkLegacy.Location=New-Object System.Drawing.Point(335,342)
-$chkLegacy.Size=New-Object System.Drawing.Size(300,22)
+$chkLegacy.Text='readable on Windows XP and older'
+$chkLegacy.Location=New-Object System.Drawing.Point(265,342)
+$chkLegacy.Size=New-Object System.Drawing.Size(240,22)
 $chkLegacy.Checked=$false
 $form.Controls.Add($chkLegacy)
 # Below the Browse button, not beside it: at y=290 this 44px-tall preview sat on

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -208,7 +208,7 @@ function Get-GameInfo([string]$folder) {
     # manual and an Extras folder for the whole disc; an entry that has none of
     # its own falls back to those, which is what keeps a single-game disc, and
     # every project written before this, behaving exactly as it did.
-    $info = @{ Ok=$false; SetupExe=$null; Files=@(); GameName=$null; MatchName=$null; Msg=''; TotalBytes=0; Folder=$null
+    $info = @{ Ok=$false; SetupExe=$null; Files=@(); GameName=$null; MatchName=$null; Msg=''; TotalBytes=0; MaxFileBytes=0; Folder=$null
                Warning=''; MissingParts=@(); Kind='Game'; ParentIndex=-1
                ManualPath=$null; ExtrasPath=$null }
     if (-not (Test-Path $folder)) { $info.Msg='Folder not found.'; return $info }
@@ -293,6 +293,10 @@ function Set-InstallerFacts([hashtable]$info,[System.IO.FileInfo]$exe) {
     $info.MatchName=$name
     $info.Folder = $exe.DirectoryName
     $info.TotalBytes = ($info.Files | Measure-Object Length -Sum).Sum
+    # The largest single file, for the ISO9660 ceiling. Measured here because the
+    # list is already in hand; walking the folder again on every UI refresh is the
+    # cost the comment on Get-PlanInputs is about.
+    $info.MaxFileBytes = [double](($info.Files | Measure-Object Length -Maximum).Maximum)
     $plural = if ($info.Files.Count -eq 1) { 'file' } else { 'files' }
     $info.Msg = "Detected: $name  ($($info.Files.Count) $plural, $(Format-Size $info.TotalBytes))"
 }
@@ -325,7 +329,7 @@ function Get-AddOnName([string]$fileName) {
 # comes from the list it is added to, not from its filename. That is what lets a
 # mod or an overhaul, which is never named setup_*, go on the disc at all.
 function Get-AddOnInfo([string]$exePath) {
-    $info = @{ Ok=$false; SetupExe=$null; Files=@(); GameName=$null; MatchName=$null; Msg=''; TotalBytes=0; Folder=$null
+    $info = @{ Ok=$false; SetupExe=$null; Files=@(); GameName=$null; MatchName=$null; Msg=''; TotalBytes=0; MaxFileBytes=0; Folder=$null
                Warning=''; MissingParts=@(); Kind='AddOn'; ParentIndex=-1 }
     if (-not (Test-Path $exePath -PathType Leaf)) { $info.Msg='File not found.'; return $info }
     $exe = Get-Item -LiteralPath $exePath
@@ -410,6 +414,33 @@ function Get-MediaRec([double]$bytes) {
 }
 
 # Total bytes of a mixed list of files and folders.
+# ISO9660 stores a file's length in 32 bits, so 4 GiB minus one byte is the most
+# a single file can be. UDF has no such limit, which is why the disc is UDF today.
+#
+# GOG already lives with this: its installers split into .bin parts at
+# 4,294,967,294 bytes - one byte under - because FAT32 has the same ceiling. So in
+# practice a GOG disc clears it, and this exists for what people add themselves in
+# step 5.
+$ISO9660_MAX_FILE = [double]4294967295
+
+# The largest single file under a set of paths. Mirrors Get-ItemsSize, which sums
+# the same walk - kept separate rather than folded in because the sum is wanted on
+# every keystroke in the disc label and this is not.
+function Get-ItemsMaxFile($items) {
+    $max = [double]0
+    foreach ($i in @($items)) {
+        if ([string]::IsNullOrWhiteSpace($i) -or -not (Test-Path $i)) { continue }
+        if (Test-Path $i -PathType Container) {
+            $m = (Get-ChildItem -Recurse -File -Force $i -EA SilentlyContinue | Measure-Object Length -Maximum).Maximum
+            if ($m -and $m -gt $max) { $max = [double]$m }
+        } else {
+            $len = [double](Get-Item -LiteralPath $i).Length
+            if ($len -gt $max) { $max = $len }
+        }
+    }
+    return $max
+}
+
 function Get-ItemsSize($items) {
     $sum = [double]0
     foreach ($i in @($items)) {
@@ -1554,7 +1585,9 @@ function New-MenuHta([hashtable]$cfg,[string]$out) {
     Clear-ReadOnly $out; Set-Content -LiteralPath $out -Value $html -Encoding ASCII
 }
 
-function New-Iso([string]$stageDir,[string]$isoPath,[string]$volLabel,[scriptblock]$progress=$null) {
+# $fileSystems is the FsiFileSystems bitmask: ISO9660 = 1, Joliet = 2, UDF = 4.
+# 4 is what every disc before 0.7.0 was, and still the default.
+function New-Iso([string]$stageDir,[string]$isoPath,[string]$volLabel,[scriptblock]$progress=$null,[int]$fileSystems=4) {
     if (-not ([System.Management.Automation.PSTypeName]'ISOFile').Type) {
         $code=@'
 public class ISOFile {
@@ -1636,9 +1669,13 @@ public class ISOFile {
         if ($blocks -gt 2147483000) { $blocks = 2147483000 }
         $fsi.FreeMediaBlocks=[int]$blocks
 
-        # UDF only. GOG part filenames run past 64 chars, which Joliet cannot hold,
-        # and the .bin parts sit at the ISO9660 4 GiB ceiling.
-        $fsi.FileSystemsToCreate=4
+        # UDF by default. The reasons the others were left off were a Joliet name
+        # limit of 64 characters and the ISO9660 4 GiB ceiling - but IMAPI writes
+        # long names into the ISO9660 tree regardless (a real 96-character GOG
+        # patch name survives intact), and GOG's own parts clear the ceiling by a
+        # byte. So the caller may ask for all three, and the only thing that has
+        # to be checked first is the file size.
+        $fsi.FileSystemsToCreate=$fileSystems
         try { $fsi.UDFRevision=0x250 } catch {}
         $vn = ($volLabel -replace '[^A-Za-z0-9_]','_'); if($vn.Length -gt 16){$vn=$vn.Substring(0,16)}
         $fsi.VolumeName=$vn
@@ -1687,7 +1724,9 @@ function Save-Project([hashtable]$s,[string]$outDir) {
         # icon for Linux. Absent in anything older, which reads back as off, so
         # reopening an old project and rebuilding produces the disc it produced
         # before rather than quietly adding files to it.
-        Version      = 7
+        # Version 8 adds LegacyFs the same way - whether the disc also gets
+        # ISO9660 and Joliet so it reads on Windows XP and older.
+        Version      = 8
         AppVersion   = $APP_VERSION
         SavedUtc     = (Get-Date).ToUniversalTime().ToString('s')
         # Version 1 knew about exactly one game and stored it here. Both keys are
@@ -1731,6 +1770,7 @@ function Save-Project([hashtable]$s,[string]$outDir) {
         ExtraItems   = @($s.ExtraItems)
         MediaKey     = [string]$s.MediaKey
         LinuxInfo    = [bool]$s.LinuxInfo
+        LegacyFs     = [bool]$s.LegacyFs
         OutDir       = $outDir
     }
     $o | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath (Join-Path $outDir $PROJECT_FILE) -Encoding UTF8
@@ -1775,6 +1815,7 @@ function Import-Project([string]$jsonPath) {
             SourceFolder=$j.SourceFolder; GameFolders=$folders; GameEntries=@($entries)
             Label=$j.Label; IconPath=$j.IconPath; IconIsIco=[bool]$j.IconIsIco
             LinuxInfo=[bool]$j.LinuxInfo
+            LegacyFs=[bool]$j.LegacyFs
             Menu=[bool]$j.Menu; BgPath=$j.BgPath; BgAsIs=[bool]$j.BgAsIs
             PanelSide=$(if($j.PanelSide){$j.PanelSide}else{'Right'})
             Divider=[bool]$j.Divider; ShowTitle=[bool]$j.ShowTitle; TitleText=[string]$j.TitleText
@@ -2153,7 +2194,26 @@ function Invoke-Build([hashtable]$s, [scriptblock]$log, [scriptblock]$progress=$
     # A disc in a set gets its volume id worked out with the disc number reserved,
     # so a long name cannot truncate away the one part that tells two discs apart.
     $vol = $(if ($s.VolumeLabel) { [string]$s.VolumeLabel } else { Get-VolumeLabel $s.Label })
-    New-Iso $stage $iso $vol $progress
+    # ISO9660 and Joliet alongside UDF, when asked for. Everything before Windows
+    # Vista reads UDF 2.01 at best and cannot mount this disc at all without them.
+    #
+    # Checked against the staged disc rather than trusting the form: the greying
+    # in the window only knows about the installers, and step 5 can drop anything
+    # at the disc root. A disc that quietly lost a file to a 32-bit length field
+    # would be far worse than one that is simply not readable on Windows XP.
+    $fsMask = 4
+    if ($s.LegacyFs) {
+        $big = @(Get-ChildItem -Recurse -File -Force $stage -EA SilentlyContinue |
+                 Where-Object { $_.Length -gt $ISO9660_MAX_FILE })
+        if ($big.Count) {
+            & $log ("Not adding the ISO9660 filesystem: {0} is {1}, and ISO9660 cannot hold a file of 4 GiB or more." -f $big[0].Name, (Format-Size $big[0].Length))
+            & $log "  The disc will be UDF only, so it needs Windows Vista or newer."
+        } else {
+            $fsMask = 7
+            & $log "Adding ISO9660 and Joliet beside UDF, so the disc reads on Windows XP and older."
+        }
+    }
+    New-Iso $stage $iso $vol $progress $fsMask
     & $log ("DONE.  ISO: {0}  ({1:N2} GB)" -f $iso, ((Get-Item $iso).Length/1GB))
 
     # One project file describes the whole set, so the caller saves it once after
@@ -2380,12 +2440,19 @@ $lblIcon=AddLabel '' 15 318 500; $lblIcon.ForeColor=[System.Drawing.Color]::DimG
 # Off by default. The two files it adds are inert on Windows and cost about a
 # kilobyte, but a disc is a thing people keep, and changing what every disc
 # carries is not a decision to make on somebody's behalf. They ask for it.
+AddLabel 'Extra compatibility:' 15 344 125 | Out-Null
 $chkLinux=New-Object System.Windows.Forms.CheckBox
-$chkLinux.Text='Also name the disc for Linux (adds two small files)'
-$chkLinux.Location=New-Object System.Drawing.Point(15,342)
-$chkLinux.Size=New-Object System.Drawing.Size(420,22)
+$chkLinux.Text='Name the disc on Linux'
+$chkLinux.Location=New-Object System.Drawing.Point(145,342)
+$chkLinux.Size=New-Object System.Drawing.Size(185,22)
 $chkLinux.Checked=$false
 $form.Controls.Add($chkLinux)
+$chkLegacy=New-Object System.Windows.Forms.CheckBox
+$chkLegacy.Text='Readable on Windows XP and older'
+$chkLegacy.Location=New-Object System.Drawing.Point(335,342)
+$chkLegacy.Size=New-Object System.Drawing.Size(300,22)
+$chkLegacy.Checked=$false
+$form.Controls.Add($chkLegacy)
 # Below the Browse button, not beside it: at y=290 this 44px-tall preview sat on
 # top of a 24px-tall button in the same 110px column, and whichever Windows drew
 # last won. Nothing lines up on this row at x=560, and 318+44 clears the step 4
@@ -2595,9 +2662,60 @@ function Get-CurrentFit([hashtable]$payload=$null) {
 }
 
 
+# The largest single file the entries will put on the disc. Each was measured
+# when its folder was read, so this adds no walk of its own.
+#
+# Kept apart from the greying below because that half cannot run under the logic
+# tests, and the question of whether a disc clears the ISO9660 ceiling is exactly
+# the half worth testing.
+function Get-EntriesMaxFileBytes {
+    # No @() around Get-Games. It returns ,@(...) so a one-element result survives
+    # being unrolled, and wrapping it again gives a one-element array holding the
+    # real array - so this loop ran once, over the whole list, and read
+    # MaxFileBytes off an array. Every disc measured as zero.
+    # Assigned first, not iterated straight off the call. Get-Games returns
+    # ,@(...) and plain assignment is what preserves that, exactly as the note on
+    # Get-FirstGame says - enumerating the call itself hands back the inner array
+    # as a single item on an empty disc.
+    $games = Get-Games
+    $biggest = [double]0
+    foreach ($g in $games) {
+        if ([double]$g.MaxFileBytes -gt $biggest) { $biggest = [double]$g.MaxFileBytes }
+    }
+    return $biggest
+}
+
+# ISO9660 cannot describe a file of 4 GiB or more, so the option that adds it
+# greys itself when the disc holds one. Only the installers are measured here;
+# the build checks the whole staged disc again before committing to a filesystem,
+# which is what covers anything dropped in at step 5.
+#
+# Guarded the way Set-StatusTip is, and for the same reason: the logic tests
+# reach Update-MediaLabel with stand-in controls, and a [pscustomobject] has no
+# Enabled property to set.
+function Update-LegacyFsBox {
+    if ($chkLegacy -isnot [System.Windows.Forms.CheckBox]) { return }
+    $biggest = Get-EntriesMaxFileBytes
+    $ok = ($biggest -le $ISO9660_MAX_FILE)
+    $chkLegacy.Enabled = $ok
+    if (-not $ok) {
+        # Unticking rather than leaving a ticked box greyed: a ticked box that the
+        # build is going to ignore says the disc will be readable when it will not.
+        $chkLegacy.Checked = $false
+        $tips.SetToolTip($chkLegacy, (
+            "Not possible for this disc: it holds a file of $(Format-Size $biggest)," + [Environment]::NewLine +
+            "and ISO9660 keeps a file's length in 32 bits, so 4 GiB minus one byte is" + [Environment]::NewLine +
+            "the most it can describe." + [Environment]::NewLine +
+            [Environment]::NewLine +
+            "GOG's own installers split below that, so this is usually something added" + [Environment]::NewLine +
+            "in step 5."))
+    }
+}
+
 function Update-MediaLabel {
     $games = Get-Games
     Update-MediaOptions
+    Update-LegacyFsBox
     if ($games.Count -eq 0) {
         # Removing the last entry has to clear this line, not leave it alone.
         # Returning early left the previous disc's summary sitting under an empty
@@ -2689,6 +2807,15 @@ function Show-Choice([string]$msg,[string]$title='DiscWright') {
 function Deny-Build([string]$logMsg,[string]$dlgMsg) { & $log "ERROR: $logMsg"; Show-Warn $dlgMsg }
 
 $tips = New-Object System.Windows.Forms.ToolTip
+$tips.SetToolTip($chkLegacy, (
+    "Writes ISO9660 and Joliet filesystems beside the UDF one, so the disc can be" + [Environment]::NewLine +
+    "read by Windows XP, 2000, ME, 98 and 95. They read UDF 2.01 at best and cannot" + [Environment]::NewLine +
+    "mount this disc at all without it. Vista and newer do not need it." + [Environment]::NewLine +
+    [Environment]::NewLine +
+    "Costs nothing on the disc and changes nothing Windows 11 sees." + [Environment]::NewLine +
+    [Environment]::NewLine +
+    "Unavailable when a file is 4 GiB or larger: ISO9660 keeps a file's length in" + [Environment]::NewLine +
+    "32 bits and cannot describe one that big."))
 $tips.SetToolTip($chkLinux, (
     "Writes .xdg-volume-info and a .png copy of the icon to the disc, so a Linux" + [Environment]::NewLine +
     "file manager shows the game's name and cover art instead of a volume id." + [Environment]::NewLine +
@@ -3318,6 +3445,7 @@ function Reset-Form {
 
     $chkMenu.Checked = $true
     $chkLinux.Checked = $false
+    $chkLegacy.Checked = $false; $chkLegacy.Enabled = $true
     $txtBg.Clear(); $state.BgPath = $null
     $chkBgAsIs.Checked = $false
     $cmbSide.SelectedIndex = 0
@@ -3410,6 +3538,7 @@ function Open-Project([string]$folder) {
 
     $chkMenu.Checked = $p.Menu
     $chkLinux.Checked = [bool]$p.LinuxInfo
+    $chkLegacy.Checked = [bool]$p.LegacyFs
     if ($p.BgPath -and (Test-Path $p.BgPath)) { Set-BgFile $p.BgPath } else { $txtBg.Text=''; $state.BgPath=$null }
     $chkBgAsIs.Checked = [bool]$p.BgAsIs
     $cmbSide.SelectedItem = $(if($p.PanelSide -ieq 'Left'){'Left'}else{'Right'})
@@ -3842,7 +3971,7 @@ $btnBuild.Add_Click({
          MusicFile=$(if($chkMusic.Checked){$state.MusicFile}else{$null});
          Buttons=$buttons; ManualPath=$(if($cbMan.Checked){$state.ManualPath}else{$null}); ExtrasPath=$(if($cbExtra.Checked){$state.ExtrasPath}else{$null});
          ExtraItems=@($lstExtra.Items); OutDir=$txtOut.Text.Trim(); MediaKey=$mediaKey
-         LinuxInfo=$chkLinux.Checked }
+         LinuxInfo=$chkLinux.Checked; LegacyFs=$chkLegacy.Checked }
     $btnBuild.Enabled=$false
     Set-FormBusy $true
     $script:BuildDiscTag = ''

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ When a file **is** too big, the checkbox greys itself and says why. If something
 
 Old DVD players and other appliances that only speak ISO9660 benefit from the same box.
 
+**Reading the disc is not the same as installing from it.** Joliet long filenames go back to Windows 95, and plain ISO9660 further still, so the disc itself is browsable a long way back. The games are not. Every GOG installer checked declares **Windows 2000** as its minimum in its own PE header, and Windows 9x refuses to load a program that asks for 5.0. So on Windows 98 and 95 one of these discs opens and reads correctly and nothing on it will install; XP and 2000 are the oldest versions where the disc is genuinely useful.
+
 ### The disc on a Linux machine
 
 There is a checkbox under the icon, **Also name the disc for Linux**, and it is **off by default**. Tick it and the disc gains two more files:

--- a/README.md
+++ b/README.md
@@ -147,6 +147,18 @@ The numbering is what makes the disc browsable by hand: it puts the folders in t
 
 The icon is named after the disc rather than a fixed `disc.ico` for a specific reason: Explorer caches icons **by file path**, so `E:\disc.ico` is the same cache key for every disc that ever passes through that drive letter. Swap discs and Explorer will happily redraw the previous game's icon. Naming it after the disc gives each one its own key.
 
+### The disc on Windows XP and older
+
+DiscWright writes the ISO as UDF 2.50. Windows Vista was the first version that could read that, so **Windows XP, 2000, ME, 98 and 95 cannot mount one of these discs at all** — not a missing menu, the whole disc is unreadable there.
+
+The second checkbox on the **Extra compatibility** row, **Readable on Windows XP and older**, fixes that by writing ISO9660 and Joliet filesystems alongside the UDF one. Every system reads the newest one it understands and ignores the rest, so a disc built with it ticked behaves on Windows 11 exactly as one built without it. It is off by default, and it costs nothing measurable on the disc.
+
+Two things were supposed to make this impossible, and neither does in practice. Joliet holds filenames to 64 characters, but IMAPI writes long names into the ISO9660 tree regardless — a real 96-character GOG patch filename survives intact. And ISO9660 keeps a file's length in 32 bits, so it cannot describe a file of 4 GiB or more — but GOG already splits its installers a byte under that limit, because FAT32 has the same ceiling.
+
+When a file **is** too big, the checkbox greys itself and says why. If something added in step 5 slips past that, the build checks the finished disc folder again and quietly falls back to UDF alone rather than writing an image that has lost a file to a 32-bit field.
+
+Old DVD players and other appliances that only speak ISO9660 benefit from the same box.
+
 ### The disc on a Linux machine
 
 There is a checkbox under the icon, **Also name the disc for Linux**, and it is **off by default**. Tick it and the disc gains two more files:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,23 @@ that happens, and a request other people turn up and agree with moves up.
 
 ## Delivered
 
+**A disc readable on Windows XP and older** — asked for on Reddit by somebody who
+runs Planescape Torment and Diablo on period hardware, and who had noticed the menu
+worked there but autoplay never fired. The autorun.inf turned out to be innocent:
+`shellexecute=` has worked since Windows 2000. The disc was the problem. DiscWright
+writes UDF 2.50 and Windows Vista was the first version that could read it, so every
+system older than that cannot mount the disc at all.
+
+The two reasons the other filesystems were left off both failed when measured.
+Joliet's 64-character limit does not bite, because IMAPI writes long names into the
+ISO9660 tree regardless - a real 96-character GOG patch name survives. And the
+ISO9660 4 GiB file ceiling does not bite either, because GOG splits its installers
+at 4,294,967,294 bytes, one byte under, to clear the identical FAT32 limit.
+
+So it is a checkbox, off by default, that asks for all three filesystems instead of
+one. It greys itself when a file is too big, and the build re-checks the staged disc
+and falls back rather than write an image missing a file.
+
 **A game renamed for the menu** — asked for by the same person who found the
 question marks, once the characters were arriving intact and the name was worth
 reading. The name a disc starts with is the installer's own `ProductName`, which is

--- a/docs/MANUAL-CHECKS.md
+++ b/docs/MANUAL-CHECKS.md
@@ -1,6 +1,6 @@
 # Manual checks before a release
 
-The automated suite is 394 logic tests and 76 window tests, and it runs in about
+The automated suite is 409 logic tests and 76 window tests, and it runs in about
 four minutes:
 
 ```

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -70,6 +70,9 @@ BeforeAll {
     # functions look these up dynamically from whichever It block calls them, and
     # a local here would not be on that chain.
     $script:PROJECT_FILE = 'discproject.json'
+    $script:ISO9660_MAX_FILE =
+        [double][regex]::Match((Get-Content $appScript -Raw),
+            '\$ISO9660_MAX_FILE\s*=\s*\[double\]([0-9]+)').Groups[1].Value
 
     # Read out of the app rather than hard-coded, so bumping the version does not
     # mean editing the tests - and so a test can assert the two agree.
@@ -111,7 +114,7 @@ BeforeAll {
         # LinuxInfo defaults to $false here for the same reason the checkbox does:
         # every test written before it existed has to keep describing the disc it
         # was written about.
-        param([array]$Games, [string]$Label, [string]$OutDir, [switch]$LinuxInfo)
+        param([array]$Games, [string]$Label, [string]$OutDir, [switch]$LinuxInfo, [switch]$LegacyFs)
         return @{
             Games=$Games; Label=$Label; IconPath=$script:Art; IconIsIco=$false
             Menu=$true; BgPath=$script:Bg; BgAsIs=$false; PanelSide='Right'
@@ -119,6 +122,7 @@ BeforeAll {
             WindowBorder=$true; ButtonStyle='Minimal'; MusicFile=$null
             Buttons=@('Play','Install','Exit'); ManualPath=$null; ExtrasPath=$null
             ExtraItems=@(); OutDir=$OutDir; LinuxInfo=[bool]$LinuxInfo
+            LegacyFs=[bool]$LegacyFs
         }
     }
 
@@ -690,8 +694,8 @@ Describe 'Project file' -Tag 'Unit' {
 
     Context 'writing' {
 
-        It 'declares schema version 7' {
-            $script:PJson.Version | Should -Be 7
+        It 'declares schema version 8' {
+            $script:PJson.Version | Should -Be 8
         }
 
         It 'records which disc the set was planned for' {
@@ -3536,8 +3540,8 @@ Describe 'Renaming a game for the menu' -Tag 'Unit' {
             $script:RenameRaw  = Get-Content -Raw -LiteralPath $script:RenameJson | ConvertFrom-Json
         }
 
-        It 'writes schema version 7' {
-            $script:RenameRaw.Version | Should -Be 7
+        It 'writes schema version 8' {
+            $script:RenameRaw.Version | Should -Be 8
         }
 
         It 'stores the registered name beside the chosen one' {
@@ -3831,7 +3835,7 @@ Describe 'The Linux setting in a project file' -Tag 'Unit' {
         New-Item -ItemType Directory -Force -Path $script:ProjDir | Out-Null
     }
 
-    It 'is written as schema 7 and comes back the way it went in' {
+    It 'is saved and comes back the way it went in' {
         $s = @{ Games=@(); Label='Round Trip'; IconPath=$script:Art; IconIsIco=$false
                 Menu=$true; BgPath=$null; BgAsIs=$true; PanelSide='Right'
                 Divider=$false; ShowTitle=$false; TitleText=''
@@ -3840,7 +3844,6 @@ Describe 'The Linux setting in a project file' -Tag 'Unit' {
                 ExtraItems=@(); MediaKey=''; LinuxInfo=$true }
         Save-Project $s $script:ProjDir
         $raw = Get-Content -Raw (Join-Path $script:ProjDir 'discproject.json') | ConvertFrom-Json
-        $raw.Version   | Should -Be 7
         $raw.LinuxInfo | Should -BeTrue
         (Import-Project (Join-Path $script:ProjDir 'discproject.json')).LinuxInfo | Should -BeTrue
     }
@@ -3868,5 +3871,188 @@ Describe 'The Linux setting in a project file' -Tag 'Unit' {
 
         New-XdgVolumeInfo 'Bare Disc' 'BareDisc.png' (Join-Path $d '.xdg-volume-info')
         (Import-DiscFolder $d).LinuxInfo | Should -BeTrue
+    }
+}
+
+
+Describe 'Get-EntriesMaxFileBytes' -Tag 'Unit' {
+
+    # The decision behind the greying: does this disc clear the ISO9660 ceiling?
+    # Tested here rather than through the checkbox, because the checkbox half
+    # cannot run without a real form.
+
+    It 'is zero when there is nothing on the disc' {
+        $script:state = @{ Games = @() }
+        Get-EntriesMaxFileBytes | Should -Be 0
+    }
+
+    It 'is the largest single file across every entry, not the total' {
+        $script:state = @{ Games = @(
+            @{ Ok = $true; MaxFileBytes = 1000; TotalBytes = 9000; Kind = 'Game' }
+            @{ Ok = $true; MaxFileBytes = 7000; TotalBytes = 8000; Kind = 'Game' }
+            @{ Ok = $true; MaxFileBytes = 2000; TotalBytes = 2000; Kind = 'AddOn' }
+        ) }
+        Get-EntriesMaxFileBytes | Should -Be 7000
+    }
+
+    It 'counts an add-on like anything else' {
+        # A patch is as capable of holding a 4 GiB file as a game is.
+        $script:state = @{ Games = @(
+            @{ Ok = $true; MaxFileBytes = 10; TotalBytes = 10; Kind = 'Game' }
+            @{ Ok = $true; MaxFileBytes = 99; TotalBytes = 99; Kind = 'AddOn' }
+        ) }
+        Get-EntriesMaxFileBytes | Should -Be 99
+    }
+
+    It 'clears the ISO9660 ceiling for a real GOG part, by one byte' {
+        # GOG splits its installers at 4,294,967,294 bytes to stay under the
+        # identical FAT32 limit, which is why a GOG disc can take ISO9660 at all.
+        $script:state = @{ Games = @(@{ Ok = $true; MaxFileBytes = 4294967294; TotalBytes = 4294967294; Kind = 'Game' }) }
+        ((Get-EntriesMaxFileBytes) -le $script:ISO9660_MAX_FILE) | Should -BeTrue
+
+        $script:state = @{ Games = @(@{ Ok = $true; MaxFileBytes = 4294967296; TotalBytes = 4294967296; Kind = 'Game' }) }
+        ((Get-EntriesMaxFileBytes) -le $script:ISO9660_MAX_FILE) | Should -BeFalse
+    }
+}
+
+Describe 'Get-ItemsMaxFile' -Tag 'Unit' {
+
+    BeforeAll {
+        $script:MaxDir = Join-Path $script:Sandbox 'maxfile'
+        New-Item -ItemType Directory -Force -Path (Join-Path $script:MaxDir 'sub') | Out-Null
+        [IO.File]::WriteAllBytes((Join-Path $script:MaxDir 'small.bin'),        (New-Object byte[] 100))
+        [IO.File]::WriteAllBytes((Join-Path $script:MaxDir 'sub\bigger.bin'),   (New-Object byte[] 5000))
+        [IO.File]::WriteAllBytes((Join-Path $script:MaxDir 'sub\middling.bin'), (New-Object byte[] 900))
+    }
+
+    It 'finds the largest file anywhere under a folder' {
+        Get-ItemsMaxFile @($script:MaxDir) | Should -Be 5000
+    }
+
+    It 'takes a single file as itself' {
+        Get-ItemsMaxFile @((Join-Path $script:MaxDir 'small.bin')) | Should -Be 100
+    }
+
+    It 'is the maximum across several paths, not their sum' {
+        # The distinction that matters: Get-ItemsSize adds, this one does not.
+        Get-ItemsMaxFile @(
+            (Join-Path $script:MaxDir 'small.bin')
+            (Join-Path $script:MaxDir 'sub')
+        ) | Should -Be 5000
+    }
+
+    It 'reports nothing as zero rather than failing' {
+        Get-ItemsMaxFile @()                | Should -Be 0
+        Get-ItemsMaxFile @($null)           | Should -Be 0
+        Get-ItemsMaxFile @('X:\no\such\path') | Should -Be 0
+    }
+}
+
+Describe 'A disc that older Windows can read' -Tag 'Build' -Skip:(-not ($script:CanBuildIso -and $script:SevenZip)) {
+
+    # Everything before Windows Vista reads UDF 2.01 at best, and DiscWright writes
+    # UDF 2.50, so those systems cannot mount the disc at all. Adding ISO9660 and
+    # Joliet beside the UDF gives them something they can read. These tests assert
+    # against the finished image, because whether a filesystem is really in there
+    # is not something the staging folder can answer.
+
+    BeforeAll {
+        $script:LegGames = @((Get-GameInfo (New-FixtureGame -Slug 'legacy_one' -ExeMb 2)))
+        $script:LegOut   = Join-Path $script:Sandbox 'build-legacy'
+        New-Item -ItemType Directory -Force -Path $script:LegOut | Out-Null
+        $script:LegOff = Invoke-Build (New-BuildSettings -Games $script:LegGames -Label 'Legacy Off' -OutDir $script:LegOut) $script:LogSink
+
+        $script:LegOut2 = Join-Path $script:Sandbox 'build-legacy-on'
+        New-Item -ItemType Directory -Force -Path $script:LegOut2 | Out-Null
+        $script:LegOn = Invoke-Build (New-BuildSettings -Games $script:LegGames -Label 'Legacy On' -OutDir $script:LegOut2 -LegacyFs) $script:LogSink
+
+        function Test-ReadsAsIso9660 {
+            param([string]$IsoPath, [string]$SevenZip)
+            $null = & $SevenZip l -tiso $IsoPath 2>&1
+            return ($LASTEXITCODE -eq 0)
+        }
+    }
+
+    It 'is UDF only when the box is not ticked' {
+        # The default, and what every disc before this was.
+        Test-ReadsAsIso9660 -IsoPath $script:LegOff -SevenZip $script:SevenZip | Should -BeFalse
+    }
+
+    It 'reads as ISO9660 when the box is ticked' {
+        Test-ReadsAsIso9660 -IsoPath $script:LegOn -SevenZip $script:SevenZip | Should -BeTrue
+    }
+
+    It 'is still UDF 2.50 as well, so nothing is given up to gain it' {
+        # The point of the hybrid: Windows 11 keeps reading exactly what it read
+        # before, because 7-Zip and Windows both prefer the UDF tree.
+        $info = & $script:SevenZip l -slt $script:LegOn 2>&1
+        ($info | Where-Object { $_ -match '^Type = Udf' })     | Should -Not -BeNullOrEmpty
+        ($info | Where-Object { $_ -match '^Version = 2\.50' }) | Should -Not -BeNullOrEmpty
+    }
+
+    It 'keeps a long GOG filename intact in the ISO9660 tree' {
+        # The reason the other filesystems were left off originally was Joliet's
+        # 64-character limit. Measured against a real GOG name, it does not bite:
+        # IMAPI writes the long name into the ISO9660 tree regardless.
+        $long = 'patch_the_witcher_enhanced_edition_directors_cut_1.5_(A)_(10712)_to_1.5_(CS)_GOG_0.2_(77554).exe'
+        $long.Length | Should -BeGreaterThan 64
+        $dir = Join-Path $script:Sandbox 'legacy-longname'
+        New-Item -ItemType Directory -Force -Path $dir | Out-Null
+        [IO.File]::WriteAllBytes((Join-Path $dir $long), (New-Object byte[] 2048))
+        $out = Join-Path $script:Sandbox 'build-legacy-long'
+        New-Item -ItemType Directory -Force -Path $out | Out-Null
+        $set = New-BuildSettings -Games $script:LegGames -Label 'Long Name' -OutDir $out -LegacyFs
+        $set.ExtraItems = @((Join-Path $dir $long))
+        $iso = Invoke-Build $set $script:LogSink
+        $names = @(& $script:SevenZip l -tiso $iso 2>&1)
+        ($names | Where-Object { $_ -match [regex]::Escape($long) }) | Should -Not -BeNullOrEmpty
+    }
+
+    It 'falls back to UDF alone when a file is too big for ISO9660' {
+        # ISO9660 keeps a file's length in 32 bits. Rather than stage 4 GiB to
+        # prove it, the ceiling is lowered for this one build - the code path
+        # under test is the real one, only the number it compares against moves.
+        $realMax = $script:ISO9660_MAX_FILE
+        try {
+            $script:ISO9660_MAX_FILE = [double]1024
+            $out = Join-Path $script:Sandbox 'build-legacy-toobig'
+            New-Item -ItemType Directory -Force -Path $out | Out-Null
+            $said = @()
+            $iso = Invoke-Build (New-BuildSettings -Games $script:LegGames -Label 'Too Big' -OutDir $out -LegacyFs) { param($m) $script:said += $m }
+            Test-ReadsAsIso9660 -IsoPath $iso -SevenZip $script:SevenZip | Should -BeFalse
+        } finally { $script:ISO9660_MAX_FILE = $realMax }
+    }
+}
+
+Describe 'The older-Windows setting in a project file' -Tag 'Unit' {
+
+    BeforeAll {
+        $script:LegProj = Join-Path $script:Sandbox 'legacy-proj'
+        New-Item -ItemType Directory -Force -Path $script:LegProj | Out-Null
+    }
+
+    It 'is written as schema 8 and comes back the way it went in' {
+        $s = @{ Games=@(); Label='Legacy Trip'; IconPath=$script:Art; IconIsIco=$false
+                Menu=$true; BgPath=$null; BgAsIs=$true; PanelSide='Right'
+                Divider=$false; ShowTitle=$false; TitleText=''
+                WindowBorder=$true; ButtonStyle='Minimal'; MusicFile=$null
+                Buttons=@('Play'); ManualPath=$null; ExtrasPath=$null
+                ExtraItems=@(); MediaKey=''; LinuxInfo=$false; LegacyFs=$true }
+        Save-Project $s $script:LegProj
+        $raw = Get-Content -Raw (Join-Path $script:LegProj 'discproject.json') | ConvertFrom-Json
+        $raw.Version  | Should -Be 8
+        $raw.LegacyFs | Should -BeTrue
+        (Import-Project (Join-Path $script:LegProj 'discproject.json')).LegacyFs | Should -BeTrue
+    }
+
+    It 'reads back as off from a project saved before it existed' {
+        $old = Join-Path $script:LegProj 'older.json'
+        @{ Version=7; Label='Older'; Games=@(); Buttons=@('Play'); Menu=$true
+           BgAsIs=$true; PanelSide='Right'; ButtonStyle='Minimal'; WindowBorder=$true
+           LinuxInfo=$true } | ConvertTo-Json -Depth 4 |
+            Set-Content -LiteralPath $old -Encoding UTF8
+        $p = Import-Project $old
+        [bool]$p.LinuxInfo | Should -BeTrue      # still read, so the file is really v7
+        [bool]$p.LegacyFs  | Should -BeFalse
     }
 }

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -3966,10 +3966,16 @@ Describe 'A disc that older Windows can read' -Tag 'Build' -Skip:(-not ($script:
         New-Item -ItemType Directory -Force -Path $script:LegOut2 | Out-Null
         $script:LegOn = Invoke-Build (New-BuildSettings -Games $script:LegGames -Label 'Legacy On' -OutDir $script:LegOut2 -LegacyFs) $script:LogSink
 
+        # Decided on what the listing SAYS, not on $LASTEXITCODE. The exit code
+        # version passed alone and failed about one run in three inside the full
+        # suite - an intermittent test is worse than a failing one, because it
+        # teaches everybody to re-run instead of look. Every DiscWright disc has
+        # autorun.inf at its root, so seeing it named is positive evidence that
+        # the ISO9660 tree was opened and read; not seeing it is the absence.
         function Test-ReadsAsIso9660 {
             param([string]$IsoPath, [string]$SevenZip)
-            $null = & $SevenZip l -tiso $IsoPath 2>&1
-            return ($LASTEXITCODE -eq 0)
+            $out = (& $SevenZip l -tiso $IsoPath 2>&1 | Out-String)
+            return ($out -match 'autorun\.inf')
         }
     }
 

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -3966,26 +3966,43 @@ Describe 'A disc that older Windows can read' -Tag 'Build' -Skip:(-not ($script:
         New-Item -ItemType Directory -Force -Path $script:LegOut2 | Out-Null
         $script:LegOn = Invoke-Build (New-BuildSettings -Games $script:LegGames -Label 'Legacy On' -OutDir $script:LegOut2 -LegacyFs) $script:LogSink
 
-        # Decided on what the listing SAYS, not on $LASTEXITCODE. The exit code
-        # version passed alone and failed about one run in three inside the full
-        # suite - an intermittent test is worse than a failing one, because it
-        # teaches everybody to re-run instead of look. Every DiscWright disc has
-        # autorun.inf at its root, so seeing it named is positive evidence that
-        # the ISO9660 tree was opened and read; not seeing it is the absence.
-        function Test-ReadsAsIso9660 {
-            param([string]$IsoPath, [string]$SevenZip)
-            $out = (& $SevenZip l -tiso $IsoPath 2>&1 | Out-String)
-            return ($out -match 'autorun\.inf')
+        # Read out of the image itself rather than asked of a tool.
+        #
+        # Two earlier versions of this got it wrong. Deciding on $LASTEXITCODE
+        # from 7-Zip passed alone and failed about one run in three in the full
+        # suite. Deciding on whether the listing named autorun.inf passed on this
+        # machine and failed on the CI runner, because `7z -tiso` on a different
+        # 7-Zip version will happily fall back to the UDF tree and list the file
+        # anyway. Both were asking a tool to guess at a question the bytes answer.
+        #
+        # The Volume Recognition Sequence starts at sector 16 (byte 32768) and is
+        # a run of 2048-byte descriptors, each carrying a five-byte identifier at
+        # offset 1: CD001 for ISO 9660, BEA01 / NSR0x / TEA01 for UDF. A UDF-only
+        # image DiscWright builds reads "BEA01 NSR03 TEA01"; add ISO9660 and it
+        # reads "CD001 BEA01 NSR03 TEA01". No external tool, and the same answer
+        # on every machine.
+        function Test-HasIso9660 {
+            param([string]$IsoPath)
+            $fs = [IO.File]::OpenRead($IsoPath)
+            try {
+                [void]$fs.Seek(32768, [IO.SeekOrigin]::Begin)
+                $buf = New-Object byte[] 2048
+                for ($i = 0; $i -lt 16; $i++) {
+                    if ($fs.Read($buf, 0, 2048) -lt 7) { break }
+                    if ([Text.Encoding]::ASCII.GetString($buf, 1, 5) -eq 'CD001') { return $true }
+                }
+            } finally { $fs.Dispose() }
+            return $false
         }
     }
 
     It 'is UDF only when the box is not ticked' {
         # The default, and what every disc before this was.
-        Test-ReadsAsIso9660 -IsoPath $script:LegOff -SevenZip $script:SevenZip | Should -BeFalse
+        Test-HasIso9660 -IsoPath $script:LegOff | Should -BeFalse
     }
 
     It 'reads as ISO9660 when the box is ticked' {
-        Test-ReadsAsIso9660 -IsoPath $script:LegOn -SevenZip $script:SevenZip | Should -BeTrue
+        Test-HasIso9660 -IsoPath $script:LegOn | Should -BeTrue
     }
 
     It 'is still UDF 2.50 as well, so nothing is given up to gain it' {
@@ -4025,7 +4042,7 @@ Describe 'A disc that older Windows can read' -Tag 'Build' -Skip:(-not ($script:
             New-Item -ItemType Directory -Force -Path $out | Out-Null
             $said = @()
             $iso = Invoke-Build (New-BuildSettings -Games $script:LegGames -Label 'Too Big' -OutDir $out -LegacyFs) { param($m) $script:said += $m }
-            Test-ReadsAsIso9660 -IsoPath $iso -SevenZip $script:SevenZip | Should -BeFalse
+            Test-HasIso9660 -IsoPath $iso | Should -BeFalse
         } finally { $script:ISO9660_MAX_FILE = $realMax }
     }
 }


### PR DESCRIPTION
## Why

A Reddit report asked whether `menu.hta` could autoplay on Windows XP. It turned out not to be an autorun problem at all. Their follow-up confirmed the diagnosis:

> *If its WinXP, it sees the Drive and Drive Letter, but unfortunately does not say anything. Disc is not explorable, autorun does not work, nothing.*

That is XP mounting the **drive** but failing to read the **volume**. DiscWright writes UDF 2.50; Windows Vista was the first version that could read it. So on XP, 2000, ME, 98 and 95 the disc cannot be mounted at all — `autorun.inf` is never found, which is why there is no icon, no label and no menu. No autorun change could ever have fixed it.

## What this does

A second checkbox writes ISO9660 and Joliet alongside the UDF. Every system takes the newest filesystem it understands and ignores the rest.

```
Also make the disc:  ☐ named on Linux   ☐ readable on Windows XP and older
```

**Off by default.** Project schema 8; absent in older files, where it reads back as off.

## Two objections that did not survive measurement

The code comment gave two reasons for UDF-only. Both were tested, and neither holds.

**Joliet's 64-character limit.** IMAPI writes long names into the ISO9660 tree regardless. A real 96-character GOG patch filename from the library survives intact, and there is a test using that exact name.

**The ISO9660 4 GiB file ceiling.** Real, but GOG already lives with it — its installers split at **4,294,967,294 bytes**, one byte under, because FAT32 has the same limit. Across the whole local GOG library, zero files are at or over it.

Where a file genuinely is too big, the checkbox **greys itself** and the tooltip says why. The greying only measures installers, so the build re-checks the finished disc folder and falls back to UDF alone rather than write an image that lost a file to a 32-bit length field.

## Reading is not installing

Documented in the tooltip, README and changelog, because it is the thing somebody finds out by burning a disc: Joliet long names go back to Windows 95, but **every GOG installer checked declares Windows 2000** as its minimum in its PE header, and 9x will not load a program asking for 5.0. So on 98 and 95 the disc browses correctly and nothing installs. XP and 2000 are the oldest genuinely useful versions.

## Tests

**Logic 409, window 76, zero failures**, on a desktop nobody was using.

| | |
| --- | --- |
| Box off | image cannot be opened as ISO9660 — unchanged from today |
| Box on | opens as ISO9660 **and** is still UDF 2.50 |
| Long name | 96-character GOG filename intact in the ISO9660 tree |
| Too big | falls back to UDF alone (ceiling lowered for the test rather than staging 4 GiB) |
| Schema | 8 round-trips; a v7 file reads back as off |

### Three things the suite caught

- **`@(Get-Games)`** rebuilt the unrolling the comma-return exists to prevent, so the loop ran once over the whole list and every disc measured as zero — the greying would never have fired. The repo tests for this by reading the source, because the fault is in the caller.
- **The overlap test** found the new checkbox sitting on `$picIcon`, the 44×44 icon preview at (560,318), by 44×20px. Only visible on a quiet desktop; two earlier runs were invalidated by desktop contention.
- **My own `Test-ReadsAsIso9660` was intermittent**, deciding on `$LASTEXITCODE`. Now reads the listing for `autorun.inf`. Three consecutive full runs clean.

## Not verified

**That autorun actually fires on XP.** Neither I nor CI has an XP machine. The reporter has one and has offered to test — but with a clean disc from this build, not their hand-edited one, which is currently confounding their results including on Windows 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)