### PR TITLE
fix(ci): the probe must not redirect gh's stderr

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -266,11 +266,19 @@ jobs:
           # 0.6.0 came out with both artifacts built and neither attached. So the
           # release is created here when it is missing.
           #
+          # The probe piped to Out-Null rather than redirected with *> or 2>&1.
+          # GitHub's powershell shell runs with $ErrorActionPreference = 'Stop',
+          # and 5.1 wraps a native command's REDIRECTED stderr in a terminating
+          # NativeCommandError - so 0.7.0 failed exactly as 0.6.0 had, on the
+          # line written to prevent it, because gh says "release not found" on
+          # stderr and that became fatal. A pipe takes stdout only; stderr goes
+          # to the log unwrapped, and $LASTEXITCODE still answers the question.
+          #
           # As a DRAFT, deliberately. These notes are written by hand after
           # looking at what actually shipped, and a tag push should not publish
           # a release with no notes on it. The draft gives the artifacts
           # somewhere to go; a person writes the notes and presses publish.
-          gh release view $tag --json tagName *> $null
+          gh release view $tag --json tagName | Out-Null
           if ($LASTEXITCODE -ne 0) {
               Write-Host "No release for $tag yet - creating a draft to attach to."
               gh release create $tag --draft --verify-tag --title $tag --notes "Draft - release notes not written yet."


### PR DESCRIPTION
**v0.7.0 failed exactly as v0.6.0 did**, on the line written to prevent it. Both artifacts built correctly, neither attached, no release created.

## The cause

```
gh : release not found
+ gh release view $tag --json tagName *> $null
    + FullyQualifiedErrorId : NativeCommandError
```

Three things had to line up:

1. GitHub's `shell: powershell` prepends `$ErrorActionPreference = 'Stop'`.
2. The probe used `*> $null`, which redirects **every** stream, stderr included.
3. Windows PowerShell 5.1 wraps a native command's *redirected* stderr in a `NativeCommandError` record — and under `Stop`, that terminates.

So `gh` printing `release not found` on stderr — **the exact answer the probe existed to get** — became a terminating error and killed the script before the draft-creation code below it ever ran.

## The fix

```diff
-gh release view $tag --json tagName *> $null
+gh release view $tag --json tagName | Out-Null
```

A pipe takes stdout only. stderr goes to the step log unwrapped and harmless, and `$LASTEXITCODE` still carries the answer.

## How this gets proven

**By moving the tag, not by waiting for the next release.**

`v0.7.0` has no release attached and nothing has consumed it — it is minutes old and was never published. Once this merges I will re-push it onto the fixed commit, which runs the tag build again for real.

Deferring the proof to "next time" is precisely what let this bug reach a second release. It cannot be tested on a PR, because the whole step is behind `if: startsWith(github.ref, 'refs/tags/v')`.

Expected on the re-tag: no release found → draft created → both artifacts attached → SHA256 printed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)