### PR TITLE
chore(packaging): the project publishes itself

### DIFF
--- a/packaging/DiscWright.iss
+++ b/packaging/DiscWright.iss
@@ -22,7 +22,10 @@
 #endif
 
 #define AppName    "DiscWright"
-#define AppPublisher "Lazar Djokovic"
+// The project publishes itself. This is what Add/Remove Programs shows and what
+// the .exe's file properties carry, so it matches the winget publisher and the
+// DiscWright.DiscWright identifier rather than naming a person.
+#define AppPublisher "DiscWright"
 #define AppUrl     "https://discwright.com"
 
 [Setup]

--- a/packaging/winget/New-WingetManifest.ps1
+++ b/packaging/winget/New-WingetManifest.ps1
@@ -42,7 +42,14 @@ if (-not $OutDir) {
 }
 if (-not (Test-Path $OutDir)) { New-Item -ItemType Directory -Path $OutDir -Force | Out-Null }
 
-$id  = 'LazarDjokovic.DiscWright'
+# DiscWright.DiscWright rather than a person's name, the way Git.Git, 7zip.7zip
+# and calibre.calibre are filed: the publisher IS the project. The identifier
+# cannot be renamed once winget-pkgs has accepted it, only deprecated and
+# resubmitted, so this is the one field worth being sure about.
+#
+# A single segment is not allowed - `winget validate` rejects a bare
+# "DiscWright" against the schema, which wants Publisher.Package.
+$id  = 'DiscWright.DiscWright'
 $url = "https://github.com/lazardjokovic/discwright/releases/download/v$Version/DiscWright-$Version-setup.exe"
 
 # winget wants the hash upper-case and unbracketed.
@@ -104,8 +111,8 @@ ManifestVersion: 1.6.0
 PackageIdentifier: $id
 PackageVersion: $Version
 PackageLocale: en-US
-Publisher: Lazar Djokovic
-PublisherUrl: https://github.com/lazardjokovic
+Publisher: DiscWright
+PublisherUrl: https://discwright.com
 PublisherSupportUrl: https://github.com/lazardjokovic/discwright/issues
 PackageName: DiscWright
 PackageUrl: https://discwright.com


### PR DESCRIPTION
Settles the winget identifier before anything is submitted, because it cannot be renamed afterwards — only deprecated and resubmitted.

## The identifier

A bare `DiscWright` is **rejected by the schema**; I tested all three forms:

```
DiscWright                   REJECTED
DiscWright.DiscWright        ACCEPTED
LazarDjokovic.DiscWright     ACCEPTED
```

It has to be `Publisher.Package` — but the publisher does not have to be a person. `Git.Git`, `7zip.7zip` and `calibre.calibre` all exist in winget-pkgs with the project as its own publisher, which is the shape DiscWright has: it owns a domain and a site rather than being filed under somebody.

So **`DiscWright.DiscWright`**.

## The fields that followed

| | was | now |
| --- | --- | --- |
| `AppPublisher` (installer) | Lazar Djokovic | **DiscWright** |
| `Publisher:` (manifest) | Lazar Djokovic | **DiscWright** |
| `PublisherUrl:` | github.com/lazardjokovic | **discwright.com** |

`AppPublisher` is what Add/Remove Programs shows and what the `.exe` file properties carry — I verified that against a real build earlier, where 0.6.0's installer read `company: Lazar Djokovic`. The three installers already published keep the old value; this takes effect from the next release.

**LICENSE is deliberately untouched.** Copyright attaches to a person, and `lazardjokovic` is a public handle rather than a full name. Repo URLs keep it for the same reason — that is where the code lives.

## Verified

- Manifests generated under the new identifier: **`Manifest validation succeeded`**
- Installer URL resolves: `200`, 2,580,796 bytes, matching the v0.7.1 release asset

**Not verified:** `winget install --manifest` end to end. That needs `LocalManifestFiles` enabled, which is an administrator setting and a real one — it allows any local manifest to drive an install. winget-pkgs runs that install on a clean VM at submission time regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)