### PR TITLE
fix(packaging): manifests target schema 1.12.0

### DIFF
--- a/packaging/winget/New-WingetManifest.ps1
+++ b/packaging/winget/New-WingetManifest.ps1
@@ -50,6 +50,10 @@ if (-not (Test-Path $OutDir)) { New-Item -ItemType Directory -Path $OutDir -Forc
 # A single segment is not allowed - `winget validate` rejects a bare
 # "DiscWright" against the schema, which wants Publisher.Package.
 $id  = 'DiscWright.DiscWright'
+
+# No provenance comment in the generated files. They are submitted into
+# microsoft/winget-pkgs, where a line pointing at a path in this repository is
+# noise to whoever reviews it.
 $url = "https://github.com/lazardjokovic/discwright/releases/download/v$Version/DiscWright-$Version-setup.exe"
 
 # winget wants the hash upper-case and unbracketed.
@@ -58,12 +62,12 @@ if ($sha.Length -ne 64) { throw "Sha256 does not look like a SHA256: '$Sha256'" 
 
 # ---------------------------------------------------------------- version --
 @"
-# Created for DiscWright $Version - see packaging/winget/New-WingetManifest.ps1
+# yaml-language-server: `$schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: $id
 PackageVersion: $Version
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0
 "@ | Set-Content -LiteralPath (Join-Path $OutDir "$id.yaml") -Encoding UTF8
 
 # -------------------------------------------------------------- installer --
@@ -81,7 +85,7 @@ ManifestVersion: 1.6.0
 # uninstall. Inno Setup registers its uninstall entry as "<AppId>_is1", so this
 # has to stay in step with AppId in packaging/DiscWright.iss.
 @"
-# Created for DiscWright $Version - see packaging/winget/New-WingetManifest.ps1
+# yaml-language-server: `$schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: $id
 PackageVersion: $Version
 InstallerLocale: en-US
@@ -99,7 +103,7 @@ Installers:
   InstallerUrl: $url
   InstallerSha256: $sha
 ManifestType: installer
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0
 "@ | Set-Content -LiteralPath (Join-Path $OutDir "$id.installer.yaml") -Encoding UTF8
 
 # ----------------------------------------------------------------- locale --
@@ -107,7 +111,7 @@ ManifestVersion: 1.6.0
 # ShortDescription is the line the store front and `winget search` show, so it
 # says what the tool does rather than what it is built with.
 @"
-# Created for DiscWright $Version - see packaging/winget/New-WingetManifest.ps1
+# yaml-language-server: `$schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: $id
 PackageVersion: $Version
 PackageLocale: en-US
@@ -131,7 +135,7 @@ Description: |-
   add-ons live under the game they belong to, and a set too big for one disc can
   be split across several.
 
-  Burning is out of scope on purpose - DiscWright writes the ISO and leaves
+  Burning is out of scope on purpose. DiscWright writes the ISO and leaves
   burning to the tools that already do it well.
 Moniker: discwright
 Tags:
@@ -145,7 +149,7 @@ Tags:
 - backup
 ReleaseNotesUrl: https://github.com/lazardjokovic/discwright/releases/tag/v$Version
 ManifestType: defaultLocale
-ManifestVersion: 1.6.0
+ManifestVersion: 1.12.0
 "@ | Set-Content -LiteralPath (Join-Path $OutDir "$id.locale.en-US.yaml") -Encoding UTF8
 
 Write-Host "wrote three manifests to $OutDir"


### PR DESCRIPTION
The first submission to [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs/pull/433767) failed validation. This is the fix, plus two smaller things found in the same round trip.

## The schema version

Manifests declared `ManifestVersion: 1.6.0`. Their pipeline checks against the current schema, and packages accepted today declare **1.12.0** — confirmed by reading Git's and 7zip's live manifests in the repo, not guessed.

Guessing was the only alternative: the failing check's `detailsUrl` is the repo homepage, so **there is no log to read**, and the bot's comment is a generic template.

### `winget validate` does not tell you this

It accepted 1.6.0 every single time. It validates against schemas the **client** knows, not against what the **server** requires. A local pass says less than it appears to, and this PR's predecessor was reported as verified on the strength of it.

## The schema pointer

Added the `# yaml-language-server: $schema=...` line every manifest in that repo carries. Nothing requires it; editors use it to validate while typing, which is why `wingetcreate` emits it.

The `$` needs a backtick inside the expanding here-strings, or PowerShell reads `$schema` as a variable and writes:

```
# yaml-language-server: =https://aka.ms/winget-manifest.version.1.12.0.schema.json
```

`winget validate` does catch that, as a warning.

## Two smaller fixes

- **The provenance comment** naming `packaging/winget/New-WingetManifest.ps1` is gone. It means nothing in somebody else's repository.
- **A dash** joining two clauses in `Description` became a full stop. That text is public under Lazar's name.

All fixed in the generator rather than in the three output files, so the next release does not reintroduce any of them.

Regenerated manifests validate clean and are already pushed to the winget-pkgs PR branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)