### PR TITLE
chore(release): 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Whil
 version stays below 1.0.0, the project file format and the on-disc layout may change
 between minor versions.
 
-## [Unreleased]
+## [0.7.1] — 2026-09-12
 
 ### Fixed
 
@@ -629,7 +629,8 @@ First public release.
 - `extras/DiscLabel.ps1`, a parked printable disc-face generator, kept out of the app to
   keep the tool to one job.
 
-[Unreleased]: https://github.com/lazardjokovic/discwright/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/lazardjokovic/discwright/compare/v0.7.1...HEAD
+[0.7.1]: https://github.com/lazardjokovic/discwright/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/lazardjokovic/discwright/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/lazardjokovic/discwright/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/lazardjokovic/discwright/compare/v0.5.0...v0.5.1

--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -61,7 +61,7 @@ $PROJECT_FILE = 'discproject.json'
 # this cannot quietly drift a release behind. Shown in the title bar and the log,
 # and written into every project file - a bug report that comes with a project
 # file then says for itself which version built the disc.
-$APP_VERSION  = '0.7.0'
+$APP_VERSION  = '0.7.1'
 
 # =================== SMALL HELPERS ===================
 

--- a/docs/MANUAL-CHECKS.md
+++ b/docs/MANUAL-CHECKS.md
@@ -1,6 +1,6 @@
 # Manual checks before a release
 
-The automated suite is 409 logic tests and 76 window tests, and it runs in about
+The automated suite is 413 logic tests and 76 window tests, and it runs in about
 four minutes:
 
 ```


### PR DESCRIPTION
Stamps 0.7.1.

**Patch, not minor.** Nothing here touches the project file format or the on-disc layout, which is what the changelog preamble reserves a minor bump for below 1.0.0. A 0.7.0 project opens and rebuilds exactly as it did, and the disc it makes is the same disc.

| | |
| --- | --- |
| `$APP_VERSION` | `0.7.0` → `0.7.1` |
| `CHANGELOG.md` | `[Unreleased]` stamped `[0.7.1] — 2026-09-12`, link refs updated |
| `docs/MANUAL-CHECKS.md` | counter 409 → 413 |

**413 logic + 76 window, zero failures**, window suite on a quiet desktop. No test hardcodes a version — checked — so the bump cannot break one.

## What this tag is really for

The release job has now **failed on two consecutive releases and been fixed twice without ever running successfully**, because both times I published by hand and the tag build never got another go.

- **0.6.0** — `gh release upload` on a tag with no release: `release not found`. Fixed in #51 by creating a draft first.
- **0.7.0** — failed identically. #51's own probe used `*> $null`, and since GitHub's `shell: powershell` runs with `$ErrorActionPreference = 'Stop'`, PowerShell 5.1 turned `gh`'s stderr into a terminating `NativeCommandError` and killed the script on the line meant to prevent the problem. Fixed in #55.

So #55 is unproven. **This tag is left alone to do its work.** Expected: no release found → draft created → both artifacts attached → SHA256 printed in the run summary. Then the notes go onto that draft and it gets published.

If it fails a third time I will stop patching it blind and exercise it against a throwaway tag instead, rather than discovering it at the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)