### PR TITLE
chore(release): 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Whil
 version stays below 1.0.0, the project file format and the on-disc layout may change
 between minor versions.
 
-## [Unreleased]
+## [0.7.0] — 2026-09-11
 
 ### Added
 
@@ -604,7 +604,8 @@ First public release.
 - `extras/DiscLabel.ps1`, a parked printable disc-face generator, kept out of the app to
   keep the tool to one job.
 
-[Unreleased]: https://github.com/lazardjokovic/discwright/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/lazardjokovic/discwright/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/lazardjokovic/discwright/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/lazardjokovic/discwright/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/lazardjokovic/discwright/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/lazardjokovic/discwright/compare/v0.4.4...v0.5.0

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -61,7 +61,7 @@ $PROJECT_FILE = 'discproject.json'
 # this cannot quietly drift a release behind. Shown in the title bar and the log,
 # and written into every project file - a bug report that comes with a project
 # file then says for itself which version built the disc.
-$APP_VERSION  = '0.6.0'
+$APP_VERSION  = '0.7.0'
 
 # =================== SMALL HELPERS ===================
 


### PR DESCRIPTION
Stamps 0.7.0.

**Minor, not patch.** The changelog preamble reserves a minor bump below 1.0.0 for a change to the project file format or the on-disc layout. This release changes **both** — a disc can now carry ISO9660 and Joliet beside the UDF, and the project file moved to schema 8 to remember whether it should.

| | |
| --- | --- |
| `$APP_VERSION` | `0.6.0` → `0.7.0` |
| `CHANGELOG.md` | `[Unreleased]` stamped `[0.7.0] — 2026-09-11`, link refs updated |
| `docs/MANUAL-CHECKS.md` | already at 409, bumped with the feature |

**Logic suite: 409 passing, 0 failures.** No window test hardcodes a version — the title-bar test reads it out of the source — so the bump cannot break one.

## What this tag is really testing

It is the first tag since #51, which fixed the release job. Pushing a tag does **not** create a release, and `gh release upload` on a tag without one fails with `release not found`. That is how v0.6.0 came out with both artifacts built correctly and neither attached.

The job should now notice there is no release, create one as a **draft**, attach the zip and the installer to it, and print the installer's SHA256. The notes then get written onto that draft and published by hand, which is the point of it being a draft.

If that does not happen, the fix is wrong and I would rather find out on a release we are watching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)