### PR TITLE
fix: the menu's buttons work on Windows 98

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Whil
 version stays below 1.0.0, the project file format and the on-disc layout may change
 between minor versions.
 
+## [Unreleased]
+
+### Fixed
+
+- **The menu's buttons work on Windows 98.** Every button opened whatever it
+  opened through `Shell.ShellExecute`, which needs shell32.dll 5.0 and is
+  documented as Windows 2000 or newer. Windows 98 has the `Shell.Application`
+  object and not that method, so on 98 every button threw and nothing happened.
+  Reported from a real machine, where the disc read and browsed correctly, the
+  menu opened, and no button did anything.
+
+  Opening now goes through one helper that tries `ShellExecute` first and falls
+  back to `WScript.Shell`, which has been there since Windows Scripting Host
+  shipped with 98. The modern call is tried first, so on Windows 2000 and
+  anything later the fallback is never reached and behaviour is unchanged.
+
+  What this is worth on 98 is the half of the disc that works there. A GOG
+  installer will not run - they declare Windows 2000 as their minimum - but
+  **Manual** and **Extras** open a folder of period patches, which is what a 98
+  machine wants from one of these discs.
+
+  **Play** will still not work there, for a different reason: it searches the
+  registry through WMI, which 98 did not install by default. Left alone, since a
+  GOG game cannot install on 98 for Play to find.
+
 ## [0.7.0] — 2026-09-11
 
 ### Added

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -1156,6 +1156,31 @@ function New-MenuHta([hashtable]$cfg,[string]$out) {
 <script language="JScript">
   var fso=new ActiveXObject("Scripting.FileSystemObject");
   var shell=new ActiveXObject("Shell.Application");
+
+  // Shell.ShellExecute needs shell32.dll 5.0 and is documented as Windows 2000
+  // or newer. Windows 98 has the Shell.Application object and not that method,
+  // so on 98 every button on this menu threw and nothing opened - reported from
+  // a real machine, where the disc read fine and none of the buttons did
+  // anything.
+  //
+  // WScript.Shell has been there since Windows Scripting Host shipped with 98,
+  // and anything running this menu already has a scripting host. It takes a
+  // command line rather than a file and a verb, so a folder or a document is
+  // handed to explorer.exe, which is what ShellExecute would have done with it.
+  //
+  // Tried in the documented order: the modern call first, so Windows 2000 and
+  // everything after it behaves exactly as it did before this existed.
+  var wsh=null;
+  function openThing(p,args,wd){
+    try{ shell.ShellExecute(p,args||"",wd||"","open",1); return true; }catch(ex){}
+    try{
+      if(!wsh) wsh=new ActiveXObject("WScript.Shell");
+      var isExe=/\.(exe|com|bat|cmd|pif|lnk)$/i.test(p);
+      var cmd=isExe?('"'+p+'"'+(args?" "+args:"")):('explorer.exe "'+p+'"');
+      if(wd){ try{ wsh.CurrentDirectory=wd; }catch(e2){} }
+      wsh.Run(cmd,1,false); return true;
+    }catch(ex2){ alert(ex2.message); return false; }
+  }
   var root="";
   var GAMES=%%GAMES%%;       // [{n:name, m:registry match, s:setup, man:manual, ext:extras, a:[{n,s}]}]
   var BTNS=%%BTNS%%;         // which of Play/Install/Manual/Extras/Exit the disc was built with
@@ -1245,8 +1270,8 @@ function New-MenuHta([hashtable]$cfg,[string]$out) {
   function openItem(p,isFolder){ try{
     if(!root){ alert("Could not work out the disc folder.\nRun the menu from the disc root."); return; }
     var f=fso.BuildPath(root,p);
-    if(isFolder){ if(fso.FolderExists(f)) shell.ShellExecute(f); else alert("Not found:\n"+f); }
-    else { if(fso.FileExists(f)) shell.ShellExecute(f); else alert("Not found:\n"+f); } }catch(e){alert(e.message);} }
+    if(isFolder){ if(fso.FolderExists(f)) openThing(f); else alert("Not found:\n"+f); }
+    else { if(fso.FileExists(f)) openThing(f); else alert("Not found:\n"+f); } }catch(e){alert(e.message);} }
   // Grey a button out rather than let it fail. Inline styles, not a CSS class:
   // this document runs in quirks mode, where compound selectors like .btn.off
   // are unreliable.
@@ -1520,8 +1545,7 @@ function New-MenuHta([hashtable]$cfg,[string]$out) {
     return out;
   }
   function launchExe(p,args,wd){
-    try{ shell.ShellExecute(p,args||"",wd||fso.GetParentFolderName(p),"open",1); window.close(); }
-    catch(ex){ alert(ex.message); }
+    if(openThing(p,args,wd||fso.GetParentFolderName(p))) window.close();
   }
   function renderTasks(){
     var h="";

--- a/tests/DiscWright.Tests.ps1
+++ b/tests/DiscWright.Tests.ps1
@@ -3273,6 +3273,45 @@ Describe "The menu's JavaScript is valid JavaScript" {
         $script:MenuLeftover | Should -BeNullOrEmpty
     }
 
+    Context 'opening things on a shell too old to have ShellExecute' {
+
+        # Shell.ShellExecute needs shell32.dll 5.0 and is documented as Windows
+        # 2000 or newer. Windows 98 has the Shell.Application object and not the
+        # method, so every button on the menu threw and nothing opened. Reported
+        # from a real 98 machine: the disc read fine and no button did anything.
+        #
+        # openThing tries ShellExecute and falls back to WScript.Shell, which has
+        # been present since Windows Scripting Host shipped with 98. These read
+        # the source rather than run it, because the fault they guard against is
+        # in the CALLER: a new button written next year that calls ShellExecute
+        # directly would work everywhere the author can test and break 98 again,
+        # silently, on a burned disc.
+
+        It 'routes every open through the one helper' {
+            # Exactly one mention, and it is the attempt inside openThing.
+            @([regex]::Matches($script:MenuJs, 'shell\.ShellExecute')).Count |
+                Should -Be 1 -Because 'buttons must call openThing, not ShellExecute'
+        }
+
+        It 'defines that helper' {
+            $script:MenuJs | Should -Match 'function openThing\s*\('
+        }
+
+        It 'falls back to something Windows 98 actually has' {
+            $script:MenuJs | Should -Match 'WScript\.Shell'
+        }
+
+        It 'tries the modern call first, so nothing newer changes behaviour' {
+            # Order matters: on Windows 2000 and later ShellExecute succeeds and
+            # the fallback is never reached, which is what keeps this invisible
+            # everywhere it is not needed.
+            $helper = [regex]::Match($script:MenuJs,
+                '(?s)function openThing\s*\(.*?\n  \}').Value
+            $helper | Should -Not -BeNullOrEmpty
+            $helper.IndexOf('ShellExecute') | Should -BeLessThan $helper.IndexOf('WScript.Shell')
+        }
+    }
+
     It 'parses' -Skip:(-not $script:HaveCScriptMenu) {
         $probe = @'
 var src = WScript.StdIn.ReadAll();


### PR DESCRIPTION
## The report

0.7.0 landed and someone tried it on three machines:

> I tried the ISO on Win11, WinXP and Win98, and they ALL autorun and work great except for Win98... None of the buttons work on the interface BUT the DVD or CD is explorable and able to be read, and on Win98 that's what counts!

Two things there. **Windows XP autoruns and runs the menu** — which 0.7.0's notes explicitly declined to claim, because nobody had tested it. Those notes have been corrected.

And on 98 the buttons do nothing. That has a cause.

## Why

The menu opens everything through `Shell.ShellExecute`. Per [Microsoft's documentation](https://learn.microsoft.com/en-us/windows/win32/shell/ishelldispatch2-shellexecute) that needs **shell32.dll 5.0, minimum client Windows 2000**. Windows 98 has the `Shell.Application` object and **not** that method, so every button threw.

It matches the report exactly: disc reads, menu opens, nothing does anything.

## The fix

One helper, `openThing`, used by all three call sites. It tries `ShellExecute`, and on failure falls back to `WScript.Shell.Run` — present since Windows Scripting Host shipped with 98, and anything running this menu already has a scripting host. A folder or document is handed to `explorer.exe`, which is what `ShellExecute` would have done with it.

**The modern call is tried first**, so Windows 2000 and everything later never reaches the fallback and behaves exactly as before.

What it's worth on 98 is the half of the disc that works there. The GOG installer still won't run — those declare Windows 2000 in their PE headers — but **Manual** and **Extras** open a folder of period patches, which is what the reporter actually described wanting:

> the fact that I CAN put old game patches and other content and use it to open via extras is fantastic!

**Play will still not work on 98**, for an unrelated reason: it searches the registry through WMI, which 98 didn't install by default. Left alone — a GOG game can't install on 98, so Play has nothing to find.

## Tests

**413 logic, 76 window, zero failures** (409 + 4 new), window suite on a quiet desktop.

The four new ones read the generated menu rather than run it, because the fault they guard against is in the **caller**. The one that matters:

```powershell
@([regex]::Matches($script:MenuJs, 'shell\.ShellExecute')).Count | Should -Be 1
```

A button written next year that calls `ShellExecute` directly would work everywhere its author can test, and break Windows 98 again, silently, on a burned disc. Now it fails a test instead. Same approach as the comma-return convention test.

## Not verified

**That it works on Windows 98.** There's no 98 machine here and the tests only prove the code is shaped correctly. The reporter has one and has offered to test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)