### PR TITLE
feat: the window wears its own icon

### DIFF
--- a/DiscWright.ps1
+++ b/DiscWright.ps1
@@ -2285,6 +2285,22 @@ $form=New-Object System.Windows.Forms.Form
 # The version belongs where it can be read off a screenshot without being asked
 # for, since that is how it arrives in a bug report.
 $form.Text="DiscWright $APP_VERSION"
+
+# The window's own icon: the title bar, the taskbar button and Alt-Tab all show
+# it. Unset, they show powershell.exe's icon, which is honest about what is
+# running and tells nobody what the program is.
+#
+# $PSScriptRoot rather than the working directory, because the .vbs launcher sets
+# the working directory and the .cmd does not, and a user can start either from
+# anywhere. Both launchers use -File, which is what populates it.
+#
+# Guarded twice. A missing .ico is survivable - the app looked like this until
+# now - and New-Object Icon throws on a file that is present but not an icon,
+# which would otherwise stop the window opening at all.
+$icoSelf = Join-Path $PSScriptRoot 'DiscWright.ico'
+if (Test-Path -LiteralPath $icoSelf) {
+    try { $form.Icon = New-Object System.Drawing.Icon($icoSelf) } catch { }
+}
 # 1054 is what the controls need. Opening at that height regardless is how a
 # window ends up with its Build button under the taskbar: 1080p leaves 1032
 # usable, and a 768px laptop far less. Open at whatever fits and let AutoScroll


### PR DESCRIPTION
The title bar, taskbar button and Alt-Tab all showed **powershell.exe's icon** — honest about what is running, and no help at all in saying what the program is. They now show DiscWright's.

Sixteen lines, all additions, twelve of them comment.

## Why it is written the way it is

**`$PSScriptRoot`, not the working directory.** The `.vbs` launcher sets a working directory and the `.cmd` does not, and either can be started from anywhere. Both use `-File`, which is what populates `$PSScriptRoot`. It is the first use of it in this file, so the reason is written down.

**Guarded twice.** A missing `.ico` is survivable — the app looked like this until now — and `New-Object Icon` throws on a file that exists but is not a valid icon, which unguarded would stop the window opening at all.

**It costs no space**, which decided it. The form already wants 1054px of controls in a window that opens at most 992 tall and scrolls to cover the difference. Anything adding height would have made the one real layout problem worse, which rules out a logo inside the form.

## What was tried and dropped

A **gold BUILD ISO button**, matching the site's `#d9a441` accent, built and looked at on the real window. Dropped: gold reads as deliberate against the site's near-black background and muddy against a light grey WinForms form. The teal stays — it is the one saturated thing on the window, on the button that does the work.

A **full dark theme** was also built as a throwaway and discarded. Worth recording that it was more achievable than expected: the disabled-TextBox problem goes away with `BorderStyle = 'FixedSingle'`, and the title bar, ListView header and combo boxes all took the colour. The remaining artifacts were the scrollbars. Not done, because it is a lot of surface to maintain on a script whose point is staying simple.

## Tests

**413 logic, 76 window, zero failures**, window suite on a quiet desktop.

The window suite matters here specifically: it finds DiscWright by window title and drives it through UI Automation, and this is the first time the window has advertised a non-default icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)